### PR TITLE
Changes to initial missions.

### DIFF
--- a/campaign/sample/planets/planet1.lua
+++ b/campaign/sample/planets/planet1.lua
@@ -24,7 +24,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primary = "Origin",
 			primaryType = "G8V",
 			milRating = 1,
-			text = [[Your first battle will be straightforward. You have been provided with a starting base. Construct an army of Glaives and Warriors and overwhelm your enemy.]]
+			text = [[This battle will be straightforward. You have been provided with a starting base. Construct an army of Glaives and overwhelm your enemy.]]
 		},
 		gameConfig = {
 			missionStartscript = false,
@@ -40,9 +40,7 @@ local function GetPlanet(planetUtilities, planetID)
 				extraUnlocks = {
 					"factorycloak",
 					"cloakraid",
-					"cloakriot",
-					"staticmex",
-					"energysolar",
+					--"cloakriot",
 					"cloakcon",
 				},
 				startUnits = {
@@ -237,17 +235,16 @@ local function GetPlanet(planetUtilities, planetID)
 					description = "Build at least 5 Glaives",
 					experience = planetUtilities.BONUS_EXP,
 				},
-				[5] = { -- Kill 10 Glaives
+				[5] = { -- Kill all enemy mexes
 					satisfyOnce = true,
-					onlyCountRemovedUnits = true, -- Only count units that died
-					comparisionType = planetUtilities.COMPARE.AT_LEAST,
-					targetNumber = 10,
+					comparisionType = planetUtilities.COMPARE.AT_MOST,
+					targetNumber = 0,
 					enemyUnitTypes = {
-						"cloakraid",
+						"staticmex",
 					},
-					image = planetUtilities.ICON_DIR .. "cloakraid.png",
+					image = planetUtilities.ICON_DIR .. "staticmex.png",
 					imageOverlay = planetUtilities.ICON_OVERLAY.ATTACK,
-					description = "Kill at least 10 Glaives",
+					description = "Destroy all enemy Metal Extractors",
 					experience = planetUtilities.BONUS_EXP,
 				},
 				[6] = {
@@ -263,7 +260,7 @@ local function GetPlanet(planetUtilities, planetID)
 			units = {
 				"factorycloak",
 				"cloakraid",
-				"cloakriot",
+				--"cloakriot",
 				"cloakcon"
 			},
 			modules = {

--- a/campaign/sample/planets/planet2.lua
+++ b/campaign/sample/planets/planet2.lua
@@ -42,12 +42,19 @@ local function GetPlanet(planetUtilities, planetID)
 				},
 				extraUnlocks = {
 					"cloakskirm",
+					"cloakriot",
 				},
 				startUnits = {
 					{
 						name = "staticradar",
 						x = 3730,
 						z = 3625,
+						facing = 3, 
+					},
+					{
+						name = "staticradar",
+						x = 3010,
+						z = 2540,
 						facing = 3, 
 					},
 					{
@@ -74,24 +81,24 @@ local function GetPlanet(planetUtilities, planetID)
 						z = 3200,
 						facing = 0, 
 					},
-					{
-						name = "cloakskirm",
-						x = 3400,
-						z = 3190,
-						facing = 0, 
-					},
+					-- {
+						-- name = "cloakskirm",
+						-- x = 3400,
+						-- z = 3190,
+						-- facing = 0, 
+					-- },
 					{
 						name = "cloakskirm",
 						x = 3460,
 						z = 3180,
 						facing = 0, 
 					},
-					{
-						name = "cloakskirm",
-						x = 3520,
-						z = 3190,
-						facing = 0, 
-					},
+					-- {
+						-- name = "cloakskirm",
+						-- x = 3520,
+						-- z = 3190,
+						-- facing = 0, 
+					-- },
 					{
 						name = "cloakskirm",
 						x = 3580,
@@ -102,12 +109,6 @@ local function GetPlanet(planetUtilities, planetID)
 						name = "cloakriot",
 						x = 3380,
 						z = 3280,
-						facing = 0, 
-					},
-					{
-						name = "cloakriot",
-						x = 3460,
-						z = 3260,
 						facing = 0, 
 					},
 					{
@@ -178,45 +179,52 @@ local function GetPlanet(planetUtilities, planetID)
 					},
 					startUnits = {
 						{
-							name = "turretriot",
-							x = 540,
-							z = 3270,
-							facing = 1, 
-							bonusObjectiveID = 4,
-						},
-						{
-							name = "turretriot",
-							x = 2000,
-							z = 2300,
+							name = "staticradar",
+							x = 1300,
+							z = 1014,
 							facing = 0, 
-							bonusObjectiveID = 4,
 						},
 						{
 							name = "turretriot",
-							x = 670,
-							z = 1540,
+							x = 2770,
+							z = 1880,
 							facing = 0, 
-							bonusObjectiveID = 4,
 						},
 						{
 							name = "turretriot",
-							x = 3560,
-							z = 800,
+							x = 850,
+							z = 1660,
 							facing = 0, 
-							bonusObjectiveID = 4,
 						},
 						{
 							name = "turretriot",
-							x = 1975,
-							z = 475,
-							facing = 1, 
-							bonusObjectiveID = 4,
+							x = 1830,
+							z = 1230,
+							facing = 0, 
+						},
+						{
+							name = "turretriot",
+							x = 3177,
+							z = 330,
+							facing = 0, 
 						},
 						{
 							name = "factorycloak",
 							x = 660,
 							z = 770,
-							facing = 2, 
+							facing = 0, 
+						},
+						{
+							name = "cloakriot",
+							x = 660,
+							z = 900,
+							facing = 0, 
+						},
+						{
+							name = "cloakriot",
+							x = 660,
+							z = 1000,
+							facing = 0, 
 						},
 						{
 							name = "staticmex",
@@ -367,10 +375,12 @@ local function GetPlanet(planetUtilities, planetID)
 					satisfyByTime = 480,
 					comparisionType = planetUtilities.COMPARE.AT_MOST,
 					targetNumber = 0,
-					-- See bonusObjectiveID in units table
+					enemyUnitTypes = {
+						"turretriot",
+					},
 					image = planetUtilities.ICON_DIR .. "turretriot.png",
 					imageOverlay = planetUtilities.ICON_OVERLAY.ATTACK,
-					description = "Kill all five enemy Stardust turrets before 8:00",
+					description = "Destroy all enemy Stardust turrets before 8:00",
 					experience = planetUtilities.BONUS_EXP,
 				},
 			},
@@ -379,6 +389,7 @@ local function GetPlanet(planetUtilities, planetID)
 			experience = planetUtilities.MAIN_EXP,
 			units = {
 				"cloakskirm",
+				"cloakriot",
 			},
 			modules = {
 				"commweapon_heavymachinegun",

--- a/campaign/sample/planets/planet3.lua
+++ b/campaign/sample/planets/planet3.lua
@@ -50,6 +50,15 @@ local function GetPlanet(planetUtilities, planetID)
 						facing = 0,
 					}, 
 					{
+						name = "cloakcon",
+						x = 3376,
+						z = 1138,
+						facing = 0,
+						commands = {
+							{cmdID = planetUtilities.COMMAND.GUARD, atPosition = {3276, 1138}},
+						},
+					},
+					{
 						name = "staticradar",
 						x = 3820,
 						z = 2880,
@@ -126,19 +135,41 @@ local function GetPlanet(planetUtilities, planetID)
 						x = 2050,
 						z = 1700,
 						facing = 0,
+						commands = {
+							{cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {2050, 1720}},
+						},
 					},
+					
 					{
 						name = "cloakbomb",
 						x = 3000,
 						z = 3000,
 						facing = 3,
+						commands = {
+							{cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {3000, 3020}},
+						},
 					},
+					{
+						name = "turretmissile",
+						x = 1187,
+						z = 890,
+						facing = 0,
+					}, 
 					{
 						name = "cloakbomb",
 						x = 1200,
 						z = 1200,
 						facing = 3,
+						commands = {
+							{cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {1200, 1220}},
+						},
 					},
+					{
+						name = "turretmissile",
+						x = 1187,
+						z = 890,
+						facing = 0,
+					}, 
 					{
 						name = "turretmissile",
 						x = 3300,
@@ -182,7 +213,8 @@ local function GetPlanet(planetUtilities, planetID)
 					allyTeam = 1,
 					unlocks = {
 						"vehraid",
-						"vehscout",
+						--"vehscout",
+						"vehriot",
 					},
 					commanderLevel = 2,
 					commander = {
@@ -198,6 +230,12 @@ local function GetPlanet(planetUtilities, planetID)
 						{
 							name = "factoryveh",
 							x = 500,
+							z = 2700,
+							facing = 1, 
+						},
+						{
+							name = "staticcon",
+							x = 300,
 							z = 2700,
 							facing = 1, 
 						},
@@ -227,8 +265,8 @@ local function GetPlanet(planetUtilities, planetID)
 						},
 						{
 							name = "staticmex",
-							x = 420,
-							z = 3070,
+							x = 424,
+							z = 3270,
 							facing = 0, 
 						},
 						{
@@ -247,12 +285,6 @@ local function GetPlanet(planetUtilities, planetID)
 							name = "vehraid",
 							x = 262,
 							z = 2220,
-							facing = 0, 
-						},
-						{
-							name = "vehscout",
-							x = 262,
-							z = 2420,
 							facing = 0, 
 						},
 						{

--- a/campaign/sample/planets/planet5.lua
+++ b/campaign/sample/planets/planet5.lua
@@ -49,6 +49,12 @@ local function GetPlanet(planetUtilities, planetID)
 						facing = 0, 
 					},
 					{
+						name = "staticradar",
+						x = 2925,
+						z = 1605,
+						facing = 0, 
+					},
+					{
 						name = "factorycloak",
 						x = 2560,
 						z = 800,
@@ -66,8 +72,8 @@ local function GetPlanet(planetUtilities, planetID)
 						facing = 0,
 						commands = {
 							{cmdID = planetUtilities.COMMAND.GUARD, atPosition = {2560, 800}},
-							{cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {1560, 800}, options = {"shift"}},
-							{unitName = "turretmissile", pos = {64, 64}, facing = 3, options = {"shift"}},
+							--{cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {1560, 800}, options = {"shift"}},
+							--{unitName = "turretmissile", pos = {64, 64}, facing = 3, options = {"shift"}},
 						},
 					},
 					{
@@ -77,6 +83,15 @@ local function GetPlanet(planetUtilities, planetID)
 						facing = 0, 
 						commands = {
 							{cmdID = planetUtilities.COMMAND.GUARD, atPosition = {2560, 800}},
+						},
+					},
+					{
+						name = "cloakcon",
+						x = 2327,
+						z = 1400,
+						facing = 0, 
+						commands = {
+							{cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {2410, 2580}},
 						},
 					},
 					{
@@ -97,47 +112,36 @@ local function GetPlanet(planetUtilities, planetID)
 						z =1150,
 						facing = 0, 
 					},
-					{
-						name = "cloakarty",
-						x =2400,
-						z =1100,
-						facing = 0, 
-					},
-					{
-						name = "cloakarty",
-						x =2440,
-						z =1080,
-						facing = 0, 
-					},
-					{
-						name = "cloakarty",
-						x =2480,
-						z =1060,
-						facing = 0, 
-					},
-					{
-						name = "cloakarty",
-						x =2520,
-						z =1040,
-						facing = 0, 
-					},
-					{
-						name = "cloakarty",
-						x =2560,
-						z =1020,
-						facing = 0, 
-					},
-					{
-						name = "cloakriot",
-						x =2700,
-						z =1100,
-						facing = 0, 
-						-- commands = {
-							-- {cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {2700, 900}},
-							-- {cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {2500, 1100}, options = {"shift"}},
-							-- {cmdID = planetUtilities.COMMAND.REPEAT, params = {1}}, -- Watch out, start state widget may override this?
-						-- },
-					},
+					-- {
+						-- name = "cloakarty",
+						-- x =2400,
+						-- z =1100,
+						-- facing = 0, 
+					-- },
+					-- {
+						-- name = "cloakarty",
+						-- x =2440,
+						-- z =1080,
+						-- facing = 0, 
+					-- },
+					-- {
+						-- name = "cloakarty",
+						-- x =2480,
+						-- z =1060,
+						-- facing = 0, 
+					-- },
+					-- {
+						-- name = "cloakarty",
+						-- x =2520,
+						-- z =1040,
+						-- facing = 0, 
+					-- },
+					-- {
+						-- name = "cloakarty",
+						-- x =2560,
+						-- z =1020,
+						-- facing = 0, 
+					-- },
 					{
 						name = "cloakriot",
 						x =2650,
@@ -281,15 +285,39 @@ local function GetPlanet(planetUtilities, planetID)
 							facing = 2, 
 						},
 						{
-							name = "turretriot",
+							name = "turretheavylaser",
 							x =2280,
 							z =3000,
+							facing = 2, 
+						},
+						{
+							name = "turretheavylaser",
+							x =2750,
+							z =2990,
+							facing = 2, 
+						},
+						{
+							name = "turretriot",
+							x =2460,
+							z =2800,
+							facing = 2, 
+						},
+						{
+							name = "turretriot",
+							x =3068,
+							z =2565,
 							facing = 2, 
 						},
 						{
 							name = "turretriot",
 							x =4750,
 							z =2280,
+							facing = 2, 
+						},
+						{
+							name = "turretriot",
+							x = 2910,
+							z = 3500,
 							facing = 2, 
 						},
 						{


### PR DESCRIPTION
Mission 1: Warrior not unlocked, "Kill 10 Glaives" -> "Destroy all enemy mexes"
Mission 2: Warrior unlocked, Stardusts reduced in number and repositioned, one starts in LoS
Mission 3: Start with a con assisting factory, AI builds Leveller, AI does not build Dart
Mission 5: Removed most starting units, AI starts with more Stinger/Stardust, a Conjurer walks into LoS range of a few of them at the start