### PR TITLE
Userlistpanel: `not`, not `not not`

### DIFF
--- a/LuaMenu/widgets/chobby/components/user_list_panel.lua
+++ b/LuaMenu/widgets/chobby/components/user_list_panel.lua
@@ -71,7 +71,7 @@ local function CompareUsers(userName, otherName)
 		return true
 	end
 
-	if otherData.isAdmin ~= userData.isAdmin then
+	if (not not otherData.isAdmin) ~= (not not userData.isAdmin) then
 		return userData.isAdmin
 	end
 

--- a/LuaMenu/widgets/chobby/components/user_list_panel.lua
+++ b/LuaMenu/widgets/chobby/components/user_list_panel.lua
@@ -71,11 +71,11 @@ local function CompareUsers(userName, otherName)
 		return true
 	end
 
-	if (not not otherData.isAdmin) ~= (not not userData.isAdmin) then
+	if (not otherData.isAdmin) ~= (not userData.isAdmin) then
 		return userData.isAdmin
 	end
 
-	if (not not otherData.isIgnored) ~= (not not userData.isIgnored) then
+	if (not otherData.isIgnored) ~= (not userData.isIgnored) then
 		return otherData.isIgnored
 	end
 


### PR DESCRIPTION
Once is enough to coerce to a boolean, twice is superfluous for a
simple equality test.

This builds from #720