### PR TITLE
Feature/map search

### DIFF
--- a/LuaMenu/widgets/chobby/components/sortable_list.lua
+++ b/LuaMenu/widgets/chobby/components/sortable_list.lua
@@ -102,7 +102,7 @@ end
 
 function SortableList:AddItem(id, control, sorting)
 	if self.controlById[id] then
-		Spring.Echo("ListWindow dupicate item", id)
+		Spring.Echo("SortableList duplicate item", id)
 		return
 	end
 
@@ -118,7 +118,7 @@ end
 
 function SortableList:UpdateItemSorting(id, sorting, supressResort)
 	if not self.controlById[id] then
-		Spring.Echo("ListWindow missing item", id)
+		Spring.Echo("SortableList missing item", id)
 		return
 	end
 
@@ -231,4 +231,16 @@ function SortableList:UpdateOrder()
 	end
 
 	self:RecalculateDisplay()
+end
+
+function SortableList:GetVisibleItemIds()
+	local visibleItemIds = {}
+	for i = 1, self.items do
+	  local id = self.identifierList[i]
+		local control = self.controlById[id]
+		if control:IsVisibleOnScreen() then
+			visibleItemIds[#visibleItemIds+1] = id
+		end
+	end
+	return visibleItemIds
 end

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -165,7 +165,7 @@ return {
 			other = "%{count} items left to download.",
 		},
 		downloads_completed = "All downloads completed.",
-		filter = "Filter",
+		type_to_filter = "Type to filter",
 
 		-- Settings
 		planetwars_notifications = "Planetwars notifications",

--- a/LuaMenu/widgets/gui_maplist_panel.lua
+++ b/LuaMenu/widgets/gui_maplist_panel.lua
@@ -149,7 +149,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 		}
 
 		sortData = {string.lower(mapName), (mapData.Width or 0)*100 + (mapData.Height or 0), string.lower(mapData.MapType), string.lower(terrainType), (haveMap and 1) or 0}
-		sortData[6] = sortData[1] .. mapSizeText .. sortData[3] .. " " .. sortData[4] -- Used for text filter by name, type, terrain or size.
+		sortData[6] = sortData[1] .. " " .. mapSizeText .. " " .. sortData[3] .. " " .. sortData[4] -- Used for text filter by name, type, terrain or size.
 	else
 		sortData = {string.lower(mapName), 0, "", "", (haveMap and 1) or 0}
 		sortData[6] = sortData[1]
@@ -337,6 +337,18 @@ local function InitializeControls()
 		hint = i18n("type_to_filter"),
 		fontsize = Configuration:GetFont(2).size,
 		parent = mapListWindow,
+		OnKeyPress = {
+			function(obj, key, ...)
+				if key ~= Spring.GetKeyCode("enter") and key ~= Spring.GetKeyCode("numpad_enter") then
+					return
+				end
+				local visibleItemIds = mapList:GetVisibleItemIds()
+				if #visibleItemIds[1] then
+					lobby:SelectMap(visibleItemIds[1])
+					CloseFunc()
+				end
+			end
+		},
 		OnTextModified = {
 			function (self)
 				filterTerms = string.lower(self.text):split(" ")
@@ -362,6 +374,7 @@ local function InitializeControls()
 		if zoomToMap then
 			mapList:ScrollToItem(zoomToMap)
 		end
+		screen0:FocusControl(ebFilter)
 	end
 
 	function externalFunctions.UpdateHaveMap(thingName)

--- a/LuaMenu/widgets/gui_maplist_panel.lua
+++ b/LuaMenu/widgets/gui_maplist_panel.lua
@@ -341,7 +341,7 @@ local function InitializeControls()
 	local externalFunctions = {}
 
 	function externalFunctions.Show(zoomToMap)
-		ebFilter.text = ""
+		ebFilter:Clear()
 		mapList:RecalculateDisplay()
 
 		if not mapListWindow.visible then

--- a/libs/chiliui/chili/controls/editbox.lua
+++ b/libs/chiliui/chili/controls/editbox.lua
@@ -151,6 +151,11 @@ function EditBox:SetText(newtext)
 	self:Invalidate()
 end
 
+function EditBox:Clear()
+	self:SetText("")
+	inherited.TextModified(self)
+end
+
 function EditBox:_LineLog2Phys(logicalLine, pos)
 	local px, py = pos, 0
 	if self.multiline then

--- a/libs/chiliui/chili/controls/editbox.lua
+++ b/libs/chiliui/chili/controls/editbox.lua
@@ -11,7 +11,7 @@
 -- @string[opt = "left"] align alignment
 -- @string[opt = "linecenter"] valign vertical alignment
 -- @string[opt = ""] text text contained in the editbox
--- @string[opt = ""] hint hint to be displayed when there is no text and the control isn't focused
+-- @string[opt = ""] hint hint to be displayed when there is no text
 -- @int[opt = 1] cursor cursor position
 -- @bool passwordInput specifies whether the text should be treated as a password
 EditBox = Control:Inherit{

--- a/libs/chiliui/chili/headers/skinutils.lua
+++ b/libs/chiliui/chili/headers/skinutils.lua
@@ -613,7 +613,7 @@ function DrawEditBox(obj)
 	local font = _GetControlFont(obj)
 	local displayHint = false
 
-	if text == "" and not obj.state.focused then
+	if text == "" then
 		text = obj.hint
 		displayHint = true
 		font = obj.hintFont


### PR DESCRIPTION
Improved search and usability in the map list. Specifically:

+ Filter field now searches map name, dimensions (wxh string), type and terrain
+ Filter is split into space separated terms and each term applied sequentially as AND (all terms must match). This is intended to be an intuitive way to use search.
+ Filter field has initial focus
+ Pressing enter selects the top map
+ Hint text always shown in focused controls when there is no user text
+ Fixed bug where the contents of the list weren't reset after filtering, closing and opening the list (because setText doesn't fire change event).