### PR TITLE
Prevent arithmetic error causing download handler to crash

### DIFF
--- a/LuaMenu/widgets/api_download_handler.lua
+++ b/LuaMenu/widgets/api_download_handler.lua
@@ -300,7 +300,7 @@ function wrapperFunctions.DownloadFileProgress(name, fileType, progress, seconds
 	end
 	
 	totalLength = totalLength/1023^2
-	CallListeners("DownloadProgress", downloadQueue[index].id, totalLength*math.min(1, progress/100), totalLength, name)
+	CallListeners("DownloadProgress", downloadQueue[index].id, totalLength*math.min(1, tonumber(progress)/100), totalLength, name)
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
fix #398

Tested locally, seems to work.