### PR TITLE
Improvements to CircuitAI - Brutal, Hard, Normal, and Easy.

### DIFF
--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/behaviour.json
@@ -855,7 +855,7 @@
 	},
 	"staticantinuke": {
 		"role": ["static", "heavy", "support"],
-		"limit": 1
+		"limit": 2
 	},
 	"turretheavylaser": {
 		"role": ["static", "static", "heavy"],

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/behaviour.json
@@ -854,7 +854,7 @@
 		"thr_mod": 0.55
 	},
 	"staticantinuke": {
-		"role": ["static", "heavy"],
+		"role": ["static", "heavy", "support"],
 		"limit": 1
 	},
 	"turretheavylaser": {

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/build_chain.json
@@ -3,13 +3,16 @@
 "porcupine": {
 	//        0              1                2             3                   4
 	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
-	//   5                6            7              8               9
+	//        5                6            7              8               9
 		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
-	//   10                 11            12             13               14
-		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss"],
+	//       10                 11            12             13               14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		    16			17
+		"staticantinuke", "staticheavyradar", "staticnuke"
+],
 	// Actual number of defences per cluster bounded by income
-	"land":  [0, 0, 1, 3, 1, 5, 14, 5, 6, 2, 3, 5, 0, 8, 14, 1, 3, 6, 12, 11, 13],
-	"water": [4, 1, 6, 4, 4, 3, 5],
+	"land":  [0, 0, 1, 3, 9, 1, 5, 14, 9, 5, 6, 2, 3, 5, 0, 8, 9, 14, 1, 3, 6, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
 	"prevent": 1,  // number of preventive defences
 	"amount": {  // income bound factor
 		"offset": [-0.15, 0.4],
@@ -19,11 +22,11 @@
 	},
 
 	// Base defence and time to build it, in seconds
-	"base": [[0, 20], [0, 120], [0, 360], [1, 400], [0, 500], [5, 660], [5, 860], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800]],
+	"base": [[0, 20], [0, 120], [9, 300], [0, 360], [1, 400], [0, 500], [9, 530], [16, 600], [5, 660], [5, 860], [15, 900], [9, 930], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [17, 1830]],
 
 	"superweapon": {
 		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke", "staticheavyradar"],  // FIXME: last 2 aren't superweapons
-		"weight": [ 0.4,         0.15,         0.4,               0.5,      0.3,              0.5],  // FIXME: SUM(weight) should be 1.0
+		"weight": [ 0.05,         0.15,         0.25,               0.05,      0.2,              0.3],
 
 		"condition": [18, 1600]  // [<Minimum income>, <maximum seconds to build>]
 	},
@@ -115,6 +118,7 @@
 					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
 					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
 					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
 					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
@@ -127,6 +131,7 @@
 					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
 					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
 					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
 					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
@@ -174,10 +179,18 @@
 			"hub": [[
 					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
 					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
 					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
 					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
 					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
 				]]
 		},

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/build_chain.json
@@ -3,11 +3,11 @@
 "porcupine": {
 	//        0              1                2             3                   4
 	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
-	//        5                6            7              8               9
+	//       5                6            7              8               9
 		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
 	//       10                 11            12             13               14
 		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
-	//       15		    16			17
+	//       15		   16		       17
 		"staticantinuke", "staticheavyradar", "staticnuke"
 ],
 	// Actual number of defences per cluster bounded by income
@@ -26,7 +26,7 @@
 
 	"superweapon": {
 		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke", "staticheavyradar"],  // FIXME: last 2 aren't superweapons
-		"weight": [ 0.05,         0.15,         0.25,               0.05,      0.2,              0.3],
+		"weight": [ 0.05,         0.15,        0.25,              0.05,     0.2,              0.3],
 
 		"condition": [18, 1600]  // [<Minimum income>, <maximum seconds to build>]
 	},

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/behaviour.json
@@ -788,7 +788,8 @@
 		"thr_mod": 1.0
 	},
 	"staticantinuke": {
-		"role": ["static", "heavy"]
+		"role": ["static", "heavy", "support"],
+		"limit": 1
 	},
 	"turretheavylaser": {
 		"role": ["static", "heavy"],

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/build_chain.json
@@ -1,11 +1,18 @@
 // Mono-space font required
 {
 "porcupine": {
-	//        0              1                2             3                   4             5                6            7              8               9            10                 11            12             13               14
-	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp", "turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp", "turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss"],
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//       5                6            7              8               9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10                 11            12             13               14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		   16		       17
+		"staticantinuke", "staticheavyradar", "staticnuke"
+],
 	// Actual number of defences per cluster bounded by income
-	"land":  [0, 1, 0, 3, 5, 1, 2, 1, 5, 0, 14, 1, 3, 6, 12, 11, 13],
-	"water": [4, 1, 6, 4, 4, 3, 5],
+	"land":  [0, 1, 0, 3, 9, 5, 1, 2, 1, 9, 5, 0, 14, 1, 3, 6, 9, 12, 11, 13, 16],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
 	"prevent": 1,  // number of preventive defences
 	"amount": {  // income bound factor
 		"offset": [-0.40, 0.20],
@@ -15,11 +22,11 @@
 	},
 
 	// Base defence and time to build it, in seconds
-	"base": [[0, 20], [0, 120], [0, 360], [1, 400], [0, 500], [5, 660], [5, 860],[1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [7, 2400]],
+	"base": [[0, 20], [0, 120], [9, 300], [0, 360], [1, 400], [0, 500], [9, 530], [16, 600], [5, 660], [5, 860], [15, 900], [9, 930], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [17, 1830]],
 
 	"superweapon": {
-		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith"],
-		"weight": [ 0.3,         0.2,          0.4,               0.1],
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],  // FIXME: last 1 isn't superweapon
+		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
 
 		"condition": [35, 600]  // [<Minimum income>, <maximum seconds to build>]
 	},
@@ -114,6 +121,7 @@
 					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
 					{"unit": "turretaafar", "category": "defence", "offset": {"left": -220}, "condition": "air"},
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 180]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
 					{"unit": "turretaafar", "category": "defence", "offset": {"front": -120}, "condition": "air"},
 					{"unit": "turretriot", "category": "defence", "offset": [180, -80]},
@@ -168,6 +176,25 @@
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
 					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
 					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
 				]]
 		},

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/behaviour.json
@@ -783,7 +783,8 @@
 		"thr_mod": 1.0
 	},
 	"staticantinuke": {
-		"role": ["static", "heavy"]
+		"role": ["static", "heavy", "support"],
+		"limit": 2
 	},
 	"turretheavylaser": {
 		"role": ["static", "heavy"],

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/build_chain.json
@@ -1,11 +1,18 @@
 // Mono-space font required
 {
 "porcupine": {
-	//        0              1                2             3                   4             5                6            7              8               9            10                 11            12             13               14
-	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp", "turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp", "turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss"],
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//       5                6            7              8               9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10                 11            12             13               14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		   16		       17
+		"staticantinuke", "staticheavyradar", "staticnuke"
+],
 	// Actual number of defences per cluster bounded by income
-	"land":  [0, 1, 0, 3, 5, 1, 2, 1, 5, 0, 14, 1, 3, 6, 12, 11, 13],
-	"water": [4, 1, 6, 4, 4, 3, 5],
+	"land":  [0, 1, 0, 3, 9, 5, 1, 2, 1, 5, 0, 9, 14, 1, 3, 6, 9, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
 	"prevent": 1,  // number of preventive defences
 	"amount": {  // income bound factor
 		"offset": [-0.40, 0.20],
@@ -15,11 +22,11 @@
 	},
 
 	// Base defence and time to build it, in seconds
-	"base": [[0, 20], [0, 120], [0, 360], [1, 400], [0, 500], [5, 660], [5, 860],[1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [7, 2400]],
+	"base": [[0, 20], [0, 120], [9, 300], [0, 360], [1, 400], [0, 500], [9, 530], [16, 600], [5, 660], [5, 860], [15, 900], [9, 930], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [17, 1830]],
 
 	"superweapon": {
-		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith"],
-		"weight": [ 0.3,         0.2,          0.4,               0.1],
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],  // FIXME: last 1 isn't superweapon
+		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
 
 		"condition": [35, 600]  // [<Minimum income>, <maximum seconds to build>]
 	},
@@ -168,6 +175,25 @@
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
 					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
 					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
 				]]
 		},

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/behaviour.json
@@ -783,7 +783,8 @@
 		"thr_mod": 1.0
 	},
 	"staticantinuke": {
-		"role": ["static", "heavy"]
+		"role": ["static", "heavy", "support"],
+		"limit": 1
 	},
 	"turretheavylaser": {
 		"role": ["static", "heavy"],

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/build_chain.json
@@ -1,11 +1,18 @@
 // Mono-space font required
 {
 "porcupine": {
-	//        0              1                2             3                   4             5                6            7              8               9            10                 11            12             13               14
-	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp", "turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp", "turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss"],
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//       5                6            7              8               9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10                 11            12             13               14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		   16		       17
+		"staticantinuke", "staticheavyradar", "staticnuke"
+],
 	// Actual number of defences per cluster bounded by income
-	"land":  [0, 1, 0, 3, 5, 1, 2, 1, 5, 0, 14, 1, 3, 6, 12, 11, 13],
-	"water": [4, 1, 6, 4, 4, 3, 5],
+	"land":  [0, 1, 0, 3, 9, 5, 1, 2, 1, 5, 0, 9, 14, 1, 3, 6, 9, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
 	"prevent": 1,  // number of preventive defences
 	"amount": {  // income bound factor
 		"offset": [-0.40, 0.20],
@@ -15,11 +22,11 @@
 	},
 
 	// Base defence and time to build it, in seconds
-	"base": [[0, 20], [0, 120], [0, 360], [1, 400], [0, 500], [5, 660], [5, 860],[1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [7, 2400]],
+	"base": [[0, 20], [0, 120], [9, 300], [0, 360], [1, 400], [0, 500], [9, 530], [16, 600], [5, 660], [5, 860], [15, 900], [9, 930], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [17, 1830]],
 
 	"superweapon": {
-		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith"],
-		"weight": [ 0.3,         0.2,          0.4,               0.1],
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],  // FIXME: last 1 isn't superweapon
+		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
 
 		"condition": [35, 600]  // [<Minimum income>, <maximum seconds to build>]
 	},
@@ -79,14 +86,15 @@
 			"pylon": true,
 			"hub": [[
 					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
 					{"unit": "turretriot", "category": "defence", "offset": [-80, 80]}
 				]]
 		}
 	},
 	"factory": {
-//		"factoryplane": {
-//			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"back": 0}}]]
-//		}
+		"factoryplane": {
+			"hub": [[{"unit": "staticrearm", "category": "nano", "offset": {"back": 100}}]]
+		},
 		"factorygunship": {
 			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"back": 0}}]]
 		}
@@ -94,7 +102,7 @@
 	"mex": {
 		"staticmex": {
 //			"terra": true,
-			"energy": [50, true],
+			"energy": [20, true],
 			"porc": true
 		}
 	},
@@ -104,7 +112,10 @@
 					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
 					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
 					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
 				]]
@@ -112,53 +123,38 @@
 		"raveparty": {
 			"hub": [[
 					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
-					{"unit": "turretaafar", "category": "defence", "offset": {"left": -220}, "condition": "air"},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, 180]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
-					{"unit": "turretaafar", "category": "defence", "offset": {"front": -120}, "condition": "air"},
-					{"unit": "turretriot", "category": "defence", "offset": [180, -80]},
-					{"unit": "turretheavy", "category": "defence", "offset": [-80, -80]},
-					{"unit": "turretmissile", "category": "defence", "offset": [-70, 170]},
-					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, 180]},
-					{"unit": "turretriot", "category": "defence", "offset": [180, -80]},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
-					{"unit": "turretaafar", "category": "defence", "offset": {"front": 220}, "condition": "air"},
-					{"unit": "turretheavy", "category": "defence", "offset": [180, -80]},
-					{"unit": "turretmissile", "category": "defence", "offset": [-70, 170]},
-					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, 180]},
-					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
-					{"unit": "turretriot", "category": "defence", "offset": [180, -80]},
-					{"unit": "turretaafar", "category": "defence", "offset": {"front": -230}, "condition": "air"},
-					{"unit": "turretmissile", "category": "defence", "offset": [180, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
 				]]
 		},
 		"mahlazer": {
 			"hub": [[
 					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
-					{"unit": "turretaafar", "category": "defence", "offset": {"left": -220}, "condition": "air"},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, 180]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
-					{"unit": "turretaafar", "category": "defence", "offset": {"front": -120}, "condition": "air"},
-					{"unit": "turretriot", "category": "defence", "offset": [180, -80]},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
-					{"unit": "turretheavy", "category": "defence", "offset": [-70, 170]},
-					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, 180]},
-					{"unit": "turretriot", "category": "defence", "offset": [180, -80]},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
-					{"unit": "turretaafar", "category": "defence", "offset": {"front": 220}, "condition": "air"},
-					{"unit": "turretriot", "category": "defence", "offset": [180, -80]},
-					{"unit": "turretmissile", "category": "defence", "offset": [-70, 170]},
-					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
-					{"unit": "turretlaser", "category": "defence", "offset": [-80, 180]},
-					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
-					{"unit": "turretriot", "category": "defence", "offset": [180, -80]},
-					{"unit": "turretheavy", "category": "defence", "offset": {"front": -230}, "condition": "air"},
-					{"unit": "turretmissile", "category": "defence", "offset": [180, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticheavyradar": {
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]}
 				]]
 		},
 		"staticnuke": {
@@ -168,6 +164,27 @@
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
 					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
 					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
 				]]
 		},
@@ -179,6 +196,8 @@
 					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
 					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
 					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
 					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
 				]]
 		}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/configversions.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/configversions.json
@@ -32,1153 +32,1153 @@
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIBeginner/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner32/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIBeginner32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAINovice32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAINovice32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAINovice/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAINovice32/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAINovice32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAINovice32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAINovice32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAIEasy32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAIEasy32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIEasy/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAIEasy32/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIEasy32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAIEasy32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAIEasy32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAINormal32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAINormal32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAINormal/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAINormal32/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAINormal32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAINormal32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAINormal32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAIHard32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAIHard32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIHard/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAIHard32/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIHard32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAIHard32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAIHard32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIBrutal/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal32/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIBrutal32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIBeginner/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner64/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIBeginner64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAIBeginner64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAINovice64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAINovice64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAINovice/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAINovice64/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAINovice64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAINovice64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAINovice64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAIEasy64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAIEasy64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIEasy/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAIEasy64/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIEasy64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAIEasy64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAIEasy64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAINormal64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAINormal64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAINormal/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAINormal64/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAINormal64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAINormal64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAINormal64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAIHard64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAIHard64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIHard/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAIHard64/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIHard64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAIHard64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAIHard64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIBrutal/stable/config/circuit.json",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal64/stable/config/circuit.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAIBrutal64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/CircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/CircuitAIBrutal64/stable/AIOptions.lua"
       },
 	  {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon32/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal32/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal32/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBeginner64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIBeginner64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINovice64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAINovice64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIEasy64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAINormal64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIHard64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/response.json",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":137,
+         "VersionNumber":138,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAICommon/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/DevCircuitAIBrutal64/stable/AIOptions.lua"
       },


### PR DESCRIPTION
1. AI build antinukes in base, starting at around 15 minutes IF resources, available builders and battlefield situation allows.
1a. Hard and Brutal limit antinukes to 2
1b. Easy and Normal limit antinuke to 1

2. AI protects antinuke with a ring of lotus+faradays against paralyze (widow) attacks.

3. AI is much more likely to reinforces groups of turrets (of various kinds) with Faraday.

4. If completed everything that adds up to AI base and at late game stage, AI builds nuke silo in base (resources permitting) much earlier than more costly other superweapons.

5. AI consider having at least single heavy radar sensible thing past mid-game (can still have more, as before, but will aim to have at least one, in base, before commiting to long range projects). It considers such additional radar only if economy permits.
5a. Brutal AI might add Heavy Radar to porcupine nests too, after finishing everything else that it wishes to build in them.
5b. Easy and Normal AI consider heavy radar only after finishing other porcupine/base stuff.

6. configversion.json bumped to trigger update.