### PR TITLE
ROAM Compatibility fix (for #102)

### DIFF
--- a/LuaMenu/configs/gameConfig/zk/settingsMenu.lua
+++ b/LuaMenu/configs/gameConfig/zk/settingsMenu.lua
@@ -494,6 +494,7 @@ local settings = {
 							["3DTrees"] = 0,
 							MaxDynamicMapLights = 0,
 							MaxDynamicModelLights = 0,
+							ROAM = 1,
 						}
 					},
 					{
@@ -507,6 +508,7 @@ local settings = {
 							["3DTrees"] = 1,
 							MaxDynamicMapLights = 1,
 							MaxDynamicModelLights = 1,
+							ROAM = 1, --Maybe ROAM = 0 when the new renderer is fully developed
 						}
 					},
 				},


### PR DESCRIPTION
Sets both compatibility modes to ROAM=1 for the time being. ROAM=0's renderer seems to not be quite on par with ROAM=1, though it is faster, but it doesn't handle complex geometry (ex. Onyx Cauldron) that well yet. Fixes #102 