### PR TITLE
Changed number of Antinukes for Hard and Brutal to 1 (from 2) 

### DIFF
--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/behaviour.json
@@ -855,7 +855,7 @@
 	},
 	"staticantinuke": {
 		"role": ["static", "heavy", "support"],
-		"limit": 2
+		"limit": 1
 	},
 	"turretheavylaser": {
 		"role": ["static", "static", "heavy"],

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/behaviour.json
@@ -784,7 +784,7 @@
 	},
 	"staticantinuke": {
 		"role": ["static", "heavy", "support"],
-		"limit": 2
+		"limit": 1
 	},
 	"turretheavylaser": {
 		"role": ["static", "heavy"],


### PR DESCRIPTION
AI builds one antinuke per AI player added to game, so it still ends with more than it (probably) needs, anyway.