### PR TITLE
Fix issues with the modoptions window

### DIFF
--- a/LuaMenu/configs/gameConfig/zk/ModOptions.lua
+++ b/LuaMenu/configs/gameConfig/zk/ModOptions.lua
@@ -184,7 +184,7 @@ local options = {
 	desc	= "Prevents specified units from being built ingame. Specify multiple units by using + ",
 	section	= 'startconds',
 	type	= "string",
-	def		= nil,
+	def		= "",
   },
 	{
 		key = 'globallos',


### PR DESCRIPTION
 * the Reset button now visually changes the controls as well.
   Previously it failed to do this for modoptions whose applied value was the default, for default-true checkboxes, and for `disabledunits`.
 * numericals with step 0.1 now have 1 digit of precision (previously 3)
 * numericals not aligned to step are now rounded (previously floored)