### PR TITLE
Campaign typo fixes and quality-of-life changes.

### DIFF
--- a/campaign/sample/planets/planet1.lua
+++ b/campaign/sample/planets/planet1.lua
@@ -37,7 +37,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/energysolar.png",
-				text = [[Metal is useless without a supply of energy. Build Solar Collectors to gather energy.]]
+				text = [[All construction requires equal amounts of metal and energy. Build Solar Collectors to gather energy.]]
 			},
 			{
 				image = "unitpics/cloakriot.png",

--- a/campaign/sample/planets/planet10.lua
+++ b/campaign/sample/planets/planet10.lua
@@ -34,7 +34,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/veharty.png",
-				text = [[Badgers are very good for grinding down your opposition. They fire mines which can make a region practically impassable for the enemy. They are almost defenseless unless you plan ahead with some well placed mines, so make sure they don't get flanked. Force Fire the ground with Alt + Left Click with a group of Badgers to make a line of mines.]]
+				text = [[Badgers are very good for grinding down your opposition. They fire mines which can make a region practically impassable for the enemy. They are almost defenseless unless you plan ahead with some well placed mines, so make sure they don't get flanked. Press F to force your Badgers to fire at a given location.]]
 			},
 			{
 				image = "unitpics/module_dmg_booster.png",

--- a/campaign/sample/planets/planet11.lua
+++ b/campaign/sample/planets/planet11.lua
@@ -34,7 +34,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/vehscout.png",
-				text = [[Darts are not very useful in combat, but they are very cheap, fast and can see a long way, so they are ideal for discovering enemy locations and identifying radar dots.]]
+				text = [[Darts are equipped with a disruptor beam to harass and slow enemies. Their main use is as disposable scouts, discovering enemy locations and identifying radar dots.]]
 			},
 			{
 				image = "unitpics/turretheavy.png",

--- a/campaign/sample/planets/planet12.lua
+++ b/campaign/sample/planets/planet12.lua
@@ -26,7 +26,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24457",
-			text = [[The enemy is well entrenched but, luckily for you, they have a poorly defended outpost and you have a squad of Dominatrices. Capture the outpost to gain a production base, then steal an army of Tanks and march on their main base.]]
+			text = [[The enemy is well entrenched but, luckily for you, they have a poorly defended outpost and you have a squad of Dominatrices. Capture the outpost to get a head start, then steal an army of Tanks and march on their main base.]]
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet13.lua
+++ b/campaign/sample/planets/planet13.lua
@@ -35,11 +35,11 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/shieldraid.png",
-				text = [[Bandits are a somewhat slower raiders than Glaives but compensate with superior health and range. They are exceptionally versatile units and are particularly effective while sheltered under the shield of a Convict or Thug.]]
+				text = [[Bandits are slower raiders than Glaives but compensate with superior health and range. They are exceptionally versatile units and are particularly effective while sheltered under the shield of a Convict or Thug.]]
 			},
 			{
 				image = "unitpics/shieldriot.png",
-				text = [[Outlaws wield an unconventional weapon: a disrupting pulse which damage and slow enemies (but not allies) in a wide radius. Compared to most riots it is very poor against single targets but exceptional when used to protect other units against raider assault.]]
+				text = [[Outlaws wield an unconventional weapon: a disrupting pulse which damages and slows enemies (but not allies) in a wide radius. Compared to most riots it is very poor against single targets but exceptional when used to protect other units against raider assault.]]
 			},
 		},
 		gameConfig = {

--- a/campaign/sample/planets/planet15.lua
+++ b/campaign/sample/planets/planet15.lua
@@ -43,7 +43,7 @@ local function GetPlanet(planetUtilities, planetID)
 			-- },
 			{
 				image = "unitpics/gunshipraid.png",
-				text = [[Most units will attempt to fire at low-flying aircraft and some, such as Bandits, are even good at the task. However, dedicated anti-air such as Vandals or Razor turrets are significantly more effective and have a significant range advantage.]]
+				text = [[Most units will attempt to fire at low-flying aircraft and some, such as Bandits, are even good at the task. However, dedicated anti-air such as Vandals or Razor turrets are much more effective and have a significant range advantage.]]
 			},
 		},
 		gameConfig = {

--- a/campaign/sample/planets/planet16.lua
+++ b/campaign/sample/planets/planet16.lua
@@ -31,7 +31,7 @@ local function GetPlanet(planetUtilities, planetID)
 		tips = {
 			{
 				image = "unitpics/shieldbomb.png",
-				text = [[Snitches burrow into the ground, cloaking themselves at the cost of movement, then explode when enemies get close. With an area cloaker Snitches can are free to move while cloaked, transforming them into a potent offensive weapon. Manually detonate Snitches with 'D'.]]
+				text = [[Snitches burrow into the ground, cloaking themselves while remaining stationary, then explode when enemies get close. An area cloakers will make Snitches invisible even while moving, transforming them into a potent offensive weapon. Manually detonate Snitches by pressing D.]]
 			},
 			{
 				image = "unitpics/cloakjammer.png",
@@ -39,7 +39,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/staticjammer.png",
-				text = [[The Iris mobile cloaker can morph to and from a static version - the Cornea. The Cornea cloaks units in a larger radius and is much harder to spot due it's reduced decloak radius. Cornea can be built by all standard constructors so Iris is avalible even without a Cloakbot Factory.]]
+				text = [[The Iris mobile cloaker can morph to and from a static version - the Cornea. The Cornea cloaks units in a larger radius and is much harder to spot due it's reduced decloak radius. Cornea can be built by all standard constructors, so area cloakers are avalible even without a Cloakbot Factory.]]
 			},
 		},
 		gameConfig = {

--- a/campaign/sample/planets/planet18.lua
+++ b/campaign/sample/planets/planet18.lua
@@ -35,7 +35,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/shieldscout.png",
-				text = [[Dirtbags are curious bots with many unfulfilled aspirations. They want to scout and fight but are almost blind and all they can muster is a headbutt. They try to terraform but all they manage is to drop a little pile of dirt upon their death. They make up for this by being extremely cheap and fairly tough.]]
+				text = [[Dirtbags are curious bots with many unfulfilled aspirations. They want to scout and fight but are almost blind and their only attack is a headbutt. They try to terraform but all they manage is to drop a little pile of dirt upon their death. The good side is that they are very cheap and quite tough.]]
 			},
 			{
 				image = "unitpics/staticmissilesilo.png",

--- a/campaign/sample/planets/planet19.lua
+++ b/campaign/sample/planets/planet19.lua
@@ -39,7 +39,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/staticmex.png",
-				text = [[Connecting Metal Extractors to your energy production structures can give you more metal income through Overdrive. Check the wiki for more information about how Overdrive works.]]
+				text = [[Connecting Metal Extractors to your energy production structures can give you more metal income through Overdrive. Check the online manual for more information about how Overdrive works.]]
 			},
 			{
 				image = "unitpics/staticcon.png",

--- a/campaign/sample/planets/planet19.lua
+++ b/campaign/sample/planets/planet19.lua
@@ -35,7 +35,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/energypylon.png",
-				text = [[In order to fire, your Cerberus needs to be connected to a power grid with at least 50 energy, although it does not consume this energy. Use Energy Pylons to extend the grid from your ally's Fusions.]]
+				text = [[In order to fire, your Cerberus needs to be connected to a power grid with at least 50 energy, although it does not consume this energy. Use Energy Pylons to extend the grid from your ally's Fusions. The Economy view (F4) displays your power grid as coloured circles.]]
 			},
 			{
 				image = "unitpics/staticmex.png",
@@ -686,7 +686,7 @@ local function GetPlanet(planetUtilities, planetID)
 					},
 					image = planetUtilities.ICON_DIR .. "staticarty.png",
 					imageOverlay = planetUtilities.ICON_OVERLAY.REPAIR,
-					description = "Build two Cerberi",
+					description = "Build two Cerberuses",
 					experience = planetUtilities.BONUS_EXP,
 				},
 				[3] = { -- Win in 12 minutes

--- a/campaign/sample/planets/planet2.lua
+++ b/campaign/sample/planets/planet2.lua
@@ -26,16 +26,16 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24417",
-			text = [[Glaives and Reavers served you well in the previous battle, but on this planet your opponent has prepared their own Reavers and Stardust turrets to counter them. Build a Cloakbot Factory, then counter them with longer-ranged Ronins to secure victory.]]
+			text = [[Your opponent has prepared powerful close-range Stardust turrets and Reavers to defeat your raiders. Build a Cloakbot Factory, then counter their strategy with longer-ranged Ronins to secure victory.]]
 		},
 		tips = {
 			{
 				image = "unitpics/turretriot.png",
-				text = [[Stardusts will shred any unit which gets into its range. Your Ronins can avoid this fate by attacking from just outside the Stardusts' range.]]
+				text = [[Stardusts are riot turrets which will shred any nearby units. Your Ronins can avoid this fate by attacking from just outside the Stardusts' range.]]
 			},
 			{
 				image = "unitpics/cloakskirm.png",
-				text = [[As skirmishers, Ronins are faster than and outrange Reavers so can destroy them without losses. Glaives can dodge the slow Ronin rockets and pose a much bigger threat.]]
+				text = [[Ronins are skirmishers which can safely destroy Reavers from long range. Glaives are fast enough to close the distance while avoiding Ronin rockets.]]
 			},
 			{
 				image = "unitpics/cloakcon.png",

--- a/campaign/sample/planets/planet21.lua
+++ b/campaign/sample/planets/planet21.lua
@@ -31,7 +31,7 @@ local function GetPlanet(planetUtilities, planetID)
 		tips = {
 			{
 				image = "unitpics/striderdante.png",
-				text = [[The Dante likes to get up close and personal so its heatrays inflict maximum damage. Fire a large barrage of napalm rockets with manual fire (default hotkey D).]]
+				text = [[The Dante likes to get up close and personal so its heatrays can inflict maximum damage. Fire a large barrage of napalm rockets with manual fire (default hotkey D).]]
 			},
 			{
 				image = "unitpics/chickens.png",
@@ -39,7 +39,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/guardian.png",
-				text = [[The faction you stole the Strider Hub from is still pretty pissed as well. They're hard pressed by the chickens, but don't expect them to make your life easy.]]
+				text = [[The faction you stole the Strider Hub from is still pretty pissed as well. They're hard pressed by the chickens, but don't expect them to make your escape easy.]]
 			},
 		},
 		gameConfig = {

--- a/campaign/sample/planets/planet22.lua
+++ b/campaign/sample/planets/planet22.lua
@@ -39,7 +39,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/amphbomb.png",
-				text = [[Limpets do not float, but its large disruption pulse can reach surface targets even from the seafloor. The Limpet's slowbomb does not affect allies so you can use it within your army.]]
+				text = [[The Limpet does not float, but its large disruption pulse can reach surface targets even from the seafloor. The Limpet's explosion does not damage or slow friendly units, so it is safer to use than other bombs.]]
 			},
 		},
 		gameConfig = {

--- a/campaign/sample/planets/planet24.lua
+++ b/campaign/sample/planets/planet24.lua
@@ -26,7 +26,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F9IV",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
-			text = [[You've discovered some Ancient Fabricators capable of generating metal from nothing. A rival faction is eager to claim your prize, and they have surrounded your base. Use Djinn teleporters and Lobsters to launch an attack from behind.]]
+			text = [[You've discovered some Ancient Fabricators capable of generating metal from nothing. A rival faction is eager to claim your prize, and they have surrounded your base. Use Djinn teleporters and Lobsters to launch an attack from behind and break the siege.]]
 		},
 		tips = {
 			{
@@ -81,8 +81,8 @@ local function GetPlanet(planetUtilities, planetID)
 						z = 6140,
 						facing = 0,
 						commands = {
-							{cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {1950, 6420}},
-							{cmdID = planetUtilities.COMMAND.ATTACK, pos = {1950, 6750}, options = {"shift"}},
+							{cmdID = planetUtilities.COMMAND.RAW_MOVE, pos = {1950, 6540}},
+							{cmdID = planetUtilities.COMMAND.ATTACK, pos = {1950, 6870}, options = {"shift"}},
 						},
 					},
 					{

--- a/campaign/sample/planets/planet25.lua
+++ b/campaign/sample/planets/planet25.lua
@@ -31,7 +31,7 @@ local function GetPlanet(planetUtilities, planetID)
 		tips = {
 			{
 				image = "unitpics/amphraid.png",
-				text = [[Ducks are slower than most raiders but they can move and heal underwater. They are armed with a dual purpose torpedo mission which allows them to fight both above and below the water.]]
+				text = [[Ducks are slower than most raiders but they can move and heal underwater. They are armed with a dual purpose torpedo launcher which allows them to fight both above and below the water.]]
 			},
 			{
 				image = "unitpics/amphriot.png",

--- a/campaign/sample/planets/planet26.lua
+++ b/campaign/sample/planets/planet26.lua
@@ -35,7 +35,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/hoverskirm.png",
-				text = [[Scalpels fire a pair of guided missiles at medium range. They are helpless during their long reload time - either bring an escort or destroy the enemy with the first salvo.]]
+				text = [[Scalpels fire a pair of guided missiles at medium range. They are helpless during their long reload time - either destroy the enemy with the first salvo or bring an escort. Maces are good at cleaning up after a Scalpel volley.]]
 			},
 			{
 				image = "unitpics/energywind.png",

--- a/campaign/sample/planets/planet27.lua
+++ b/campaign/sample/planets/planet27.lua
@@ -31,7 +31,7 @@ local function GetPlanet(planetUtilities, planetID)
 		tips = {
 			{
 				image = "unitpics/hoverdepthcharge.png",
-				text = [[Claymores fire depth charges at short range for large area-of-effect damage. To make this less of a suicide mission the depth charge floats for a few seconds before tracking its target. Depth charges can also be dropped as short-lived mines, even on land, press D to drop a mine manually.]]
+				text = [[Claymores fire depth charges at short range for large area-of-effect damage. To make this less of a suicide mission the depth charge floats for a few seconds before tracking its target. Depth charges can also be dropped as short-lived mines, even on land. Press D to drop a mine manually.]]
 			},
 			{
 				image = "unitpics/hoveraa.png",

--- a/campaign/sample/planets/planet3.lua
+++ b/campaign/sample/planets/planet3.lua
@@ -35,7 +35,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/cloakbomb.png",
-				text = [[Imp EMP bombs are capable of stunning large numbers of light-weight units (friend or foe) in a large radius. The EMP does not inflict long-term damage so make sure you have combat units standing by to take advantage in the moment.]]
+				text = [[Imp EMP bombs will stun any nearby units when they explode. They are mostly a defensive tool, and don't kill anything themselves, so make sure you have other units like Reavers to finish the job.]]
 			},
 			{
 				image = "unitpics/vehraid.png",

--- a/campaign/sample/planets/planet3.lua
+++ b/campaign/sample/planets/planet3.lua
@@ -39,7 +39,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/vehraid.png",
-				text = [[The Scorchers heat ray weapon is incredibly lethal at point-blank range. Destroy them from a distance or stun them with Imps before engaging.]]
+				text = [[The Scorchers' heat ray weapon is incredibly lethal at point-blank range. Destroy them from a distance or stun them with Imps before engaging.]]
 			},
 		},
 		gameConfig = {
@@ -58,6 +58,13 @@ local function GetPlanet(planetUtilities, planetID)
 					"turretmissile"
 				},
 				startUnits = {
+					{
+						name = "cloakriot",
+						x = 3550,
+						z = 1250,
+						facing = 0,
+						difficultyAtMost = 2,
+					}, 
 					{
 						name = "factorycloak",
 						x = 3276,

--- a/campaign/sample/planets/planet30.lua
+++ b/campaign/sample/planets/planet30.lua
@@ -25,7 +25,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = [[Crossing a river under enemy fire is a daunting prospect, but it becomes easier when you control the water. Bombard the shoreline with Envoy cruisers to force passage through the shallows.]]
+			text = [[Crossing a river under enemy fire is a daunting prospect, but it becomes easier when you control the river. Bombard the shoreline with Envoy cruisers to force passage through the shallows.]]
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet40.lua
+++ b/campaign/sample/planets/planet40.lua
@@ -31,11 +31,11 @@ local function GetPlanet(planetUtilities, planetID)
 		tips = {
 			{
 				image = "unitpics/tankassault.png",
-				text = [[The Minotaur assault tank is a very tough unit considering its affordable price. Use it to brute-force your way through enemy positions.]]
+				text = [[The Minotaur assault tank is a very tough unit for a relatively affordable price. Use it to brute-force your way through enemy positions.]]
 			},
 			{
 				image = "unitpics/tankarty.png",
-				text = [[Use the Emissary artillery tank to weaken defenses that would otherwise be inefficient to assault directly with Minotaurs.]]
+				text = [[Use the Emissary artillery tank to weaken defenses that are too dangerous to attack directly with Minotaurs.]]
 			},
 			{
 				image = "unitpics/factorycloak.png",

--- a/campaign/sample/planets/planet47.lua
+++ b/campaign/sample/planets/planet47.lua
@@ -2520,6 +2520,7 @@ local function GetPlanet(planetUtilities, planetID)
 			bonusObjectiveConfig = {
 				[1] = { -- Make six Widows
 					satisfyOnce = true,
+					countRemovedUnits = true,
 					comparisionType = planetUtilities.COMPARE.AT_LEAST,
 					targetNumber = 9,
 					unitTypes = {

--- a/campaign/sample/planets/planet57.lua
+++ b/campaign/sample/planets/planet57.lua
@@ -34,7 +34,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/subtacmissile.png",
-				text = [[The Scylla constructs and fires tactical missiles - use these to destroy static targets which are elevated or far away. Remember that destroying Pylon connections will disable heavy defences.]]
+				text = [[The Scylla constructs and fires tactical missiles. Use these to destroy static targets which are elevated or far away. Remember that destroying Pylon connections will disable heavy defences.]]
 			},
 			{
 				image = "unitpics/weaponmod_standoff_rocket.png",

--- a/campaign/sample/planets/planet58.lua
+++ b/campaign/sample/planets/planet58.lua
@@ -25,7 +25,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K1VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24614",
-			text = [[Two enemy groups are already engaged on this icy planet. Defeat them both at a safe distance with the Merlin artillery strider.]]
+			text = [[Two enemy groups are already engaged on this icy planet. Defeat them both from a safe distance with the Merlin artillery strider.]]
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet6.lua
+++ b/campaign/sample/planets/planet6.lua
@@ -119,10 +119,11 @@ local function GetPlanet(planetUtilities, planetID)
 					commanderLevel = 2,
 					commander = {
 						name = "Firelord",
-						chassis = "recon",
+						chassis = "guardian",
 						decorations = {
 						},
 						modules = {
+							"commweapon_flamethrower",
 							"commweapon_flamethrower",
 						}
 					},

--- a/campaign/sample/planets/planet63.lua
+++ b/campaign/sample/planets/planet63.lua
@@ -25,7 +25,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "B5II",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24614",
-			text = [[Your Tech Lab is attempting to discover how the hostiles on this planet have subjugated a hive of Chickens. Protect the Lab until the research is complete.]]
+			text = [[Your Tech Lab is attempting to discover how the hostiles on this planet have subjugated a hive of Chickens. Protect the Tech Lab until its research is complete.]]
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet68.lua
+++ b/campaign/sample/planets/planet68.lua
@@ -25,7 +25,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G1V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24642",
-			text = [[Your opponent is already conducting a victory dance with their Disco Rave Party. Hold off their assault until your Starlight orbital chisel is complete, then demonstrate that their celebration is premature.]]
+			text = [[Your opponent is already conducting a victory dance with their Disco Rave Party cannon. Hold off their assault until your Starlight orbital chisel is complete, then demonstrate that their celebration is premature.]]
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet7.lua
+++ b/campaign/sample/planets/planet7.lua
@@ -31,11 +31,11 @@ local function GetPlanet(planetUtilities, planetID)
 		tips = {
 			{
 				image = "unitpics/cloaksnipe.png",
-				text = [[Unlike all other cloaked units, the Phantom can fire its weapon without dropping its cloak. Use this to sneak into the defence network, destroying what you need to without blowing your cover.]]
+				text = [[Unlike all other cloaked units, the Phantom can fire its weapon without becoming visible. Use this to sneak into the defence network, destroying what you need to without blowing your cover.]]
 			},
 			{
 				image = "unitpics/turretheavy.png",
-				text = [[Heavier turrets cannot fire unless they are connected to energy-producing buildings. Deactivate them by destroying Energy Pylons or the energy producers themselves.]]
+				text = [[Heavier turrets cannot fire unless they are connected to energy-producing buildings. Deactivate them by destroying the connecting Energy Pylons or the energy producers themselves.]]
 			},
 			{
 				image = "unitpics/shieldfelon.png",

--- a/campaign/sample/planets/planet9.lua
+++ b/campaign/sample/planets/planet9.lua
@@ -30,10 +30,6 @@ local function GetPlanet(planetUtilities, planetID)
 		},
 		tips = {
 			{
-				image = "unitpics/vehcon.png",
-				text = [[Assist factories with constructors, such as the Mason, to speed up unit production. Assisting is more flexible and efficient than constructing additional factories.]]
-			},
-			{
 				image = "unitpics/vehraid.png",
 				text = [[The heatray weapon of the Scorcher does little damage at a distance and massive damage at close range. Move them right next to an enemy unit and watch it melt.]]
 			},


### PR DESCRIPTION
On Easy and Normal, the player starts with a Reaver in Mission 3 (Imp/Picket).
Mission 6 (Knight) commander is now a Guardian com with two flamethrowers, so it cannot jump in holes.
Fixed Mission 47 (Flea/Widow) optional objective.