### PR TITLE
Possibly fixed #2596

### DIFF
--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIBrutal/stable/config/build_chain.json
@@ -24,11 +24,13 @@
 	// Base defence and time to build it, in seconds
 	"base": [[0, 20], [0, 120], [9, 300], [0, 360], [1, 400], [0, 500], [9, 530], [16, 600], [5, 660], [5, 860], [15, 900], [9, 930], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [17, 1830]],
 
+  // FIXME last 2 aren't superweapons
 	"superweapon": {
-		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke", "staticheavyradar"],  // FIXME: last 2 aren't superweapons
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke", "staticheavyradar"],
 		"weight": [ 0.05,         0.15,        0.25,              0.05,     0.2,              0.3],
 
-		"condition": [18, 1600]  // [<Minimum income>, <maximum seconds to build>]
+// [<Minimum income>, <maximum seconds to build>]
+		"condition": [18, 1600]
 	},
 
 	// Fallback defence

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/build_chain.json
@@ -24,11 +24,13 @@
 	// Base defence and time to build it, in seconds
 	"base": [[0, 20], [0, 120], [9, 300], [0, 360], [1, 400], [0, 500], [9, 530], [16, 600], [5, 660], [5, 860], [15, 900], [9, 930], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [17, 1830]],
 
+// FIXME last 1 isn't superweapon
 	"superweapon": {
-		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],  // FIXME: last 1 isn't superweapon
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],
 		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
 
-		"condition": [35, 600]  // [<Minimum income>, <maximum seconds to build>]
+// [<Minimum income>, <maximum seconds to build>]
+		"condition": [35, 600]
 	},
 
 	// Fallback defence

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIEasy/stable/config/build_chain.json
@@ -27,7 +27,7 @@
 // FIXME last 1 isn't superweapon
 	"superweapon": {
 		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],
-		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
+		"weight": [ 0.1,         0.2,          0.3,               0.1,       0.3],
 
 // [<Minimum income>, <maximum seconds to build>]
 		"condition": [35, 600]

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/build_chain.json
@@ -24,11 +24,13 @@
 	// Base defence and time to build it, in seconds
 	"base": [[0, 20], [0, 120], [9, 300], [0, 360], [1, 400], [0, 500], [9, 530], [16, 600], [5, 660], [5, 860], [15, 900], [9, 930], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [17, 1830]],
 
+// FIXME last 1 isn't superweapon
 	"superweapon": {
-		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],  // FIXME: last 1 isn't superweapon
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],
 		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
 
-		"condition": [35, 600]  // [<Minimum income>, <maximum seconds to build>]
+// [<Minimum income>, <maximum seconds to build>]
+		"condition": [35, 600]
 	},
 
 	// Fallback defence

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAIHard/stable/config/build_chain.json
@@ -27,7 +27,7 @@
 // FIXME last 1 isn't superweapon
 	"superweapon": {
 		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],
-		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
+		"weight": [ 0.1,         0.2,          0.3,               0.1,       0.3],
 
 // [<Minimum income>, <maximum seconds to build>]
 		"condition": [35, 600]

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/build_chain.json
@@ -27,7 +27,7 @@
 // FIXME: last 1 isn't superweapon
 	"superweapon": {
 		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],
-		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
+		"weight": [ 0.1,         0.2,          0.3,               0.1,       0.3],
 
 // [<Minimum income>, <maximum seconds to build>]
 		"condition": [35, 600]

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/DevCircuitAINormal/stable/config/build_chain.json
@@ -24,11 +24,13 @@
 	// Base defence and time to build it, in seconds
 	"base": [[0, 20], [0, 120], [9, 300], [0, 360], [1, 400], [0, 500], [9, 530], [16, 600], [5, 660], [5, 860], [15, 900], [9, 930], [1, 980], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [17, 1830]],
 
+// FIXME: last 1 isn't superweapon
 	"superweapon": {
-		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],  // FIXME: last 1 isn't superweapon
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "staticantinuke"],
 		"weight": [ 0.1,         0.2,          0.3,               0.1       0.3],
 
-		"condition": [35, 600]  // [<Minimum income>, <maximum seconds to build>]
+// [<Minimum income>, <maximum seconds to build>]
+		"condition": [35, 600]
 	},
 
 	// Fallback defence


### PR DESCRIPTION
Possible fixed:
https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/2596

It seems that some builds of ZK interpret things following '//' (comment mark) as possible markers to resume interpreting,  while others not. I have no idea what causes the difference, but I've tested various .json interpreters, and indeed, some of the treat anything past '//' as comment to the end of the line, while others do not.

This commit aims to fix the issue at hand - hoever, in my opinion all our .json files should get scrutinized for comments formating and sanitized, OR reason for the difference in interpreting between ZK builds get discovered and ensured that all know what to do with comment lines.