### PR TITLE
Chobby Flag to Minimize Draw Updates (CPU Usage)

### DIFF
--- a/LuaMenu/widgets/api_limit_fps.lua
+++ b/LuaMenu/widgets/api_limit_fps.lua
@@ -91,10 +91,17 @@ function widget:AllowDraw()
 		lastTimer = timer
 		return true
 	end
-	if oldFramesInBuffer < 3 then
+
+	if (config.lobbyIdleSleep) then
+		if (fastRedraw or constantRedrawSeconds) and oldFramesInBuffer < 3 then
+			framesInBuffer = oldFramesInBuffer + 1
+			return true
+		end
+	elseif oldFramesInBuffer < 3 then
 		framesInBuffer = oldFramesInBuffer + 1
 		return true
 	end
+	
 	return false
 end
 

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -217,6 +217,7 @@ function Configuration:init()
 	self.enableTextToSpeech = true
 	self.showOldAiVersions = false
 	self.drawAtFullSpeed = false
+	self.lobbyIdleSleep = false
 	self.rememberQueuesOnStart = false
 
 	self.language = "en"
@@ -510,6 +511,7 @@ function Configuration:GetConfigData()
 		confirmation_mainMenuFromBattle = self.confirmation_mainMenuFromBattle,
 		confirmation_battleFromBattle = self.confirmation_battleFromBattle,
 		drawAtFullSpeed = self.drawAtFullSpeed,
+		lobbyIdleSleep = self.lobbyIdleSleep,
 		rememberQueuesOnStart = self.rememberQueuesOnStart,
 		loadLocalWidgets = self.loadLocalWidgets,
 		activeDebugConsole = self.activeDebugConsole,

--- a/LuaMenu/widgets/gui_settings_window.lua
+++ b/LuaMenu/widgets/gui_settings_window.lua
@@ -925,6 +925,7 @@ local function GetLobbyTabControls()
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("simple_ai_list"), "simpleAiList", true)
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("animate_lobby"), "animate_lobby", true)
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("drawFullSpeed"), "drawAtFullSpeed", false)
+	children[#children + 1], offset = AddCheckboxSetting(offset, "Minimize lobby updates", "lobbyIdleSleep", true)
 	children[#children + 1], offset = AddCheckboxSetting(offset, i18n("keep_queues"), "rememberQueuesOnStart", false, nil, "Stay in matchmaker queues when a battle is launched.")
 
 	children[#children + 1] = Label:New {


### PR DESCRIPTION
Adds a 'Minimize lobby updates' checkbox to the settings menu, which will allow Chobby to idle during inactivity, disabled by default (requires user testing as it may cause flicker on some systems), and adjusts the frame rate limiter