### PR TITLE
Module unlock changes.

### DIFF
--- a/campaign/sample/planets/planet34.lua
+++ b/campaign/sample/planets/planet34.lua
@@ -1132,7 +1132,7 @@ local function GetPlanet(planetUtilities, planetID)
 				"staticrearm",
 			},
 			modules = {
-				"module_high_power_servos_LIMIT_B_2",
+				"module_adv_nano_LIMIT_H_1",
 			},
 			abilities = {
 			}

--- a/campaign/sample/planets/planet37.lua
+++ b/campaign/sample/planets/planet37.lua
@@ -713,7 +713,7 @@ local function GetPlanet(planetUtilities, planetID)
 				"gunshipheavytrans",
 			},
 			modules = {
-				"module_high_power_servos_LIMIT_C_2",
+				"module_battle_drone_LIMIT_D_2",
 			},
 			abilities = {
 			}

--- a/campaign/sample/planets/planet50.lua
+++ b/campaign/sample/planets/planet50.lua
@@ -94,7 +94,7 @@ local function GetPlanet(planetUtilities, planetID)
 				"jumpaa",
 			},
 			modules = {
-				"module_adv_nano_LIMIT_H_1",
+				
 			},
 			abilities = {
 			}

--- a/campaign/sample/planets/planet65.lua
+++ b/campaign/sample/planets/planet65.lua
@@ -86,7 +86,7 @@ local function GetPlanet(planetUtilities, planetID)
 				"striderdetriment",
 			},
 			modules = {
-				"module_battle_drone_LIMIT_D_2",
+				
 			},
 			abilities = {
 			}

--- a/campaign/sample/planets/planet70.lua
+++ b/campaign/sample/planets/planet70.lua
@@ -90,6 +90,7 @@ local function GetPlanet(planetUtilities, planetID)
 				"planeheavyfighter",
 			},
 			modules = {
+				"module_high_power_servos_LIMIT_B_2",
 			},
 			abilities = {
 			}

--- a/campaign/sample/planets/planet71.lua
+++ b/campaign/sample/planets/planet71.lua
@@ -118,7 +118,9 @@ local function GetPlanet(planetUtilities, planetID)
 		},
 		completionReward = {
 			experience = planetUtilities.MAIN_EXP,
-			modules = {},
+			modules = {
+				"module_high_power_servos_LIMIT_C_2",
+			},
 			units = {
 				"tankraid"
 			},


### PR DESCRIPTION
 - Servos from 37 to 71 and 34 to 70
 - Battle drone from 65 to 37
 - Nano from 50 to 34

These changes leave 50 (jumpfac) and 65 (detri) without modules. Jump module is intended to be added to 50 later.