### PR TITLE
Likho mission: remove decoy comm

### DIFF
--- a/campaign/sample/planets/planet35.lua
+++ b/campaign/sample/planets/planet35.lua
@@ -2407,7 +2407,7 @@ local function GetPlanet(planetUtilities, planetID)
 							facing = 1,
 						},
  						{
-							name = "dynstrike5_00",
+							name = "jumparty",
 							x = 1284,
 							z = 775,
 							facing = 3,


### PR DESCRIPTION
There's a bonus objective to kill "the enemy commander" but there's an impostor that leaves people confused.