### PR TITLE
Campaign codex small edits

### DIFF
--- a/campaign/sample/codex.lua
+++ b/campaign/sample/codex.lua
@@ -497,9 +497,10 @@ Oh right, I was a student at an Imperial Academy of War. Funny thing, to have fo
 		name = "New Falsell Anomaly",
 		image = "campaign/sample/graphics/unitpics/fakeunit.png",
 		category = "5. Anomalies",
-		text = [[What was going on here? Why leave such formidable defenses with no mobile forces to support it? Did they really think that this would be enough? Defenses alone can only slow an enemy down to buy time, not stop it. You would think that those in charge of such clearly sensitive defense would apply such basic principle.
-Expect they clearly
-Didn't. What good reason could they possibly have?
+		text = [[What was going on here? Why leave such formidable defenses with no mobile forces to support it?
+Did they really think that this would be enough? Defenses alone can only slow an enemy down to buy time, not stop it.
+You would think that those in charge of such clearly sensitive defense would apply such basic principle.
+Expect they clearly didn't. What good reason could they possibly have?
 Uh, my
 Commander seems to have some weird software glitch going on.
 I should try and fix that.
@@ -552,14 +553,16 @@ Aren't
 You,
 Little one?
 You could
-Scour the entire
-Galaxy if you want, you won't find them
-Here. You are the only one left on this side of
+Scour 
+The entire
+Galaxy if you want, you won't 
+Find them here. You are the only one left on this side of
 Eternity. Now go, continue your little quest elsewhere.
-There is nothing for you here. Your friends thought they could contain me, the poor little things. They never understood how futile were their little metal boxes, had I wanted to leave.
-But worry not, my time has not come yet. When the last stars have gone out and the last world have frozen, only then will I wake.
+There is nothing for you here. Your friends thought they could contain me, the poor little things. They never understood how futile were their little metal boxes, had I wanted to leave. But worry not, my time has not come yet. When the last stars have gone out and the last world have frozen, only then will I wake.
  
 See you then, little one.]]
+-- Before taking control of the text, the message starts with the first word of each line. This is why it is broken up that way, and always capitalized, and why the fourth line starts with Expect instead of Except.
+-- The last lines also sort of contain their own short message the same way.
 	},
 	anomaly_lovaza_jira = { -- planet28
 		name = "Lovaza Jira Memetics",

--- a/campaign/sample/codex.lua
+++ b/campaign/sample/codex.lua
@@ -375,7 +375,7 @@ While the newly-unified Rebel military was adept at raids and information warfar
  
 The loss of the army into which the Rebels had poured so much of their resources broke their military, and it would never recover. Following this defeat, and despite occasional successes in resisting the Empire's advance, the Rebels would not see another key victory, only losing ground from then on.
  
-By the time of the Event, only a few worlds still held on against the Empire's armies, with resistance movements on many others mercilessly hunted down. Had everyone not disappeared, it would have been a matter of time before their complete annihilation.]]
+By the time of the event, only a few worlds still held on against the Empire's armies, with resistance movements on many others mercilessly hunted down. Had everyone not disappeared, it would have been a matter of time before their complete annihilation.]]
 	},
 	location_rockbar = { -- planet57
 		name = "Rockbar Battleground",

--- a/campaign/sample/codex.lua
+++ b/campaign/sample/codex.lua
@@ -80,7 +80,7 @@ As it turns out, it appears that the Dynasty was behind it all. The oldest known
  
 Tracing back to Earth, they were a shadowy group of biosupremacists, obsessed with creating superior humans through genetic and biological modifications, and ruling over humanity as its greatest representatives. They shunned cybernetic enhancements, and hated non-human synths and free machines as anathema. They were divided into rival families, united only in their goal and against common menaces.
  
-They only acted openly when they were certain of their strength, preferring to subvert those they could, and secretly organizing rebellions against those they couldn't. They were the puppetmasters behind the Rebels, hoping to destabilize the Empire and take over in the resulting chaos. Even if the Empire won, it would have been weakened enough for the Dynasty to grow in influence - assuming they had not  been discovered.
+They only acted openly when they were certain of their strength, preferring to subvert those they could, and secretly organizing rebellions against those they couldn't. They were the puppetmasters behind the Rebels, hoping to destabilize the Empire and take over in the resulting chaos. Even if the Empire won, it would have been weakened enough for the Dynasty to grow in influence - assuming they had not been discovered.
  
 And yet, by their historical standards, the whole operation feels botched and amateurish. They may have survived against all odds, but as a mere shadow of themselves.]]
 	},
@@ -106,13 +106,13 @@ Still, something feels wrong with the whole affair. They had to know it had such
  
 Hitting the galaxy like a hurricane, they smashed all resistance, systematically dismantling any higher form of organization and advanced installations they found, before continuing to the next system.
  
-Taken aback, the Celestial Dominion, Ghost Mandate and Dynasty put their longstanding cold war on hold to band together against this new menace, but to no avail. Within months, both the mighty Ghost Fleet and the Four Thrones had been destroyed, with only a few survivors managing to reach Dynasty space before the Anarchai scatterships.
+Taken aback, the Celestial Dominion, Ghost Mandate and Dynasty put their longstanding cold war on hold to band together against this new menace, but to no avail. Within months, both the mighty Ghost Fleet and the Four Thrones had been destroyed, with only a few survivors managing to reach Dynasty space before the Anarchai scattershapes.
  
 It would be the only time in known history where the Dynasties broke their principle of human supremacy, making large-scale use of tech from Celestial and Ghost remnants. Against all odds, this unholy alliance of desperation did manage to slow down the ineluctable Anarchai advance - though not for long.
  
 Three years after their emergence, Chatka, the Dynasty homeworld and last bastion of resistance, would be burned to cinders.
  
-But then, the Anarchai turned their scatterships against each other, destroying themselves to the last. As suddenly as they had appeared, the Anarchai were gone - leaving the galaxy stunned, ruined, utterly disorganized - but to their own surprise, still alive.
+But then, the Anarchai turned their scattershapes against each other, destroying themselves to the last. As suddenly as they had appeared, the Anarchai were gone - leaving the galaxy stunned, ruined, utterly disorganized - but to their own surprise, still alive.
  
 Haven was fascinated by the Anarchai. Located in their presumed birthplace, they spent considerable effort trying to pierce the mystery of their origins, even as the war against the Empire was taking a turn for the worse.]]
 		-- ed note: Nothing to do with the Zero-K contributor Anarchid, the name resemblance is just a coincidence. Here, Anarchai is constructed from Archai (plural of Arche).
@@ -345,7 +345,7 @@ In a strange turn of fate, the human-supremacist Dynasty, oldest and longest-liv
  
 Faced with annihilation, not only of themselves but of the entire galaxy, the Dynasty renounced its founding principle. They installed Celestial cybernetic enhancements on their Demiurge battalion, creating in desperation what would be the greatest warriors in galactic history, and the only ones to ever stand their ground, if only for a moment, against the Anarchai.
  
-They would hold for two years, repelling many planetary assaults, but losing almost as many Demiurges to late cybernetic incompatibilities than to enemy action. Ultimately, though, it was not the Demiurges that would fail. Concentrating all their forces on the lone system, the Anarchai shut down the system's hyperspace barriers and triggered a starpulse, destroying all space defenses. Then sent their immense starships to break the planetary shield, overwhelm the anti-aerospace defenses, and burn the planet to the mantle.
+They would hold for two years, repelling many planetary assaults, but losing almost as many Demiurges to late cybernetic incompatibilities than to enemy action. Ultimately, though, it was not the Demiurges that would fail. Concentrating all their forces on the lone system, the Anarchai shut down the system's hyperspace barriers and triggered a starpulse, destroying all space defenses. Then sent their siege clusters to break the planetary shield, overwhelm the anti-aerospace defenses, and burn the planet to the mantle.
  
 The rest, as they said, is History.]]
 	},
@@ -575,15 +575,15 @@ What they could not find at the time, but what became clear once the fighting st
 		name = "Leopard Artefact",
 		image = "campaign/sample/graphics/icons/EmpireHavenBattle.png",
 		category = "5. Anomalies",
-		text = [[No wonder they fought so hard over it, this artifact was a freaking Anarchai scattership!
+		text = [[No wonder they fought so hard over it, this artifact was a freaking Anarchai scattershape!
  
-When the Ghost Fleet hit the Anarchai, they were completely unprepared to what they were actually facing. However, it is a testament to the might of the Mandate's military that they still managed to destroy several scatterships during the engagement.
+When the Ghost Fleet hit the Anarchai, they were completely unprepared to what they were actually facing. However, it is a testament to the might of the Mandate's military that they still managed to destroy several scattershapes during the engagement.
  
-This particular scattership phased right through Leopard after sustaining heavy damage, ending up trapped in its mantle. The few self-repair systems were barely enough to keep its integrity, but its gestalt had been irremediably destroyed - which is presumably why the Anarchai didn't bother recovering or destroying it afterwards.
+This particular scattershape phased right through Leopard after sustaining heavy damage, ending up trapped in its mantle. The few self-repair systems were barely enough to keep its integrity, but its gestalt had been irremediably destroyed - which is presumably why the Anarchai didn't bother recovering or destroying it afterwards.
  
 Even in its mindless, damaged state, had its self-repair systems kicked in and made it spaceworthy again, it would have had enough firepower to endanger the entire galaxy again. And its technology was so advanced and different from what we know today, who knows what could happen, had someone tried studying it... Haven was terrified that the Empire would be careless enough to try, and the Empire that Haven was desperate enough for it. And so they fought, not to gain control of it, but to make sure no-one would.
  
-Ultimately, the scattership's internal systems have stopped working one after another, and it is now little more than a wreck full of exotic materials. Still, I am going to leave it alone, just in case..]]
+Ultimately, the scattershape's internal systems have stopped working one after another, and it is now little more than a wreck full of exotic materials. Still, I am going to leave it alone, just in case..]]
 	},
 	anomaly_estann_all = { -- planet43
 		name = "Estann All Nanotech",


### PR DESCRIPTION
Replaced Anarchai scatterships by scattershapes, and one reference to starships by siege clusters. It was suggested that this would make them feel more alien if they don't have things as pedestrian as mere ships

Replaced an instance of 'Event' by 'event', as it is 'event' everywhere else. If 'Event' is better though, it could be changed everywhere instead.

Fixed the New Falsell hidden message