### PR TITLE
Limit campaign storyline to availability of missions

### DIFF
--- a/LuaMenu/widgets/gui_campaign_handler.lua
+++ b/LuaMenu/widgets/gui_campaign_handler.lua
@@ -731,26 +731,15 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 		children = fluffLabels,
 	}
 
-	local planetDesc
-	if startable or Configuration.debugMode then
-		planetDesc = TextBox:New {
-			x = 20,
-			y = "25%",
-			right = 4,
-			bottom = "25%",
-			text = planetData.infoDisplay.text,
-			font = Configuration:GetFont(3),
-		}
-	else
-		planetDesc = TextBox:New {
-			x = 20,
-			y = "25%",
-			right = 4,
-			bottom = "25%",
-			text = "This planet will need to be approached for further study.",
-			font = Configuration:GetFont(3),
-		}	
-	end
+	local planetDesc = TextBox:New {
+		x = 20,
+		y = "25%",
+		right = 4,
+		bottom = "25%",
+		text = ((startable or Configuration.debugMode) and planetData.infoDisplay.text) or "This planet will need to be approached for further study.",
+		font = Configuration:GetFont(3),
+	}	
+
 
 	local subPanel = Panel:New{
 		parent = starmapInfoPanel,

--- a/LuaMenu/widgets/gui_campaign_handler.lua
+++ b/LuaMenu/widgets/gui_campaign_handler.lua
@@ -732,8 +732,8 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 	}
 
 	local planetDesc = TextBox:New {
-		x = 20,
-		y = "25%",
+		x = 8,
+		y = "30%",
 		right = 4,
 		bottom = "25%",
 		text = ((startable or Configuration.debugMode) and planetData.infoDisplay.text) or "This planet will need to be approached for further study.",

--- a/LuaMenu/widgets/gui_campaign_handler.lua
+++ b/LuaMenu/widgets/gui_campaign_handler.lua
@@ -731,14 +731,26 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 		children = fluffLabels,
 	}
 
-	local planetDesc = TextBox:New {
-		x = 8,
-		y = "30%",
-		right = 4,
-		bottom = "25%",
-		text = planetData.infoDisplay.text,
-		font = Configuration:GetFont(3),
-	}
+	local planetDesc
+	if startable or Configuration.debugMode then
+		planetDesc = TextBox:New {
+			x = 20,
+			y = "25%",
+			right = 4,
+			bottom = "25%",
+			text = planetData.infoDisplay.text,
+			font = Configuration:GetFont(3),
+		}
+	else
+		planetDesc = TextBox:New {
+			x = 20,
+			y = "25%",
+			right = 4,
+			bottom = "25%",
+			text = "This planet will need to be approached for further study.",
+			font = Configuration:GetFont(3),
+		}	
+	end
 
 	local subPanel = Panel:New{
 		parent = starmapInfoPanel,


### PR DESCRIPTION
Gates the story content of planets that are unable to be started by replacing their descriptions with placeholder text "This planet will need to be approached for further study." (enabling debug mode will bypass this change)