### PR TITLE
New briefing text and extendedText for the campaign

### DIFF
--- a/LuaMenu/widgets/gui_campaign_handler.lua
+++ b/LuaMenu/widgets/gui_campaign_handler.lua
@@ -725,7 +725,7 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 		x = 8,
 		y = 60,
 		right = 4,
-		bottom = "72%",
+		bottom = "76%",
 		columns = 2,
 		rows = 2,
 		children = fluffLabels,
@@ -917,10 +917,30 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 	end
 
 	local function SizeUpdate()
-		local font = Configuration:GetFont(((planetHandler.height < 680) and 2) or 3)
+		local font = Configuration:GetFont(((planetHandler.height < 760) and 2) or 3)
 
 		planetDesc.font.size = font.size
 		planetDesc:Invalidate()
+		if planetHandler.height < 660 then
+			planetDesc._relativeBounds.top = 60
+			fluffGrid:SetVisibility(false)
+		elseif planetHandler.height < 820 then
+			planetDesc._relativeBounds.top = "27%"
+			fluffGrid:SetVisibility(true)
+		else
+			planetDesc._relativeBounds.top = "30%"
+			fluffGrid:SetVisibility(true)
+		end
+		planetDesc:UpdateClientArea(false)
+		
+		if planetHandler.height < 600 then
+			subPanel._relativeBounds.right = 390
+			subPanel._relativeBounds.bottom = "2%"
+		else
+			subPanel._relativeBounds.right = "50%"
+			subPanel._relativeBounds.bottom = "4%"
+		end
+		subPanel:UpdateClientArea(false)
 
 		for i = 1, 4 do
 			fluffLabels[i].font.size = font.size

--- a/campaign/sample/planets/planet1.lua
+++ b/campaign/sample/planets/planet1.lua
@@ -30,7 +30,7 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24417",
 			text = "How long have I been sleeping? Centuries? No, stars have drifted way too much. And this Commander- I have never seen anything like it. What was I doing in that thing?"
 			.. "\n "
-			.. "\nI cannot stay there. Those automatons are everywhere, and when they are not fighting each-other, they attack me as soon as I stop moving."
+			.. "\nI cannot stay there. Those automata are everywhere, and when they are not fighting each-other, they attack me as soon as I stop moving."
 			,
 			extendedText = "I hoped to avoid local forces, but ther are simply too many of them. Still, this battle should be straightforward. I will simply overwhelm them with an army of Glaives and Reavers, and then take that factory out."
 			.. "\n "

--- a/campaign/sample/planets/planet1.lua
+++ b/campaign/sample/planets/planet1.lua
@@ -28,7 +28,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24417",
-			text = [[This battle will be straightforward. Construct an army of Glaives and Reavers to overwhelm your enemy.]]
+			text = "How long have I been sleeping? Centuries? No, stars have drifted way too much. And this Commander- I have never seen anything like it. What was I doing in that thing?"
+			.. "\n "
+			.. "\nI cannot stay there. Those automatons are everywhere, and when they are not fighting each-other, they attack me as soon as I stop moving."
+			,
+			extendedText = "I hoped to avoid local forces, but ther are simply too many of them. Still, this battle should be straightforward. I will simply overwhelm them with an army of Glaives and Reavers, and then take that factory out."
+			.. "\n "
+			.. "\nI can do this."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet1.lua
+++ b/campaign/sample/planets/planet1.lua
@@ -15,7 +15,7 @@ local function GetPlanet(planetUtilities, planetID)
 			y = (planetUtilities.planetPositions and planetUtilities.planetPositions[planetID][2]) or 0.87,
 			image = image,
 			size = planetUtilities.PLANET_SIZE_MAP,
-			hintText = "Keep taking planets until you conquer the galaxy.",
+			hintText = "Keep taking planets until you reclaim the galaxy.",
 			hintSize = {402, 100},
 		},
 		infoDisplay = {

--- a/campaign/sample/planets/planet10.lua
+++ b/campaign/sample/planets/planet10.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G2VI",
 			milRating = 2,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24457",
-			text = [[Help your ally to push across the island with Fencer missile trucks and Badger mine artillery. A slow but inevitable push will bring you victory just as surely as a lightning assault.]]
+			text = "With the IFF codes I could scavenge on that last world, one of the armies down there is now recognizing me as an ally. This should be useful for fighting my way through here."
+			.. "\n "
+			.. "\nThis is a nasty world, with corrosive oceans. I wonder how local life adapted so well."
+			,
+			extendedText = "If I help my ally to push across the island with Fencer missile trucks and Badger mine artillery, a slow but inevitable push should work just as surely as a lightning assault."
+			.. "\n "
+			.. "\nThat said, I would prefer a lightning assault. I don't want to stay in a corrosive hydrosphere any longer than necessary."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet11.lua
+++ b/campaign/sample/planets/planet11.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24457",
-			text = [[Your opponent is sending gunships out from behind a formidable defensive array. Use Crasher anti-air rovers to shoot down the gunships, then Impaler artillery to tear down the base.]]
+			text = "This world seems to have rebelled against their Empire, while it was too busy fighting on other fronts. They built formidable defences, most of them still intact as the Empire cut them off instead of landing a punitive force."
+			.. "\n "
+			.. "\nSomehow, it has been enough to cripple them, and most of their mobile ground forces have disappeared."
+			,
+			extendedText = "Ground forces or not, they are sending Gunships out from behind a formidable defensive array. I have Crasher anti-air rovers to shoot down the gunships, then I can tear down their base with Impaler artillery."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet11.lua
+++ b/campaign/sample/planets/planet11.lua
@@ -29,7 +29,7 @@ local function GetPlanet(planetUtilities, planetID)
 			.. "\n "
 			.. "\nSomehow, it has been enough to cripple them, and most of their mobile ground forces have disappeared."
 			,
-			extendedText = "Ground forces or not, they are sending Gunships out from behind a formidable defensive array. I have Crasher anti-air rovers to shoot down the gunships, then I can tear down their base with Impaler artillery."
+			extendedText = "Ground forces or not, they are sending Gunships out from behind a formidable defensive array - the blasted automata are taking me for an Imperial landing force. I have Crasher anti-air rovers to shoot down the gunships, then I can tear down their base with Impaler artillery."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet12.lua
+++ b/campaign/sample/planets/planet12.lua
@@ -26,7 +26,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24457",
-			text = [[The enemy is well entrenched but, luckily for you, they have a poorly defended outpost and you have a squad of Dominatrices. Capture the outpost to get a head start, then steal an army of Tanks and march on their main base.]]
+			text = "This rich industrial world is quite well-defended, but a dormant saboteur unit recognized my IFF and signaled me. I should be able to subvert those defences with its help."
+			.. "\n "
+			.. "\nAs far as I can tell, it identified me as allied to the rebels against whoever was the Empire controlling this world."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet12.lua
+++ b/campaign/sample/planets/planet12.lua
@@ -29,6 +29,8 @@ local function GetPlanet(planetUtilities, planetID)
 			text = "This rich industrial world is quite well-defended, but a dormant saboteur unit recognized my IFF and signaled me. I should be able to subvert those defences with its help."
 			.. "\n "
 			.. "\nAs far as I can tell, it identified me as allied to the rebels against whoever was the Empire controlling this world."
+			,
+			extendedText = "Hostile forces are well entrenched but, luckily for me, they have a poorly defended outpost and I now have a squad of Dominatrices. Capturing the outpost will give me a head start, then I can steal an army of Tanks and march on their main base."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet13.lua
+++ b/campaign/sample/planets/planet13.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "N/A",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24441",
-			text = [[This isolated asteroid is being used by the enemy as an observation and command post. Use Shieldbots to conquer the rough terrain, then bring your Commander to the Interception Network structure to download important strategic data.]]
+			text = "On this asteroid is the most powerful communication network of the sector, and its defences have significantly decayed over time."
+			.. "\n "
+			.. "\nInterstellar pursuit forces from many worlds have kept dogging me. I can easily outrun them, but no-one is safe from a mistake. With this network, I should be able to shake them off my trail for good."
+			,
+			extendedText = "All I need to do is to bring my Commander close enough to the Interception Network structure and upload a new set of instructions."
+			.. "\n "
+			.. "\nShieldbots should do well on this rough terrain."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet14.lua
+++ b/campaign/sample/planets/planet14.lua
@@ -26,7 +26,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G1V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24441",
-			text = [[You're outnumbered on this small battlefield, but your Felon shieldbots will allow you to fight efficiently and minimise losses. Expand aggressively and reclaim the nearby rocks and trees to build up your army and economy, then push forward and destroy both enemies.]]
+			text = "This world is covered with mineral wealth, often in surface rocks that would have been easy to exploit, if only during one battle or another. I wonder why it is still there. There must be some natural process that renew them, maybe it also explains this broken geography..."
+			,
+			extendedText = "I am outnumbered and stuck in a small battlefield, but my Felon shieldbots should allow me to fight efficiently and minimise losses. I will need to expand aggressively and reclaim the nearby rocks (for metal) and trees (for energy) to build up my army and economy. Then I can push forward and destroy both forces."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet15.lua
+++ b/campaign/sample/planets/planet15.lua
@@ -26,7 +26,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24441",
-			text = [[Your opponent will field Hovercraft and Gunships to cross the oasis which separates your bases. Build Rogues to defeat the hovercraft and Vandals to defeat the gunships.]]
+			text = "This is the station world of an imperial Rapid Reaction Force - or what is left of it, anyway. If I don't take them out now, they may fall on my back in the middle of another battle some day..."
+			,
+			extendedText = "The RRF will field Hovercraft and Gunships to cross the oasis which separates our bases. Rogues should take care of the hovercraft and Vandals will shoot the gunships down."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet16.lua
+++ b/campaign/sample/planets/planet16.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24441",
-			text = [[Use a combination of Snitch mobile bombs and Iris area cloakers to decimate enemy formations in this battle. Build some Geothermal Generators to provide the energy for your area cloakers.]]
+			text = "A billion years ago, this world was hit by a gigantic asteroid. Ancient terraformation have long made it inhabitable, but now it also features strange, parallel mountain ranges and great sources of geothermal energy."
+			.. "\n "
+			.. "\nI wonder who thought it was a good idea to defend those rather dry mountains with Amphbots of all things."
+			,
+			extendedText = "With a combination of well-placed Snitch mobile bombs and Iris area cloakers, I can decimate entire enemy formations. Those area cloakers need some hefty energy input to work, so I better build some Geothermal Generators to feed them."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet17.lua
+++ b/campaign/sample/planets/planet17.lua
@@ -26,7 +26,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "L9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24441",
-			text = [[You will face the fearsome, fire-spewing Dante strider in this battle. Use Aspis area shields to deflect the assault, and Racketeer artillery to disarm the Dante.]]
+			text = "I would never have imagined this lava hellscape of a planet to be inhabited, let alone host major defences. There must be something down there that escaped me, something valuable enough to account for such a military investment."
+			,
+			extendedText = "Of course someone would use monstrous, fire-spewing Dante striders to defend a place like this. I will need Aspis area shields to deflect the assault, and Racketeer artillery to disarm those Dante."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet18.lua
+++ b/campaign/sample/planets/planet18.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K1V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24489",
-			text = [[Automated defenses are usually easily overcome, if only you hadn't deleted most of your construction blueprints to make room for your recently unearthed discovery - terrain manipulation technology. Use terraforming (at a 50% discount) to clog up or bypass the automated defenses surrounding the Interception Network to make your escape.]]
+			text = "This world was in the middle of being terraformed - or re-teraformed anyway, as it seems a long-forgotten catastrophe had reverted the first efforts. With no-one in command, the efforts are continuing with rather unfocused enthusiasm."
+			.. "\n "
+			.. "\nThis should be the right place to get terrain manipulation technology."
+			,
+			extendedText = "Simple automated defenses are usually easily overcome, if only I didn't have to compress most of my construction blueprints to make room for terrain manipulation technology. I really, really hope I can revert that compression later."
+			.. "\n "
+			.. "\nI will have to use terraforming (at a 50% discount) to clog up or bypass the defenses surrounding the Interception Network, so I can jam hostile units and make my escape."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet19.lua
+++ b/campaign/sample/planets/planet19.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24441",
-			text = [[Finish the Cerberus artillery piece and link it to your ally's power plants. This cannon will break the enemy's defensive line and allow you to destroy their base.]],
+			text = "The two forces here are both too entrenched for automated raids to dislodge the other. One of them recognized my IFF, luckily enough, so I should be able to break the stalemate. All I need is to find a way to break some tough defences."
+			.. "\n "
+			.. "\nI wonder how much initiative those AIs have been given. Can it decide to make tactical alliances on its own? Or did it somehow know my IFF?"
+			,
+			extendedText = "I can finish the Cerberus artillery piece and link it to my ally's power plants. Then this cannon will break the enemy's defensive line and allow us to destroy their base once and for all."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet2.lua
+++ b/campaign/sample/planets/planet2.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24417",
-			text = [[Your opponent has prepared powerful close-range Stardust turrets and Reavers to defeat your raiders. Build a Cloakbot Factory, then counter their strategy with longer-ranged Ronins to secure victory.]]
+			text = "Where is everyone? Automated systems and non-sapient life are still there, but no trace of intelligent beings. No humans, no cyborgs, no free machines, nothing..."
+			.. "\n "
+			.. "\nMost of the unit blueprints are gone. I will need to find new copies on my way out of here."
+			,
+			extendedText = "There are powerful close-range Stardust turrets and Reavers protecting them from my raiders. Once I have a Cloakbot Factory up and running, I will have to counter them with loger-ranged Ronins and open the way for taking their production systems out."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet2.lua
+++ b/campaign/sample/planets/planet2.lua
@@ -30,7 +30,7 @@ local function GetPlanet(planetUtilities, planetID)
 			.. "\n "
 			.. "\nMost of the unit blueprints are gone. I will need to find new copies on my way out of here."
 			,
-			extendedText = "There are powerful close-range Stardust turrets and Reavers protecting them from my raiders. Once I have a Cloakbot Factory up and running, I will have to counter them with loger-ranged Ronins and open the way for taking their production systems out."
+			extendedText = "There are powerful close-range Stardust turrets and Reavers protecting them from my raiders. Once I have a Cloakbot Factory up and running, I will have to counter them with longer-ranged Ronins and open the way for taking their production systems out."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet20.lua
+++ b/campaign/sample/planets/planet20.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G1V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24429",
-			text = [[You have secured a Tech Lab but the enemy surrounds you on all sides. Construct Stinger and Stardust defence structures and hold out for 15 minutes.]]
+			text = "There is a Tech Lab on this world, and it seems accessible enough. I should be able to drop in, siphon its databases and jump out"
+			.. "\n "
+			.. "\nThis place is unlike anything I have ever seen. It is as if an immense tree had died there, leaving only a colossal fossilised stump. Maybe it is why they built a Tech Lab here in the first place?"
+			,
+			extendedText = "The good news is, I have secured the Tech Lab."
+			.. "\n "
+			.. "\nThe bad news is, angry automata now surround me on all sides, and I have to hold out for the next 15 minutes. With enough Stinger and Stardust turrets, it should be feasible enough. I hope."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet21.lua
+++ b/campaign/sample/planets/planet21.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24489",
-			text = [[You've captured a Strider Hub capable of building the heavy Dante riot strider, but the incoming waves of Chickens will make the task of retrieving a prototype from the surface much more difficult...]]
+			text = "There was a major military R&D complex here. Most of it is unusable by now, but there is a functional Strider Hub down there. If I can access it, it could be very useful."
+			.. "\n "
+			.. "\nSomething seems to have escaped its containment. I detect sporadic engagements between the local defence and whatever is hiding in the ground..."
+			,
+			extendedText = "I have captured a Strider Hub capable of building the heavy Dante riot strider. But with the restrictions of this place, I will need to extract an entire Dante to get the blueprint."
+			.. "\n "
+			.. "\nBetween the angry security systems and incoming waves of Chickens, getting one off the surface is going to be a challenge."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet22.lua
+++ b/campaign/sample/planets/planet22.lua
@@ -26,7 +26,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F3V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
-			text = [[The bodies of water on this battlefield would pose difficulties for most factories, but the Amphbot Factory can take advantage of them instead.]]
+			text = "Whoever named this near-frozen iceball Blackmire had a weird sense of humour, or something went very wrong with terraforming efforts. Probably the latter, given how many layers of battle damage are buried below all that snow."
+			,
+			extendedText = "Despite the ever-prevalent snow, those equatorial ranges still have unfrozen bodies of water. It would be a problem for most factories, but the Amphbot Factory can take advantage of them instead."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet23.lua
+++ b/campaign/sample/planets/planet23.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
-			text = [[Launch an amphibious attack on the beach with heavy Grizzly assault walkers. You have 25 minutes to push past the Gauss defensive emplacements and secure a beachhead by destroying the Garrisons.]]
+			text = "Immense armies cover those continents, waiting for an invasion that never came. They are so vast that they forewent Commanders for fixed C&C buildings."
+			.. "\n "
+			.. "\nThe oceans are poorly defended, though. Naval forces decayed faster, under the harsher maritime conditions. I can use this, take out those command structures, and find out what they were preparing for..."
+			,
+			extendedText = "Arriving in the ocean and launching an amphibious attack on the beach, with heavy Grizzly assault walkers, seemed a good idea at the time. I had underestimated how fast land forces can be redeployed, and how far I was from a massive counterattack."
+			.. "\n "
+			.. "\nNow, I only have 25 minutes to push past the Gauss defensive emplacements, secure a beachhead, repel waves of whatever they throw at me, and destroy those three Garrisons."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet24.lua
+++ b/campaign/sample/planets/planet24.lua
@@ -26,7 +26,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F9IV",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
-			text = [[You've discovered some Ancient Fabricators capable of generating metal from nothing. A rival faction is eager to claim your prize, and they have surrounded your base. Use Djinn teleporters and Lobsters to launch an attack from behind and break the siege.]]
+			text = "There is an Ancient Fabricator on this world, capable of generating metal from nothing. It is hidden behind thick layers of defence, but their jamming systems have long stopped working. If I can jump right on top of it, I should be able to fight my way out."
+			,
+			extendedText = "The first part of the plan went pretty well, but now I am boxed in there. Time to use Djinn teleporters and Lobsters to launch an attack from behind the inner ring and break the siege."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet25.lua
+++ b/campaign/sample/planets/planet25.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "M0VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
-			text = [[Launch an attack across the river with an army capable of fighting underwater - the amphibious Duck raider and Scallop riot bots.]]
+			text = "This world's terraforming has been interrupted half-stage. While it is not a desert world anymore, and water is becoming abundant, few lifeforms have managed to adapt its still-toxic atmosphere."
+			.. "\n "
+			.. "\nI feel like this is a common theme in this sector, and judging by geological records, there seem to be cycles of terraforming collateral destruction from conflicts."
+			,
+			extendedText = "I have to launch an attack across the river, with an army capable of fighting underwater - the amphibious Duck raider and Scallop riot bots."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet26.lua
+++ b/campaign/sample/planets/planet26.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
-			text = [[Shut down the enemy Tidal Generator operation on this sunny coastline with the Hovercraft factory.]]
+			text = "There are the remains of a strong army on this world, but few large-scale defense installations. It looks like an occupation force on a freshly conquered world, who had to dismantle the existing defenses and never had time to build new ones."
+			,
+			extendedText = "Instead of building dedicated military powerplants, they commandeered civilian Tidal Generator farms. If I destroy those, they won't have enough energy left to be a menace."
+			.. "\n "
+			.. "\nFor a coastal area like this one, he Hovercraft factory should be well-adapted."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet26.lua
+++ b/campaign/sample/planets/planet26.lua
@@ -28,7 +28,7 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
 			text = "There are the remains of a strong army on this world, but few large-scale defense installations. It looks like an occupation force on a freshly conquered world, who had to dismantle the existing defenses and never had time to build new ones."
 			,
-			extendedText = "Instead of building dedicated military powerplants, they commandeered civilian Tidal Generator farms. If I destroy those, they won't have enough energy left to be a menace."
+			extendedText = "Instead of building dedicated military power plants, they commandeered civilian Tidal Generator farms. If I destroy those, they won't have enough energy left to be a menace."
 			.. "\n "
 			.. "\nFor a coastal area like this one, he Hovercraft factory should be well-adapted."
 		},

--- a/campaign/sample/planets/planet27.lua
+++ b/campaign/sample/planets/planet27.lua
@@ -28,7 +28,7 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
 			text = "This planet was renowned for its tourism resorts and galaxy-famous culinary traditions - or so the advertisement broadcasts tell me. I don't remember ever hearing about it, but it is true this world has been relatively spared from collateral damage, compared to others in the sector."
 			.. "\n "
-			.. "\nUltimately, as the strategic picture beakem grimmer, even such a place suffered military occupation."
+			.. "\nUltimately, as the strategic picture became grimmer, even such a place suffered military occupation."
 			,
 			extendedText = "Some of the local forces recognize one of the IFF codes I found last world. They can take care of surface targets, but I will need to support them with Claymore depth charge and Flail AA hovercraft against underwater and aerial threats."
 		},

--- a/campaign/sample/planets/planet27.lua
+++ b/campaign/sample/planets/planet27.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
-			text = [[Your ally can take care of any surface targets, but you'll need to support them with Claymore depth charge and Flail AA hovercraft against underwater and aerial threats.]]
+			text = "This planet was renowned for its tourism resorts and galaxy-famous culinary traditions - or so the advertisement broadcasts tell me. I don't remember ever hearing about it, but it is true this world has been relatively spared from collateral damage, compared to others in the sector."
+			.. "\n "
+			.. "\nUltimately, as the strategic picture beakem grimmer, even such a place suffered military occupation."
+			,
+			extendedText = "Some of the local forces recognize one of the IFF codes I found last world. They can take care of surface targets, but I will need to support them with Claymore depth charge and Flail AA hovercraft against underwater and aerial threats."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet28.lua
+++ b/campaign/sample/planets/planet28.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24469",
-			text = [[The Artefact on this planet is already hotly contested by two opposing factions, and they're bringing heavy units and striders into play. Use the Halberd armoured assault hovercraft and Lance anti-heavy artillery to cross the battlefield and reach the Artefact.]]
+			text = "There is something valuable enough for someone to have put, not one, but two armies to guard it. Were they wary of a Commander betraying and stealing it?"
+			.. "\n "
+			.. "\nWhatever it is, I will have to find a way past those two armies."
+			,
+			extendedText = "I managed to trick those two armies to fight each-other thanks to an IFF glitch, but they are bringing heavy units and striders into play. I will need the Halberd armoured assault hovercraft and Lance anti-heavy artillery to cross the battlefield and reach that Artefact."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet29.lua
+++ b/campaign/sample/planets/planet29.lua
@@ -26,7 +26,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G6V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24489",
-			text = [[The enemy of my enemy... is at least useful. Build up your economy with Fusion Generators while the two opposing factions fight, then eradicate them both. Advanced Radars will keep you informed on the overall battle state.]]
+			text = "I expected to find imperial or rebel forces here, those appear to be neither. Was this a pirate haven? Opportunistic warlords? There seem to be several factions down there. If I land on just the right spot, I may trick them into fighting each-other."
+			,
+			extendedText = "The enemy of my enemy... is at least useful. If I build up my economy with Fusion Generators while those two fight, then I can eradicate them both. Advanced Radars will keep me informed on the overall battle state."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet3.lua
+++ b/campaign/sample/planets/planet3.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K4VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24417",
-			text = [[Your opponent will use raiding squads of Scorchers against you in this battle. Shut them down with Imp EMP bombs.]]
+			text = "This was a major military hub, I can detect the remains of staging grounds and logistic networks. With all those broken plateaux, this area would have been easier to defend. This is bad news for me, I will have to take those defences out if I want to continue that way."
+			.. "\n "
+			.. "\nWhoever they were fighting, it was not going well. There is evidence of raids even here, the frontline would not have been far."
+			,
+			extendedText = "This AI seems to rely on raiding squads of Scorchers. Good thing I had time for scavenging, those Imp EMP bombs will be helpful for shutting them down."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet30.lua
+++ b/campaign/sample/planets/planet30.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = [[Crossing a river under enemy fire is a daunting prospect, but it becomes easier when you control the river. Bombard the shoreline with Envoy cruisers to force passage through the shallows.]]
+			text = "This chokepoint defended the territory of something called Haven. The Empire attempted to break through, and managed to gain a foothold on this world. That battle is still going, with mindless automata still carrying their last recieved orders."
+			.. "\n "
+			.. "\nOne of the local garrisons somehow identified me as an enemy of the Empire and gave me IFF codes. I wonder on how many Haven worlds those will work."
+			,
+			extendedText = "Crossing a river under enemy fire is a daunting prospect, but it becomes easier if I control the river. There are several old Sunlance defence systems, but I can bombard the shoreline with Envoy cruisers to force passage through the shallows."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet30.lua
+++ b/campaign/sample/planets/planet30.lua
@@ -25,7 +25,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = "This chokepoint defended the territory of something called Haven. The Empire attempted to break through, and managed to gain a foothold on this world. That battle is still going, with mindless automata still carrying their last recieved orders."
+			text = "This chokepoint defended the territory of something called Haven. The Empire attempted to break through, and managed to gain a foothold on this world. That battle is still going, with mindless automata carrying their last recieved orders."
 			.. "\n "
 			.. "\nOne of the local garrisons somehow identified me as an enemy of the Empire and gave me IFF codes. I wonder on how many Haven worlds those will work."
 			,

--- a/campaign/sample/planets/planet31.lua
+++ b/campaign/sample/planets/planet31.lua
@@ -27,9 +27,9 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
 			text = "Invalid IFF? Well, it was worth trying. Local defences have considearbly decayed, but what's left is still dangerous."
 			.. "\n "
-			.. "\nThis world had never been disputed to Haven yet, but they knew it would be the next line of defence when Harsar Lief fell. With most of the planet covered by water, they could have held it from strategic archipelagoes against a considerable foe."
+			.. "\nThis world had never been disputed to Haven yet, but they knew it would be the next line of defence at the fall of Harsar Lief. With most of the planet covered by water, they could have held it from strategic archipelagoes against a considerable foe."
 			,
-			extendedText = "With those small islands dotting the ocean, this is ideal for the deployment of ships and submarines. I should move fast to take control of this resource-rich archipelago - once I hold it, I will be safe. The other planetary garrisons have long lost their overseas projection capabilities."
+			extendedText = "With those small islands dotting the ocean, this is ideal for the deployment of ships and submarines. I should move fast to take control of this resource-rich archipelago - once I hold it, I will be safe. The other planetary garrisons have long lost their oversea projection capabilities."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet31.lua
+++ b/campaign/sample/planets/planet31.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = [[This planet is largely covered by water, making it ideal for the deployment of ships and submarines. Move fast to take control of this resource-rich archipelago.]]
+			text = "Invalid IFF? Well, it was worth trying. Local defences have considearbly decayed, but what's left is still dangerous."
+			.. "\n "
+			.. "\nThis world had never been disputed to Haven yet, but they knew it would be the next line of defence when Harsar Lief fell. With most of the planet covered by water, they could have held it from strategic archipelagoes against a considerable foe."
+			,
+			extendedText = "With those small islands dotting the ocean, this is ideal for the deployment of ships and submarines. I should move fast to take control of this resource-rich archipelago - once I hold it, I will be safe. The other planetary garrisons have long lost their overseas projection capabilities."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet32.lua
+++ b/campaign/sample/planets/planet32.lua
@@ -25,7 +25,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G5VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = [[An enemy artillery piece is dominating this island chain. Assault it directly or cut off its energy supply, then clear out any lingering opposition.]]
+			text = "This time half the garrison recognized the IFF codes, and now the other half is turning against them. Their protocols were clearly not meant to run without supervision for so long."
+			,
+			extendedText = "An enemy artillery piece is dominating this island chain. I should either assault it directly or cut off its energy supply, then I can clear out any lingering opposition."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet33.lua
+++ b/campaign/sample/planets/planet33.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K3VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
-			text = [[If you want to control the sea, it's also important to control the air above it. Use Owl scout planes to find underwater units, then Raven precision bombers to destroy those underwater units and any other high-value targets.]]
+			text = "There is something very wrong with this world. Almost no life despite advanced terraforming, a warm ocean producing no moisture, and an island that makes no geological sense right in the middle of it."
+			.. "\n "
+			.. "\nWhatever is on this island is extremely well guarded, and the Empire broke their teeth on it. But the garrison's protocols have also decayed faster than they should, and I may be able to turn it over..."
+			,
+			extendedText = "I have managed to hack some of the garrison, but forces next to that artefact are not responding."
+			.. "\n "
+			.. "\nIf I want to control the sea, it's also important to control the air above it. The Owl scout planes will be useful to find underwater units, then Raven precision bombers to destroy those underwater units and any other high-value targets."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet34.lua
+++ b/campaign/sample/planets/planet34.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
-			text = [[The enemy has dug into a reasonable defensive position, assisted by aircraft. Supplement your ground forces with Thunderbirds to disarm enemy defences and Swifts to shoot down their planes.]]
+			text = "This unterraformable dustball of a planet would never have attracted any attention, was it not lying right on the largest warp nexus in the galaxy."
+			.. "\n "
+			.. "\nAnd of course, some pirates were trying to take it over, biting much more than they could chew - the Empire made sure to guard it well. Good thing the pirates' security was so poor, I managed to hack their IFF."
+			,
+			extendedText = "The Imperials had dug into a reasonable defensive position, assisted by aircraft. I should supplement my ground forces with Thunderbirds to disarm enemy defences and Swifts to shoot down their planes."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet35.lua
+++ b/campaign/sample/planets/planet35.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G2V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
-			text = [[Since your allies have built a few strong anti-air bastions, the enemy has chosen to rely on ground-to-air emplacements of their own rather than attempt to contest air control with fighters. Show them the deficiencies of this strategy with the resilient and deadly Likho.]]
+			text = "A long time ago, this world was a jewel, sculpted to perfection - or so its original terraformers said. Even after so much decay, I can still see their work from orbit, and I am not impressed. Their mountain work is inferior, their seas pretentious and unsubtle, and they couldn't even stabilize the polar ice caps."
+			.. "\n "
+			.. "\nThey were so insecure, they even left a force to assault anyone disagreeing, which is now set to \"everyone\"."
+			,
+			extendedText = "A splinter force born from a technical disagreement over river drawing has identified me as an ally. What the hell was wronng with that Empire!?"
+			.. "\n "
+			.. "\nMy new allies had built a few strong anti-air bastions, so the enemy is relying on ground-to-air emplacements of their own rather than attempt to contest air control with fighters. Which was short-sighted - it won't hold against the resilient and deadly Likho."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet36.lua
+++ b/campaign/sample/planets/planet36.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
-			text = [[Use the fast-moving Locust raider gunships to curtail your opponent's expansion, then Nimbus support gunships to finish them off.]]
+			text = "Occupation forces on this world have dwindled to a few dormant bots. Hopefully I can land and take them out before they awaken..."
+			.. "\n "
+			.. "\nAnother rebel planet that fell to a merciless imperial punitive expedition. I wonder what drove so many worlds to raise against the Empire."
+			,
+			extendedText = "They are waking up earlier than I expected. I should use fast-moving Locust raider gunships to curtail their expansion, then Nimbus support gunships to finish them off."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet36.lua
+++ b/campaign/sample/planets/planet36.lua
@@ -28,7 +28,7 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
 			text = "Occupation forces on this world have dwindled to a few dormant bots. Hopefully I can land and take them out before they awaken..."
 			.. "\n "
-			.. "\nAnother rebel planet that fell to a merciless imperial punitive expedition. I wonder what drove so many worlds to raise against the Empire."
+			.. "\nAnother rebel planet that fell to a merciless imperial punitive expedition. I wonder what drove so many worlds to rise against the Empire."
 			,
 			extendedText = "They are waking up earlier than I expected. I should use fast-moving Locust raider gunships to curtail their expansion, then Nimbus support gunships to finish them off."
 		},

--- a/campaign/sample/planets/planet37.lua
+++ b/campaign/sample/planets/planet37.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G7V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
-			text = [[Expand to the mainland from your resource-poor island using Charon and Hercules transports, then use transports to create a highly mobile land army.]]
+			text = "This world was on an interstellar crossroad. While it made it wealthy, it was to be its undoing. When neighbouring planets rebelled, it became a battlefield, a capital strategic prize to be fought over."
+			.. "\n "
+			.. "\nIts terraformation was destabilized by the constant battles, and now it is slowly reverting to the ice world it had once been."
+			,
+			extendedText = "This is not where I should be! Something went wrong with the landing. I must absolutely expand to the mainland from this resource-poor island using Charon and Hercules transports. Then I can use transports to create a highly mobile land army."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet38.lua
+++ b/campaign/sample/planets/planet38.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "M2V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
-			text = [[In addition to your opponent, this time you'll have to deal with the charming local fauna as well - this planet is infested with chickens. You'll have to manage both threats to be victorious.]]
+			text = "A marginal desert world with a few buried scientific outposts. With luck I will find valuable information in those, if I can get rid of the army defending the surface."
+			.. "\n "
+			.. "\nI have weird readings on that sand, though, and the local army seems to avoid it. I have a bad feeling about this..."
+			,
+			extendedText = "This planet is infested with Chicken, and now the swarm is waking up! I hate those things. What the hell are they anyway ? At least they don't take sides, and equally attack everything. All I have to do is to hold them off long enough to beat the automata."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet39.lua
+++ b/campaign/sample/planets/planet39.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G6V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
-			text = [[The enemy is about to complete a Krow heavy gunship. Quickly build Tridents to defeat it, then build your own Krows and return the favour.]]
+			text = "This world was both wealthy and peripheral, making it an ideal place to start a rebellion. Long after everyone is gone, the rebel army is still facing the expeditionary force the Empire sent to crush them to a standstill."
+			.. "\n "
+			.. "\nWith no one left to do geomaintenance, it is slowly freezing, returning to its original ice world state."
+			,
+			extendedText = "I've got lucky, the rebel forces recognized one of my IFF signals. The dormant armies are both reactivating, though. This time, it will not end in a cold war."
+			.. "\n "
+			.. "\nThe other side is about to complete a Krow heavy gunship. I must quickly build Tridents to defeat it, then build my own Krows and return the favour."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet4.lua
+++ b/campaign/sample/planets/planet4.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F2III",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24429",
-			text = [[Your opponent has taken to the air with Gunships in this battle. Construct the anti-air Gremlins and Hacksaw missile turrets to bring them down.]]
+			text = "This is where the raids on Myror were launched from. Either time or a counterattack crippled them, but the expeditionary force that had captured this world is still there."
+			.. "\n "
+			.. "\nWhile I should not underestimate them, what is left does not seem well-adapted for defending ground."
+			,
+			extendedText = "Ground forces seem to have almost entirely decayed, and they now rely on Gunships for combat. I will need anti-air Gremlins and Hacksaw missile turrets to bring them down."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet40.lua
+++ b/campaign/sample/planets/planet40.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24489",
-			text = [[Enter this active battle and dominate the low ground with the raw power of the Tank Foundry. Push through the enemy defenses to destroy their Nuclear Silo while protecting your own team's Anti-Nukes.]]
+			text = "This was one of the first rebel worlds, and one of the last to fall. To make sure it would never rebel again, the occupation force was allowed to use nuclear missiles against the next uprising."
+			.. "\n "
+			.. "\nThe nuclear silos are still there, but some long-forgotten rebel malware infiltrated part of the occupation forces. And it just signaled me that it is, and I quote, Liberation Time."
+			,
+			extendedText = "I must dominate the low ground with the raw power of the Tank Foundry, push through the enemy defenses and destroy their Nuclear Silo while protecting our own Anti-Nukes. Should be easy enough..."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet41.lua
+++ b/campaign/sample/planets/planet41.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G7V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24489",
-			text = [[Negotiations with the local warlord regarding access to this planet's Warp Gates have gone poorly. It's time for plan B: take the Gates by force. Make sure your Commander is loaded out for a fight.]]
+			text = "If I can take control of this planet's warp gates, it will open up half the sector. What is surprising is that the local forces are not imperial. How did the Empire loose control of such an important sector to an independent warlord?"
+			.. "\n "
+			.. "\nThis gives me an idea... still, better load my Commander for a fight, just in case."
+			,
+			extendedText = "I thought I could hack the warlord's Commander, but its AI just glitched on me. Time for plan B: take the Gates by force."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet42.lua
+++ b/campaign/sample/planets/planet42.lua
@@ -29,7 +29,6 @@ local function GetPlanet(planetUtilities, planetID)
 			text = "This desert planet had one of the greatest mountain ranges in the galaxy, before most of it was flattened by the Empire, as they tracked down fleeing Rebels hidden there. Imperial search parties are still there, looking for Rebels in what little is left of the range."
 			.. "\n "
 			.. "\nIf I can get rid of them, some Rebel holdout may answer to some of my scavenged codes. Who knows, they may still have useful data..."
-			--"This desert planet had one of the vastest mountain ranges I have ever seen. Rebel forces from nearby systems took refuge in it after their worlds fell, with the Empire in hot pursuit. Those levelled most of the mountains, but some Rebels managed to stay hidden in the central chains. Imperial search parties are still there, looking for Rebel activity. If I can get rid of them, Rebel remnants may answer to some of my scavenged codes. Who knows, they may still have useful data?"
 			,
 			extendedText = "I have taken control of a small search party, but only the sturdier Tanks are still working. Not ideal for this kind of terrain - especially with the other search party using Spiders."
 			.. "\n "

--- a/campaign/sample/planets/planet42.lua
+++ b/campaign/sample/planets/planet42.lua
@@ -26,7 +26,14 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G0V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24489",
-			text = [[This terrain is better suited for the enemy Spiders than your Tanks. To change that flatten the hills with Tremor heavy artillery, then finish the job with the super-heavy Cyclops assault tank.]]
+			text = "This desert planet had one of the greatest mountain ranges in the galaxy, before most of it was flattened by the Empire, as they tracked down fleeing Rebels hidden there. Imperial search parties are still there, looking for Rebels in what little is left of the range."
+			.. "\n "
+			.. "\nIf I can get rid of them, some Rebel holdout may answer to some of my scavenged codes. Who knows, they may still have useful data..."
+			--"This desert planet had one of the vastest mountain ranges I have ever seen. Rebel forces from nearby systems took refuge in it after their worlds fell, with the Empire in hot pursuit. Those levelled most of the mountains, but some Rebels managed to stay hidden in the central chains. Imperial search parties are still there, looking for Rebel activity. If I can get rid of them, Rebel remnants may answer to some of my scavenged codes. Who knows, they may still have useful data?"
+			,
+			extendedText = "I have taken control of a small search party, but only the sturdier Tanks are still working. Not ideal for this kind of terrain - especially with the other search party using Spiders."
+			.. "\n "
+			.. "\nTime to take a page from the previous users, and flatten the hills with Tremor heavy artillery. Then, I can finish the job with the super-heavy Cyclops assault tank."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet43.lua
+++ b/campaign/sample/planets/planet43.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F3VII",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24457",
-			text = [[This planet is covered by a sprawling metropolis, built by nano-machines... which nobody remembered to turn off. Any destroyed units or buildings will be rebuilt, but they won't be friendly to you any more. Hold off the 'zombies' for long enough to reach the Artefact.]]
+			text = "This planet is covered by a sprawling metropolis, built by nano-machines, with nobody left to turn them off. I would have preferred avoiding such a place, but there is something down there, something older than the nanites."
+			.. "\n "
+			.. "\nIf I am fast enough, I should be able to recover whatever it is and get out of there before the nanites become too much of a problem."
+			,
+			extendedText = "Any destroyed units or buildings will be rebuilt by the nanites, but they will be hostile to everyone. I will have to hold off the 'zombies' for long enough to go through any existing defences and reach the Artefact."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet44.lua
+++ b/campaign/sample/planets/planet44.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = [[Your ally's bots aren't going to cut it alone on a battlefield this mountainous. The Redback riot and Recluse skirmish spiders will take control of the high ground, and rain death upon your enemies in the valley below.]]
+			text = "The Rebel forces of this planet took a last stand in the mountains, awaiting an end that never came. Now that everyone is gone, the armies are still waiting."
+			.. "\n "
+			.. "\nTime to put an end to this."
+			,
+			extendedText = "Rebel bots aren't going to cut it alone on a battlefield this mountainous. My Redback riot and Recluse skirmish spiders can take control of the high ground, and rain death upon their enemies in the valley below."
 		},
 		tips = {
 			

--- a/campaign/sample/planets/planet45.lua
+++ b/campaign/sample/planets/planet45.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K1VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = [[In this battle you start at a large numerical and economical disadvantage. However, the high plateaus on this map will give your Spiders an edge, especially the heavy Crab riot/skirmisher.]]
+			text = "This strange geology again, just like Walchice. Those mountain-sized trees, or whatever they were, have been dead for longer than life on Earth has breathed oxygen. How did they grow on two world on each side of the galaxy? I have never heard of interstellar life older than humankind..."
+			.. "\n "
+			.. "\nNo wonder this world is so well-guarded. But who knows what I could find down there?"
+			,
+			extendedText = "This is bad, I have a serious numerical and economical disadvantage. However, the high plateaus on this map may give my Spiders an edge, especially the heavy Crab riot/skirmisher."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet46.lua
+++ b/campaign/sample/planets/planet46.lua
@@ -25,7 +25,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G3V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = [[This battlefield is exceptionally mountainous; your opponent will field Spiders and it would be advisable for you to do the same. Force your opponent to give you access to the Interception Network with Venom EMP and Hermit assault spiders.]]
+			text = "Learning from the Rebels, the Empire has placed its main Interception Network in a giant mountain range on a desert planet. This network was covering the entire sector and was the central piece of their war against the Rebels. If I can access it, I can download everything they had on the Rebels."
+			,
+			extendedText = "This battlefield is exceptionally mountainous. The defenders will field Spiders and I'd better do the same. If I want to force my way to the Interception Network, the Venom EMP and Hermit assault spiders are going to help."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet47.lua
+++ b/campaign/sample/planets/planet47.lua
@@ -27,7 +27,7 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
 			text = "There are armies down there, that have been constantly fighting since everyone disappeared. Everywhere else with a stalemate, they would have gone dormant, awaiting external change to resume combat. But not here. This was set up deliberately, to continue long after there was anyone left."
 			.. "\n "
-			.. "\nWas it a statement ? A final act of defiance before disappearing ? Maybe I'll find answers down there."
+			.. "\nWas it a statement? A final act of defiance, before going into the night?"
 			,
 			extendedText = "This side's Dantes are struggling in the hills against enemy Scorpions and Merlins. But I have Fleas and Widows to decloak, stun and destroy them."
 			.. "\n "

--- a/campaign/sample/planets/planet47.lua
+++ b/campaign/sample/planets/planet47.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24530",
-			text = [[Your ally's Dantes are struggling in the hills against enemy Scorpions and Merlins. Use Fleas and Widows to decloak, stun and destroy them.]]
+			text = "There are armies down there, that have been constantly fighting since everyone disappeared. Everywhere else with a stalemate, they would have gone dormant, awaiting external change to resume combat. But not here. This was set up deliberately, to continue long after there was anyone left."
+			.. "\n "
+			.. "\nWas it a statement ? A final act of defiance before disappearing ? Maybe I'll find answers down there."
+			,
+			extendedText = "This side's Dantes are struggling in the hills against enemy Scorpions and Merlins. But I have Fleas and Widows to decloak, stun and destroy them."
+			.. "\n "
+			.. "\nTime to break the stalemate."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet48.lua
+++ b/campaign/sample/planets/planet48.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G1V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
-			text = [[Your enemy's defences on this level are dependent on a few critical structures, but the rough terrain will make it very difficult to get close enough to destroy them. The Tactical Missile Silo provides a much more practical solution to this problem.]]
+			text = "This was a nightmare scenario for the Empire: a rebellion on an special arsenal world. The loyalist barricaded themselves in the mountains with the stockpiles, waiting for reinforcements that never came."
+			.. "\n "
+			.. "\nI should crack that fortress open and raze it once and for all. There are things buried down there, that should never have been built."
+			,
+			extendedText = "The loyalist positions are dependent on a few critical structures, but the rough terrain will make it very difficult to get close. The Tactical Missile Silo is exactly what I need for this."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet49.lua
+++ b/campaign/sample/planets/planet49.lua
@@ -25,7 +25,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G6VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
-			text = "There are two massive armies fighting down there, but both are declaring themselves Imperial forces. This didn't start with a glitch either, it was clearly two humans that initiated this. What could have driven them to do such a thing ?"
+			text = "There are two massive armies fighting down there, but both are declaring themselves Imperial forces. This didn't start with a glitch either, it was clearly two humans that initiated this. What could have driven them to do such a thing?"
 			.. "\n "
 			.. "\nI really don't want to fight both of them at the same time. Time to negociate with derelict automata again..."
 			,

--- a/campaign/sample/planets/planet49.lua
+++ b/campaign/sample/planets/planet49.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G6VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
-			text = [[The artillery cannons of your enemies' battleships are pretty big, but the Big Bertha plasma cannon is positively humongous. Use your static artillery to suppress the enemy until reinforcements arrive.]]
+			text = "There are two massive armies fighting down there, but both are declaring themselves Imperial forces. This didn't start with a glitch either, it was clearly two humans that initiated this. What could have driven them to do such a thing ?"
+			.. "\n "
+			.. "\nI really don't want to fight both of them at the same time. Time to negociate with derelict automata again..."
+			,
+			extendedText = "The artillery cannons of the other sides' battleships are pretty big, but the Big Bertha plasma cannon is positively humongous."
+			.. "\n "
+			.. "\nI should use static artillery to suppress the enemy until reinforcements arrive from the other continent. Hoping those tin cans still work, their strategic movement routines aren't corrupted, and they correctly interpreted my instructions."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet49.lua
+++ b/campaign/sample/planets/planet49.lua
@@ -27,7 +27,7 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
 			text = "There are two massive armies fighting down there, but both are declaring themselves Imperial forces. This didn't start with a glitch either, it was clearly two humans that initiated this. What could have driven them to do such a thing?"
 			.. "\n "
-			.. "\nI really don't want to fight both of them at the same time. Time to negociate with derelict automata again..."
+			.. "\nI really don't want to fight both of them at the same time. Time to negotiate with derelict automata again..."
 			,
 			extendedText = "The artillery cannons of the other sides' battleships are pretty big, but the Big Bertha plasma cannon is positively humongous."
 			.. "\n "

--- a/campaign/sample/planets/planet5.lua
+++ b/campaign/sample/planets/planet5.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G7V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24417",
-			text = [[Your opponent is relying on a network of defensive turrets and shielded bots to keep them safe. Use Slings to weaken your opponent's defences and shields before you commit to an assault.]],
+			text = "This world was a strategic chokepoint. There are extensive traces of combat damage, some ancient enough to be covered by once-thriving cities."
+			.. "\n "
+			.. "\nWhoever it was defending - or defending from - there is still an active defense network entrenched down there. I will have to punch through it, if I want access to that sector."
+			,
+			extendedText = "It is relying on a network of defensive turrets and shielded bots to keep its production infrastructure safe. I will need Slings to weaken its defences and shields before I can commit to an assault. And I will need spotters for those Slings.",
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet50.lua
+++ b/campaign/sample/planets/planet50.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24594",
-			text = [[Your ally on this planet is vulnerable and weak, so you'll have to rely on your Jumpbots' inherent advantage on rough terrain to win despite this disadvantage. Either strike quickly to take out one opponent or prepare for a long game of attrition.]]
+			text = "Lying on an interstellar crossroad, this planet seems to have attracted many smugglers. They operated from its fields of broken plateaux, while bribed local officials looked the other way."
+			.. "\n "
+			.. "\nNow, this is bound to attract some attention, but if I could just manage to gain access to the operations of a data smuggler... "
+			,
+			extendedText = "The smuggler's defenses are barely perfunctory, so I will have to rely on my Jumpbots' inherent advantage on rough terrain - and either strike quickly to take out one opponent or prepare for a long game of attrition."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet51.lua
+++ b/campaign/sample/planets/planet51.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G0V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24594",
-			text = [[Your Tech Lab is about to be overrun by enemy forces! Your base is too far away to reinforce the Lab in time... unless you employ an unconventional means of transport.]]
+			text = "Barely inhabitable, far from anything valuable but right between fortress worlds, this was the ideal place for the Empire's sensitive research projects. If they knew something about what happened, it could be there."
+			.. "\n "
+			.. "\nI could access to some research systems and their defences, but not remotely access their data. Hopefully I can land, grab the data and depart before the main planetary garrison wakes up..."
+			,
+			extendedText = "This is bad! I landed too far, the entire planet's garrison is waking up and the Tech Lab is about to be overrun! I am too far away to reinforce it in time. Unless..."
+			.. "\n "
+			.. "\nI will have to employ an unconventional means of transport."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet52.lua
+++ b/campaign/sample/planets/planet52.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F9V/F9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24457",
-			text = [[Despite its unappealing environment, this planet has been the focus of many battles, and it is littered with scrap. The self-replicating Puppy walking bombs can quickly turn these wrecks into a new army for you.]]
+			text = "This world appears to have been prosperous, once. But a series of violent uprisings and punitive expeditions have reduced it to a barely inhabitable, glassy ashball."
+			.. "\n "
+			.. "\nIt is so covered with wrecks that most of its industry, or what was left of it, appears to have been recycling them."
+			,
+			extendedText = "This planet has been the focus of so many battles, it is now littered with scrap. The self-replicating Puppy walking bombs can quickly turn these wrecks into a new army for me."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet53.lua
+++ b/campaign/sample/planets/planet53.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K2V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
-			text = [[Your allies are struggling against cloaked skirmishers and artillery attacking them at range. Use Firewalker napalm artillery and jumping Jacks to find and destroy the hidden enemies.]]
+			text = "Local forces are emitting a general distress call. A rogue commander was trying to take this world over and carve herself a nice little kingdom - with her army still at it. Loosing control of the military? The Empire must have been crumbling from the inside."
+			.. "\n "
+			.. "\nThere are warp jammers down there, to prevent anyone from fleeing or getting outside help. I will have to destroy them to continue that way."
+			,
+			extendedText = "The local forces categorized me as \"outside help\", fortunately, but they are struggling against cloaked skirmishers and artillery attacking them at range. Time to use Firewalker napalm artillery and jumping Jacks to find and destroy the hidden enemies."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet53.lua
+++ b/campaign/sample/planets/planet53.lua
@@ -26,7 +26,7 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K2V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
-			text = "Local forces are emitting a general distress call. A rogue commander was trying to take this world over and carve herself a nice little kingdom - with her army still at it. Loosing control of the military? The Empire must have been crumbling from the inside."
+			text = "Local forces are emitting a general distress call. A rogue commander was trying to take this world over and carve herself a nice little kingdom - with her army still at it. Losing control of the military? The Empire must have been crumbling from the inside."
 			.. "\n "
 			.. "\nThere are warp jammers down there, to prevent anyone from fleeing or getting outside help. I will have to destroy them to continue that way."
 			,

--- a/campaign/sample/planets/planet54.lua
+++ b/campaign/sample/planets/planet54.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
-			text = [[This island is blessed with strong geothermal activity, allowing cheap and easy energy generation. Unfortunately your enemy got here first. Sabotage their operation with Skuttle jumping bombs.]]
+			text = "I am surprised a world so geologically active could be terraformed at all, let alone for it to hold for so long on its own."
+			.. "\n "
+			.. "\nThis is a problem, though, as it is still powering the core of a large defense system. There is no moving through here with those geothermal plants still running."
+			,
+			extendedText = "I have taken control of one of the major geothermal plants. If I can destroy the three others on this island, the entire defense system should power down. Skuttle jumping bombs could be useful for that..."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet55.lua
+++ b/campaign/sample/planets/planet55.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G6V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24594",
-			text = [[All previous attempts to defeat the enemy's large cluster of Funnelweb support striders and Big Bertha static artillery have failed. It falls to you to deploy the nuclear option.]]
+			text = "The fortress world that guarded the early Empire's southern flank. Never seriously challenged since those days, its garrison may have grown complacent - but the defences that are left are still formidable."
+			.. "\n "
+			.. "\nThere is what looks like backdoors in some of the garrison's codes, strangely enough. They would have been useless in actual conflict, though, effective only against unsupervised automata..."
+			,
+			extendedText = "Some of the forces have already turned against each-other by the time I landed, but all previous attempts to defeat the enemy's large cluster of Funnelweb support striders and Big Bertha static artillery have failed."
+			.. "\n "
+			.. "\nTime to deploy the nuclear option."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet56.lua
+++ b/campaign/sample/planets/planet56.lua
@@ -29,7 +29,7 @@ local function GetPlanet(planetUtilities, planetID)
 			.. "\n "
 			.. "\nAutomated defenses have suffered from the raids, but are still operational - and a Detriment roaming around. How can it be working after half an eternity exposed and without maintenance?"
 			,
-			extendedText = "That Detriment will crushe any attempt to build a base. I have to stay on the move with Athena mobile constructors, until I can build up an army strong enough to take it down."
+			extendedText = "That Detriment will crush any attempt to build a base. I have to stay on the move with Athena mobile constructors, until I can build up an army strong enough to take it down."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet56.lua
+++ b/campaign/sample/planets/planet56.lua
@@ -27,7 +27,7 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
 			text = "There is technology on this world, that is both much more ancient and more andvanced than it should be. There are the remains of several raiding parties sent by the Empire to try - without success - and capture it."
 			.. "\n "
-			.. "\nAutomated defenses have suffered from the raids, but are still operational - and a Detriment roaming around. How can it be working after half an eternity exposed and without maintenance ?"
+			.. "\nAutomated defenses have suffered from the raids, but are still operational - and a Detriment roaming around. How can it be working after half an eternity exposed and without maintenance?"
 			,
 			extendedText = "That Detriment will crushe any attempt to build a base. I have to stay on the move with Athena mobile constructors, until I can build up an army strong enough to take it down."
 		},

--- a/campaign/sample/planets/planet56.lua
+++ b/campaign/sample/planets/planet56.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24510",
-			text = [[Many raiders have tried - and failed - to take the ancient technology on this planet by brute force. The automated defence system has decayed over time but a Detriment crushes any attempt to build a base. Stay on the move with Athena mobile constructors, building up an army to destroy the Detriment.]]
+			text = "There is technology on this world, that is both much more ancient and more andvanced than it should be. There are the remains of several raiding parties sent by the Empire to try - without success - and capture it."
+			.. "\n "
+			.. "\nAutomated defenses have suffered from the raids, but are still operational - and a Detriment roaming around. How can it be working after half an eternity exposed and without maintenance ?"
+			,
+			extendedText = "That Detriment will crushe any attempt to build a base. I have to stay on the move with Athena mobile constructors, until I can build up an army strong enough to take it down."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet57.lua
+++ b/campaign/sample/planets/planet57.lua
@@ -27,7 +27,7 @@ local function GetPlanet(planetUtilities, planetID)
 			feedbackLink = "http://zero-k.info/Forum/Thread/24594",
 			text = "A major naval exercise was just starting down there, when it all stopped. No preparations, no warning, complete surprise... This has to be one of the first places where everyone disappeared."
 			.. "\n "
-			.. "\nWell, both sides are evenly matched - when I go down, the side I join should win pretty easily, right ?"
+			.. "\nWell, both sides are evenly matched - when I go down, the side I join should win pretty easily, right?"
 			,
 			extendedText = "This was evenly matched, but the Detriment the other side is about to deploy could change that in a hurry. If this is some kind of automated balance system, well, it's rather flattering."
 		},

--- a/campaign/sample/planets/planet57.lua
+++ b/campaign/sample/planets/planet57.lua
@@ -25,9 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24594",
-			text = ""
+			text = "A major naval exercise was just starting down there, when it all stopped. No preparations, no warning, complete surprise... This has to be one of the first places where everyone disappeared."
+			.. "\n "
+			.. "\nWell, both sides are evenly matched - when I go down, the side I join should win pretty easily, right ?"
 			,
-			extendedText = "So far this naval battle has been evenly matched, but the Detriment they are about to deploy could change that in a hurry."
+			extendedText = "This was evenly matched, but the Detriment the other side is about to deploy could change that in a hurry. If this is some kind of automated balance system, well, it's rather flattering."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet57.lua
+++ b/campaign/sample/planets/planet57.lua
@@ -25,7 +25,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24594",
-			text = [[So far this naval battle has been evenly matched, but the Detriment your opponent is about to deploy could change that in a hurry.]]
+			text = ""
+			,
+			extendedText = "So far this naval battle has been evenly matched, but the Detriment they are about to deploy could change that in a hurry."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet58.lua
+++ b/campaign/sample/planets/planet58.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K1VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24614",
-			text = [[Two enemy groups are already engaged on this icy planet. Defeat them both from a safe distance with the Merlin artillery strider.]]
+			text = "This wealthy ice planet was one of the main Rebel worlds, and the Empire sent a large occupation force to make sure it would never challenge it again. But somehow, the Rebels managed to turn one half of the force against the other."
+			.. "\n "
+			.. "\nThe civilian population, de facto hostage, would have all become collateral damage - had it not disappeared just as combat started."
+			,
+			extendedText = "The two groups have awakened and are resuming hostilities. I can defeat them both from a safe distance with the Merlin artillery strider."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet59.lua
+++ b/campaign/sample/planets/planet59.lua
@@ -31,7 +31,7 @@ local function GetPlanet(planetUtilities, planetID)
 			.. "\n "
 			.. "\nAnd now that thing is powering up again."
 			,
-			extendedText = "The plague will convert any destroyed unit wreck into zombies, hostile to all. I can the Ultimatum's Disintegrator Gun to put them all the way down, then deactivate that damn Artefact before it releases something even nastier."
+			extendedText = "The plague will convert any destroyed unit wreck into zombies, hostile to all. I can use the Ultimatum's Disintegrator Gun to put them all the way down, then deactivate that damn Artefact before it releases something even nastier."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet59.lua
+++ b/campaign/sample/planets/planet59.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G9VI",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24614",
-			text = [[Provoked by a rival salvager, the Artefact on this planet has released an automatic defensive measure - nanobots convert any destroyed unit wrecks into zombies, hostile to all intruders. Use the Ultimatum's Disintegrator Gun to put them all the way down, then get away before the Artefact does something even nastier.]]
+			text = "Rebel scientists were studying an artefact found in an archeological site, when they were overrun by the Empire. Desperate for any advantage they could, they activated it, releasing a zombie nanoplague."
+			.. "\n "
+			.. "\nAll it cost them was the lives of every single inhabitant on the planet."
+			.. "\n "
+			.. "\nAnd now that thing is powering up again."
+			,
+			extendedText = "The plague will convert any destroyed unit wreck into zombies, hostile to all. I can the Ultimatum's Disintegrator Gun to put them all the way down, then deactivate that damn Artefact before it releases something even nastier."
 		},
 		tips = {
 			{
@@ -38,7 +44,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/pw_artefact.png",
-				text = [[The Artefact has no direct defences of its own but it is being defended by a rival. Push through the zombies and your opponent's defences to access the Artefact.]]
+				text = [[The Artefact has no direct defences of its own but it is being defended by a hostile force. Push through the zombies and your opponent's defences to access the Artefact.]]
 			},
 		},
 		gameConfig = {

--- a/campaign/sample/planets/planet6.lua
+++ b/campaign/sample/planets/planet6.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F9V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24429",
-			text = [[This battle is taking place at high altitude, so deploy Wind Generators for cheap and efficient energy income. Use the Knight's lightning gun to eliminate the enemy Jumpbots.]]
+			text = "This world is covered with islands, with a surprising variety of defences. Was it used for combat testing?"
+			.. "\n "
+			.. "\nMany of those islands seem isolated from each-other. I will only need to clear one, hopefully it won't contain any nasty experimental unit."
+			,
+			extendedText = "This battle is taking place at high altitude, I can use Wind Generators for cheap and efficient energy income."
+			.. "\n "
+			.. "\nThose Jumpbots I am up against seem rather strange. Not sure whta the best tactics are against them, but I hope my Knight's lightning gun will help."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet6.lua
+++ b/campaign/sample/planets/planet6.lua
@@ -32,7 +32,7 @@ local function GetPlanet(planetUtilities, planetID)
 			,
 			extendedText = "This battle is taking place at high altitude, I can use Wind Generators for cheap and efficient energy income."
 			.. "\n "
-			.. "\nThose Jumpbots I am up against seem rather strange. Not sure whta the best tactics are against them, but I hope my Knight's lightning gun will help."
+			.. "\nThose Jumpbots I am up against seem rather strange. Not sure what the best tactics are against them, but I hope my Knight's lightning gun will help."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet60.lua
+++ b/campaign/sample/planets/planet60.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G7V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24594",
-			text = [[Take control of the sea and then the enemy shoreline with Shogun battleships. You'd better hurry - if they finish their Zenith meteor controller, things will become a lot more difficult...]]
+			text = "This was the capital of Haven. It must have been such a beautiful world in its prime. But war was closing, even there. Evacuation had started, and they were halfway done turning it into a fortress. Every industry retooled to build military hardware. Every air traffic system repuroposed for war."
+			.. "\n "
+			.. "\nThen, just like that, everyone was gone."
+			,
+			extendedText = "I'm lucky that even half the fleet acknowledged those damn IFF codes. Now, to take control of the sea, then the enemy shoreline, with Shogun battleships. I'd better hurry - if they finish that Zenith meteor controller, things will become a lot more difficult..."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet61.lua
+++ b/campaign/sample/planets/planet61.lua
@@ -29,7 +29,7 @@ local function GetPlanet(planetUtilities, planetID)
 			.. "\n "
 			.. "\nWas it the last delusion of a decadent regime? Or would they have truly risen stronger in due time?"
 			,
-			extendedText = "Even with those backdoors, much of the local forces are still hostile - I will have to dislodge them from their mounatinous defensive bastions. Fortunately, those Funnelweb striders are well equiped for that particular task."
+			extendedText = "Even with those backdoors, much of the local forces are still hostile - I will have to dislodge them from their mountainous defensive bastions. Fortunately, those Funnelweb striders are well equiped for that particular task."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet61.lua
+++ b/campaign/sample/planets/planet61.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "F9IV",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24614",
-			text = [[Your enemy controls more than half the map, with heavy defensive emplacements protecting his claim. Use the Funnelweb to protect your army on a series of strikes at enemy strongpoints, then take command of their artefacts by destroying the defences around them.]]
+			text = "With the Empire growing increasingly unstable, they fell back to their home sectors, letting the periphery slowly decay into lawlessness. Hidden behind their fortress worlds, they hoped to regrow their strength and strike again, reconquering the galaxy once and for all."
+			.. "\n "
+			.. "\nWas it the last delusion of a decadent regime? Or would they have truly risen stronger in due time?"
+			,
+			extendedText = "Even with those backdoors, much of the local forces are still hostile - I will have to dislodge them from their mounatinous defensive bastions. Fortunately, those Funnelweb striders are well equiped for that particular task."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet62.lua
+++ b/campaign/sample/planets/planet62.lua
@@ -25,7 +25,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G7V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
-			text = [[Your enemy is causing trouble with a collection of heavy units, including large Paladin striders. Ambush and destroy their heavies in the mountains with Scorpions.]]
+			text = "This is the closest point the Rebel military ever came to threaten the Empire's heartland. But overconfidence was their downfall: instead of keeping with ambush and clever strategic play, they met the Empire on its own terms in a single, decisive engagement."
+			.. "\n "
+			.. "\nThis defeat broke the momentum of the Rebel forces, from which they would never recover."
+			,
+			extendedText = "Once bitten, twice shy: the Empire stationed an impressive collection of heavy units here, including large Paladin striders. I managed to take control of a few Scorpions - which was surprisingly easy - and mountains are a good place for ambush, to destroy those heavies."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet63.lua
+++ b/campaign/sample/planets/planet63.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "B5II",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24614",
-			text = [[Your Tech Lab is attempting to discover how the hostiles on this planet have subjugated a hive of Chickens. Protect the Tech Lab until its research is complete.]]
+			text = "Not wanting to risk damaging the unique environment of this strange crystalline planet, the Empire refrained from exterminating the Chicken swarm laying there, periodically culling them instead."
+			.. "\n "
+			.. "\nScience teams were sent to study both planet and Chicken - and maybe find a way to control them. As far as is known, no one has ever succeeded at such task, but there have always been others to keep trying."
+			,
+			extendedText = "This is a nightmare. Somehow a Queen subjugated the army stationed here to cull them! What have these fools done, while attempting to control it ?"
+			.. "\n "
+			.. "\nWhatever happens, I must hold on to this Tech Lab long enough to download their data."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet64.lua
+++ b/campaign/sample/planets/planet64.lua
@@ -25,7 +25,19 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24642",
-			text = [[This battle will take place on a massive salt plain, littered with sharp spikes. Use Paladin striders to dominate all aspects of the fight.]]
+			text = "Planet Intrepid, crown jewel of the Empire, garden of the East - this dead, barren world?"
+			.. "\n "
+			.. "\nI can see it now. Left unsupervised, maintenance failed, gardens dried and the entire ecosystem fell into a death spiral."
+			.. "\n "
+			.. "\nLeaving nothing but grey sand, haunted by decaying armies and fading memories."
+			,
+			extendedText = "This battle takes place on what was once a shallow lake, renown across the entire galaxy for its splendor."
+			.. "\n "
+			.. "\nI remember seeing it as a child. Poets of all worlds tried to capture its beauty, but I doubt any could have succeeded."
+			.. "\n "
+			.. "\nAll that is left is now a massive salt plain, littered with odd, towering spikes."
+			.. "\n "
+			.. "\nUsed well, Paladin striders will dominate all aspects of the fight. Armies should never have come to this place. I shall make sure none will ever again."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet64.lua
+++ b/campaign/sample/planets/planet64.lua
@@ -31,7 +31,7 @@ local function GetPlanet(planetUtilities, planetID)
 			.. "\n "
 			.. "\nLeaving nothing but grey sand, haunted by decaying armies and fading memories."
 			,
-			extendedText = "This battle takes place on what was once a shallow lake, renown across the entire galaxy for its splendor."
+			extendedText = "This battle takes place on what was once a shallow lake, renowed across the entire galaxy for its splendor."
 			.. "\n "
 			.. "\nI remember seeing it as a child. Poets of all worlds tried to capture its beauty, but I doubt any could have succeeded."
 			.. "\n "

--- a/campaign/sample/planets/planet65.lua
+++ b/campaign/sample/planets/planet65.lua
@@ -25,7 +25,15 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24642",
-			text = [[The deep water channels and hills of this battleground present a challenging tactical landscape. The ultra-heavy amphibious Detriment strider is ideally suited to such mixed terrain.]]
+			text = "This was one of the last worlds to see its inhabitants disappear. Refugees from all the quadrant fled here, waiting for transit to the last bastion of humanity. Many seems to have accepted their fate, though, and built immense temporary cities, to be reclaimed by nature after their passing."
+			.. "\n "
+			.. "\nThe Empire would not, however. Even knowing how futile it was, they fortified this world with all they had."
+			,
+			extendedText = "The deep water channels and hills of this battleground present a challenging tactical landscape. The ultra-heavy amphibious Detriment strider is ideally suited to such mixed terrain."
+			.. "\n "
+			.. "\nHow ironic for those defiant armies, to stand immobile as everyone disappeared, and for countless more years, only to destroy themselves in such a futile way."
+			.. "\n "
+			.. "\nI wish I could have just continued my way, and left them rest in peace."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet66.lua
+++ b/campaign/sample/planets/planet66.lua
@@ -25,7 +25,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24642",
-			text = [[Two duelling Zenith meteor controllers threaten to reduce this planet to space dust. If you can destroy the enemy Zenith, you'll at least have the satisfaction of being the owner of that space dust.]]
+			text = "The Rebel homeworld, the planet where it all started. Here, the Empire chose to make an example - they turned its two civilian spacecraft vector towers into Zenith meteor controllers. Then, they let the Rebels capture one, and waited for the duelling Zenith to slowly turn the planet to rubble."
+			.. "\n "
+			.. "\nWhat really happened? Why did they actually rebel? And why would I have been their ally? Time to find out."
+			,
+			extendedText = "The two duelling Zenith meteor controllers have powered up - I must destroy the enemy Zenith before they turn the entire planet to space dust."
+			.. "\n "
+			.. "\nThe ruins of this world hold my answers. I have NOT faced so many hardships, only to let some long dead war criminals raze them to the ground."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet67.lua
+++ b/campaign/sample/planets/planet67.lua
@@ -29,7 +29,7 @@ local function GetPlanet(planetUtilities, planetID)
 			.. "\n "
 			.. "\nHow ironic that it would be the first place where everyone would disappear... Or maybe this is where it all started."
 			.. "\n "
-			.. "\nWhat happened to you, Zhurou? What are you hiding?."
+			.. "\nWhat happened to you, Zhurou? What are you hiding?"
 			,
 			extendedText = "I have taken control of the superweapon they were building here, but a massive fleet of capital ships is closing on me. All I have to do is hold them off long enough and complete the damn thing."
 			.. "\n "

--- a/campaign/sample/planets/planet67.lua
+++ b/campaign/sample/planets/planet67.lua
@@ -25,7 +25,15 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G4V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24642",
-			text = [[You are facing a massive fleet of capital ships. Ensure your complete domination of the seas with the Disco Rave Party superweapon.]]
+			text = "Haven's last redoubt. Should the capital on Pendust fall, it is here they would have fought the Empire to the bitter end."
+			.. "\n "
+			.. "\nHow ironic that it would be the first place where everyone would disappear... Or maybe this is where it all started."
+			.. "\n "
+			.. "\nWhat happened to you, Zhurou ? You will tell me."
+			,
+			extendedText = "I have taken control of the superweapon they were building here, but a massive fleet of capital ships is closing on me. All I have to do is hold them off long enough and complete the damn thing."
+			.. "\n "
+			.. "\nSend me your worst, automata. I will NOT be denied."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet67.lua
+++ b/campaign/sample/planets/planet67.lua
@@ -29,7 +29,7 @@ local function GetPlanet(planetUtilities, planetID)
 			.. "\n "
 			.. "\nHow ironic that it would be the first place where everyone would disappear... Or maybe this is where it all started."
 			.. "\n "
-			.. "\nWhat happened to you, Zhurou ? You will tell me."
+			.. "\nWhat happened to you, Zhurou? What are you hiding?."
 			,
 			extendedText = "I have taken control of the superweapon they were building here, but a massive fleet of capital ships is closing on me. All I have to do is hold them off long enough and complete the damn thing."
 			.. "\n "

--- a/campaign/sample/planets/planet68.lua
+++ b/campaign/sample/planets/planet68.lua
@@ -33,7 +33,7 @@ local function GetPlanet(planetUtilities, planetID)
 			,
 			extendedText = "They were building not one but two superweapons here. If this was to be humanity's last stand, they would give it all."
 			.. "\n "
-			.. "\nUnfortunately, only one is operational, and it is pointed right at me. I will hold off their assault regardless, even supported by a Disco Rave Party rapid-fire cannon - until my Starlight orbital chisel is complete."
+			.. "\nUnfortunately, only one is operational, and it is pointed right at me. Well, so be it. I will hold off their assault, even supported by a Disco Rave Party rapid-fire cannon - until my Starlight orbital chisel is complete."
 			.. "\n "
 			.. "\nCome hell or high water, I will find out what happened here."
 		},

--- a/campaign/sample/planets/planet68.lua
+++ b/campaign/sample/planets/planet68.lua
@@ -1,4 +1,4 @@
---------------------------------------------------------------------------------
+	--------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Planet config
 
@@ -25,7 +25,17 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G1V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24642",
-			text = [[Your opponent is already conducting a victory dance with their Disco Rave Party cannon. Hold off their assault until your Starlight orbital chisel is complete, then demonstrate that their celebration is premature.]]
+			text = "This is it, humanity's last planet. A frozen, windswept desert world, where to wait for the end."
+			.. "\n "
+			.. "\nAnd yet... did they really flee all the way there only to delay the inevitable?"
+			.. "\n "
+			.. "\nIf the Empire knew anything about what really happened - if they ever found an escape, this is where the answers will be."
+			,
+			extendedText = "They were building not one but two superweapons here. If this was to be humanity's last stand, they would give it all."
+			.. "\n "
+			.. "\nUnfortunately, only one is operational, and it is pointed right at me. I will hold off their assault regardless, even supported by a Disco Rave Party rapid-fire cannon - until my Starlight orbital chisel is complete."
+			.. "\n "
+			.. "\nCome hell or high water, I will find out what happened here."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet69.lua
+++ b/campaign/sample/planets/planet69.lua
@@ -30,7 +30,15 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G8V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24417",
-			text = [[Use a nimble force of Glaives to penetrate the enemy lines and rescue your commander from the local automatons. Once activated, construct an army and storm the enemy base as retribution.]]
+			text = "[ Emergency boot sequence complete, terminating pilot hibernation ]"
+			.. "\n[ Recovering data... Recovery incomplete, see log file for error list ]"
+			.. "\n[ Alert: Commander unit systems unresponsive: movement, armament, construction, IFF. External reboot required. ]"
+			.. "\n[ Welcome aboard, <missing data>. Do you wish to see the tutorial? Y/N ]"
+			.. "\n "
+			.. "\nWh-"
+			.. "\nWhat? Where am I?"
+			.. "\nI- I can't think clearly... That noise - is that weapon fire?"
+			-- There is no in-game briefing screen for this, so thee is no need for extendedText
 		},
 		gameConfig = {
 			gameName = "Quick Rocket Tutorial",

--- a/campaign/sample/planets/planet7.lua
+++ b/campaign/sample/planets/planet7.lua
@@ -32,7 +32,7 @@ local function GetPlanet(planetUtilities, planetID)
 			,
 			extendedText = "Frontal attack would be suicidal, but most of it is static defences. If I can infiltrate Phantom sniper bots and destroy their Singularity Plants, it will deactivate the heavier defences."
 			.. "\n "
-			.. "\nI should not let my guard down. Some mobile forces are still active..."
+			.. "\nI should not let my guard down, some mobile forces are still active. And there is something very strange with their data flux..."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet7.lua
+++ b/campaign/sample/planets/planet7.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G7V",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24429",
-			text = [[The Artefact on this planet contains invaluable information, but it is protected by a large automated defence network. Infiltrate the Automaton base with Phantom sniper bots and destroy the Singularity Plants to deactivate the heavier defences.]]
+			text = "There is something very strange on this world. Some kind of artefact, I have never seen anything like it. Could it hold answers about what happened to everyone? I need to get closer."
+			.. "\n "
+			.. "\nIt is heavily defended, direct assault would be a bad idea. Maybe I can find some weakness in those defences..."
+			,
+			extendedText = "Frontal attack would be suicidal, but most of it is static defences. If I can infiltrate Phantom sniper bots and destroy their Singularity Plants, it will deactivate the heavier defences."
+			.. "\n "
+			.. "\nI should not let my guard down. Some mobile forces are still active..."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet70.lua
+++ b/campaign/sample/planets/planet70.lua
@@ -26,7 +26,9 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "A4IV",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24566",
-			text = [[Burn out forests of Wind Generators with Phoenixes to cripple your enemy and allow the land units of your ally to make progress. Protect your bombers against enemy air with Raptors.]]
+			text = "Even if it hadn't been set back so often by wars over its resources, I doubt terraforming this blasted world could have ever been successful. Now, all that is left from those efforts are constant, maddening winds that can drive even automata insane."
+			,
+			extendedText = "The programming of those automata has decayed in an incomprehensible mess. I couldn't have turned them, but some did so on their own. I don't like it - let's burn out those forests of Wind Generators with Phoenixes, and protect those against enemy air with Raptors. The faster I cripple their energy sources, the sooner I can get out of here."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet71.lua
+++ b/campaign/sample/planets/planet71.lua
@@ -26,7 +26,15 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "K1",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24489",
-			text = [[This remote moon was used for widely broadcast rally races in a bygone age. A classic challenge now awaits all comers: the Super Extreme Kodachi Rally!]]
+			text = "This remote moon used to broadcast rally races to the entire galaxy. Did I watch those? It feels oddly familiar."
+			.. "\n "
+			.. "\nI can still pick a signal up, some of the broadcast systems are still working to this day. The show must go on, I guess. Not letting petty distractions like the apocalypse get in the way."
+			.. "\n "
+			.. "\nLet's try and hack in, see if it rings any bells..."
+			,
+			extendedText = "...ok, this didn't do anything. Maybe that one ?"
+			.. "\n "
+			.. "\n[Welcome, new challenger, and good luck for the Super Extreme Kodachi Rally! Your will be starting---right now!]"
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet8.lua
+++ b/campaign/sample/planets/planet8.lua
@@ -26,7 +26,13 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "G3V",
 			milRating = 2,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24429",
-			text = [[The enemy has a Big Bertha cannon which is dominating the battlefield. Sneak into their base with Scythes and eliminate the threat.]]
+			text = "There is a battle raging for the control of this world, but without direction, it seems to have reached stalemate a long time ago."
+			.. "\n "
+			.. "\nOne side has recognized my IFF signal as friendly, strangely enough. If I can tip the fight in their favor, this should let me find out what is going on here."
+			,
+			extendedText = "If I can destroy this Big Bertha cannon here, it should open things up for my allies. The best method for eliminating may be those Scythes."
+			.. "\n "
+			.. "\nThis should be enough to tip the battle and give them control of this world."
 		},
 		tips = {
 			{

--- a/campaign/sample/planets/planet9.lua
+++ b/campaign/sample/planets/planet9.lua
@@ -26,7 +26,11 @@ local function GetPlanet(planetUtilities, planetID)
 			primaryType = "B2Ia",
 			milRating = 1,
 			feedbackLink = "http://zero-k.info/Forum/Thread/24457",
-			text = [[Besides the occasional strange hills dotting the landscape, this is a smooth and level battlefield. Your opponent has arrived before you and has begun expanding their economy. Use your Scorchers to punish their greed.]]
+			text = "This ugly desert world would have been a large industrial hub at one time. Mineral resources, mostly flat terrain, calm weather, lying at an interstellar crossroads and no environment to ruin with pollution."
+			.. "\n "
+			.. "\nNo wonder they fought so hard to keep it. War vehicles are still crisscrossing its empty sand plains, eternally waiting for the next invasion."
+			,
+			extendedText = "Besides the occasional strange hills dotting the landscape, this is a smooth and level battlefield. This area is lightly defended, but local forces will start tapping into that resource extraction network as soon as I arrive to reinforce themselves. I should take as many extractors out as I can with Scorchers, as fast as possible."
 		},
 		tips = {
 			{


### PR DESCRIPTION
WIP for the new campaign scenario:
 - All briefing texts replaced
 - All briefings (except the initial planet) have added extendedText, so a different text is displayed in the mission selection screen and in the in-game objective screen.

Codex pages have not been written yet, so this is only half of the actual work. The endings, in particular, are by necessity codex entries.
However, many players will probably not read most of the codex entries, if any, and this is how the story is initially conveyed, so it is still important that it can stand on its own.

English is not my native language, and this format with series of very short texts is unusual for me, so please watch out for typos, weird expressions and unclear sentences.
Feedback and (constructive) criticism on the scenario itself and the varied entries is also very welcome.

Tested on 1024x768 resolution for avoiding text overflow, and minimize scrolling in the objective/tips in-game menu.

Story inspired by the game Duskers (or at least the early part I played), memories from the beginning of the Sunrise campaign, summaries of previous Planetwars factions, and whatever the missions or the planet's position inspired me at the moment.