### PR TITLE
#zk now acts as a list of everyone you can see on the ZKS.

### DIFF
--- a/libs/liblobby/lobby/interface_shared.lua
+++ b/libs/liblobby/lobby/interface_shared.lua
@@ -16,7 +16,12 @@ function Interface:init()
 	self.status = "offline"
 	self.finishedConnecting = false
 	self.listeners = {}
-	self.duplicateMessageTimes = {} -- how do I give interface_zerok it's own init?
+	
+	-- Inheritance is too shallow for interface_zerok.lua to get its own init.
+	if self.InheritanceIsBrokenWorkaroundInit then
+		self:InheritanceIsBrokenWorkaroundInit()
+	end
+	
 	-- timeout (in seconds) until first message is received from server before disconnect is assumed
 	self.connectionTimeout = 50
 

--- a/libs/liblobby/lobby/interface_zerok.lua
+++ b/libs/liblobby/lobby/interface_zerok.lua
@@ -12,6 +12,15 @@ Interface.jsonCommands = {}
 Interface.commandPattern = {}
 
 -------------------------------------------------
+-- Initialization
+-------------------------------------------------
+
+function Interface:InheritanceIsBrokenWorkaroundInit()
+	self.duplicateMessageTimes = {}
+	self.commonChannels = {"zk"}
+end
+
+-------------------------------------------------
 -- BEGIN Client commands
 -------------------------------------------------
 
@@ -594,6 +603,10 @@ function Interface:_User(data)
 			awaySince = data.AwaySince,
 			inGameSince = data.InGameSince,
 		})
+		
+		for i = 1, #self.commonChannels do
+			self:_OnJoined(self.commonChannels[i], data.Name)
+		end
 		return
 	end
 	


### PR DESCRIPTION
This list is rest by JoinChannelResponse so the server should either send JoinChannelResponse for #zk before it sends users or it should initially send the correct list in JoinChannelResponse for #zk.