### PR TITLE
Use map with dimensions in multi poll tooltip

### DIFF
--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1314,9 +1314,11 @@ local function SetupVotePanel(votePanel, battle, battleID)
 	local function SetMultiPollCandidates(candidates)
 		for i = 1, MULTI_POLL_MAX do
 			if candidates[i] then
+				-- displayName is the map's internal name and its dimensions in a human friendly way
+				local mapName = candidates[i].displayName or candidates[i].name
 				multiPollOpt[i].imMinimap.file, multiPollOpt[i].imMinimap.checkFileExists = config:GetMinimapSmallImage(candidates[i].name)
 				multiPollOpt[i].imMinimap:Invalidate()
-				multiPollOpt[i].button.tooltip = "Vote for " .. candidates[i].name
+				multiPollOpt[i].button.tooltip = "Vote for " .. mapName
 			end
 		end
 	end

--- a/libs/liblobby/lobby/interface_zerok.lua
+++ b/libs/liblobby/lobby/interface_zerok.lua
@@ -1291,6 +1291,7 @@ function Interface:_BattlePoll(data)
 		}
 		if not data.YesNoVote then
 			candidates[i].name = opt.Name
+			candidates[i].displayName = opt.DisplayName
 		end
 	end
 


### PR DESCRIPTION
The poll candidates cannot directly override the map name since it is used
internally elsewhere (e.g. when looking up minimaps). Instead use a separate
displayName property populated on the server with dimensions.