### PR TITLE
Bugfix for the campaign commander silently losing modules on startup.

### DIFF
--- a/LuaMenu/widgets/api_campaign_data.lua
+++ b/LuaMenu/widgets/api_campaign_data.lua
@@ -411,6 +411,7 @@ local function RecalculateCommanderLevel()
 		end
 		level = level + 1
 	end
+	UpdateCommanderModuleCounts()
 	UpdateModuleRequirements()
 end
 


### PR DESCRIPTION
If you had chosen any commander-modules that have prereqs, one of those would be replaced by empty-slot each time you loaded the campaign data.