### PR TITLE
Fix spawn config typo in mission 44

### DIFF
--- a/campaign/sample/planets/planet44.lua
+++ b/campaign/sample/planets/planet44.lua
@@ -226,7 +226,7 @@ local function GetPlanet(planetUtilities, planetID)
 							facing = 1,
 						},
  						{
-							name = "turretruit",
+							name = "turretriot",
 							x = 272,
 							z = 3488,
 							facing = 0,


### PR DESCRIPTION
`turretruit` -> `turretriot`