### PR TITLE
Set top left corner of fullscreen and manual fullscreen

### DIFF
--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -1773,6 +1773,8 @@ function widget:Initialize()
 		elseif battleStartDisplay == 3 then -- Fullscreen
 			Configuration:SetSpringsettingsValue("XResolution", screenX)
 			Configuration:SetSpringsettingsValue("YResolution", screenY)
+			Configuration:SetSpringsettingsValue("WindowPosX", 0)
+			Configuration:SetSpringsettingsValue("WindowPosY", 0)
 			Configuration:SetSpringsettingsValue("Fullscreen", 1)
 		elseif battleStartDisplay == 4 then -- Manual Borderless
 			local borders = WG.Chobby.Configuration.manualBorderless.game or {}
@@ -1785,6 +1787,8 @@ function widget:Initialize()
 			local resolution = WG.Chobby.Configuration.manualFullscreen.game or {}
 			Configuration:SetSpringsettingsValue("XResolution", resolution.width or screenX)
 			Configuration:SetSpringsettingsValue("YResolution", resolution.height or screenY)
+			Configuration:SetSpringsettingsValue("WindowPosX", 0)
+			Configuration:SetSpringsettingsValue("WindowPosY", 0)
 			Configuration:SetSpringsettingsValue("Fullscreen", 1)
 		end
 


### PR DESCRIPTION
Bugfix that corrects Fullscreen issues on Windows 7 when paired a windowed lobby with a non-zero x and y coordinate set.