### PR TITLE
Fix UserListPanel sorting

### DIFF
--- a/LuaMenu/widgets/chobby/components/user_list_panel.lua
+++ b/LuaMenu/widgets/chobby/components/user_list_panel.lua
@@ -71,7 +71,7 @@ local function CompareUsers(userName, otherName)
 		return true
 	end
 
-	if otherData.isAdmin ~= userData.isAdmin then
+	if (not not otherData.isAdmin) ~= (not not userData.isAdmin) then
 		return userData.isAdmin
 	end
 


### PR DESCRIPTION
Offline users have a nil isAdmin, non-admins have a false isAdmin.

This caused comparisons to often enter the admin branch prematurely,
breaking alphabetical etc ordering.

`not not` rather than `not` for a simple inequality seems a little
superfluous, but consistency is important, and in any case, unrelated
nonfunctional changes can always be made in a separate commit.