### PR TITLE
Campaign Planet View Layout Adjustments

### DIFF
--- a/LuaMenu/widgets/gui_campaign_handler.lua
+++ b/LuaMenu/widgets/gui_campaign_handler.lua
@@ -744,7 +744,7 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 		parent = starmapInfoPanel,
 		x = "3%",
 		y = "4%",
-		right = "50%",
+		right = "60%",
 		bottom = "4%",
 		children = {
 			nameLabel,
@@ -917,33 +917,36 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 	end
 
 	local function SizeUpdate()
-		local font = Configuration:GetFont(((planetHandler.height < 760) and 2) or 3)
+		local fluffFont = Configuration:GetFont(((planetHandler.height < 720) and 2) or 3)
+		local descFont = Configuration:GetFont(((planetHandler.height < 720) and 1) or 2) 
 
-		planetDesc.font.size = font.size
+		planetDesc.font.size = descFont.size
 		planetDesc:Invalidate()
-		if planetHandler.height < 660 then
+		if planetHandler.height < 560 then
 			planetDesc._relativeBounds.top = 60
 			fluffGrid:SetVisibility(false)
+
 		elseif planetHandler.height < 820 then
-			planetDesc._relativeBounds.top = "27%"
+			planetDesc._relativeBounds.top = "26%"
 			fluffGrid:SetVisibility(true)
+
 		else
-			planetDesc._relativeBounds.top = "30%"
+			planetDesc._relativeBounds.top = "25%"
 			fluffGrid:SetVisibility(true)
 		end
 		planetDesc:UpdateClientArea(false)
 
 		if planetHandler.height < 600 then
-			subPanel._relativeBounds.right = 390
+			subPanel._relativeBounds.right = 320
 			subPanel._relativeBounds.bottom = "2%"
 		else
-			subPanel._relativeBounds.right = "50%"
+			subPanel._relativeBounds.right = "40%"
 			subPanel._relativeBounds.bottom = "4%"
 		end
 		subPanel:UpdateClientArea(false)
 
 		for i = 1, 4 do
-			fluffLabels[i].font.size = font.size
+			fluffLabels[i].font.size = fluffFont.size
 			fluffLabels[i]:Invalidate()
 		end
 		fluffGrid:Invalidate()

--- a/LuaMenu/widgets/gui_campaign_handler.lua
+++ b/LuaMenu/widgets/gui_campaign_handler.lua
@@ -732,8 +732,8 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 	}
 
 	local planetDesc = TextBox:New {
-		x = 8,
-		y = "30%",
+		x = 20,
+		y = "25%",
 		right = 4,
 		bottom = "25%",
 		text = planetData.infoDisplay.text,

--- a/LuaMenu/widgets/gui_campaign_handler.lua
+++ b/LuaMenu/widgets/gui_campaign_handler.lua
@@ -736,6 +736,7 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 		y = "25%",
 		right = 4,
 		bottom = "25%",
+		padding = {0, 0, 10, 0},
 		text = planetData.infoDisplay.text,
 		font = Configuration:GetFont(3),
 	}
@@ -936,12 +937,15 @@ local function SelectPlanet(popupOverlay, planetHandler, planetID, planetData, s
 		end
 		planetDesc:UpdateClientArea(false)
 
-		if planetHandler.height < 600 then
-			subPanel._relativeBounds.right = 320
-			subPanel._relativeBounds.bottom = "2%"
-		else
-			subPanel._relativeBounds.right = "40%"
+		if planetHandler.height > 800 then
+			subPanel._relativeBounds.right = "50%"
 			subPanel._relativeBounds.bottom = "4%"
+		elseif planetHandler.height > 400 then
+			subPanel._relativeBounds.right = "40%"
+			subPanel._relativeBounds.bottom = "2%"	
+		else
+			subPanel._relativeBounds.right = 200
+			subPanel._relativeBounds.bottom = 0
 		end
 		subPanel:UpdateClientArea(false)
 


### PR DESCRIPTION
Left pane uses 60% of available width for text and unlockables. All display elements become viewable down to 1366x768

Reduced font sizes for planet flavor text, reducing wrapping of early mission text (Folsom). Breakpoint adjustments to improve content visibility across resolutions