### PR TITLE
Userlistpanel: Show online users first

### DIFF
--- a/LuaMenu/widgets/chobby/components/user_list_panel.lua
+++ b/LuaMenu/widgets/chobby/components/user_list_panel.lua
@@ -71,7 +71,7 @@ local function CompareUsers(userName, otherName)
 		return true
 	end
 
-	if otherData.isAdmin ~= userData.isAdmin then
+	if (not not otherData.isAdmin) ~= (not not userData.isAdmin) then
 		return userData.isAdmin
 	end
 

--- a/LuaMenu/widgets/chobby/components/user_list_panel.lua
+++ b/LuaMenu/widgets/chobby/components/user_list_panel.lua
@@ -79,6 +79,9 @@ local function CompareUsers(userName, otherName)
 		return otherData.isIgnored
 	end
 
+	if (not otherData.isOffline) ~= (not userData.isOffline) then
+		return otherData.isOffline
+	end
 	return string.lower(userName) < string.lower(otherName)
 end
 

--- a/LuaMenu/widgets/chobby/components/user_list_panel.lua
+++ b/LuaMenu/widgets/chobby/components/user_list_panel.lua
@@ -71,11 +71,11 @@ local function CompareUsers(userName, otherName)
 		return true
 	end
 
-	if (not not otherData.isAdmin) ~= (not not userData.isAdmin) then
+	if (not otherData.isAdmin) ~= (not userData.isAdmin) then
 		return userData.isAdmin
 	end
 
-	if (not not otherData.isIgnored) ~= (not not userData.isIgnored) then
+	if (not otherData.isIgnored) ~= (not userData.isIgnored) then
 		return otherData.isIgnored
 	end
 


### PR DESCRIPTION
This is generally more relevant while in the lobby, and helps make
clearer the:
> [liblobby] Warning: Duplicate user(...) added to channel (...)

problems, where it appears that an online and an offline user
share the same name. This issue is not fixed here.

This builds from #721