### PR TITLE
Improve performance of initial map list display

### DIFF
--- a/LuaMenu/widgets/api_featured_maps.lua
+++ b/LuaMenu/widgets/api_featured_maps.lua
@@ -33,11 +33,34 @@ local function ToMapType(mapItem)
 	return "Special"
 end
 
+local function ToTerrainType(mapItem)
+	if mapItem.WaterLevel == 3 then
+		return "Sea"
+	end
+	local first
+	if mapItem.Hills == 1 then
+		first = "Flat "
+	elseif mapItem.Hills == 2 then
+		first = "Hilly "
+	else
+		first = "Mountainous "
+	end
+	local second
+	if mapItem.WaterLevel == 1 then
+		second = "land"
+	else
+		second = "mixed"
+	end
+
+	return first .. second
+end
+
 local function InitMapItems()
 	if not mapItems then
 		mapItems = WG.CommunityWindow and WG.CommunityWindow.LoadStaticCommunityData().MapItems or {}
 		for i = 1, #mapItems do
 			mapItems[i].MapType = ToMapType(mapItems[i])
+			mapItems[i].TerrainType = ToTerrainType(mapItems[i])
 		end
 	end
 end

--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -3,6 +3,7 @@ Configuration = LCS.class{}
 VFS.Include("libs/liblobby/lobby/json.lua")
 
 LIB_LOBBY_DIRNAME = "libs/liblobby/lobby/"
+MINIMAP_THUMB_DOWNLOAD_DIR = "LuaMenu/Images/MinimapThumbnails"
 
 
 -- all configuration attribute changes should use the :Set*Attribute*() and :Get*Attribute*() methods in order to assure proper functionality
@@ -281,7 +282,7 @@ function Configuration:init()
 
 	self.animate_lobby = (gl.CreateShader ~= nil)
 	self.minimapDownloads = {}
-	self.minimapThumbDownloads = {}
+	self.minimapDownloadStarted = {}
 	self.downloadRetryCount = 3
 
 	local saneCharacterList = {
@@ -728,23 +729,25 @@ function Configuration:AllowNotification(playerName, playerList)
 end
 
 function Configuration:GetMinimapSmallImage(mapName)
-	if not self.gameConfig.minimapThumbnailPath then
-		return LUA_DIRNAME .. "images/minimapNotFound1.png"
-	end
 	mapName = string.gsub(mapName, " ", "_")
+
 	local filePath = self.gameConfig.minimapThumbnailPath .. mapName .. ".png"
-	if not VFS.FileExists(filePath) then
-		filePath = "LuaMenu/Images/MinimapThumbnails" .. mapName .. ".jpg"
+	if VFS.FileExists(filePath) then
+		return filePath, false
 	end
-	if WG.WrapperLoopback and WG.WrapperLoopback.DownloadImage and (not VFS.FileExists(filePath)) then
-		if not self.minimapThumbDownloads[mapName] then
-			Spring.CreateDir("LuaMenu/Images/MinimapThumbnails")
-			WG.WrapperLoopback.DownloadImage({ImageUrl = "http://zero-k.info/Resources/" .. mapName .. ".thumbnail.jpg", TargetPath = filePath})
-			self.minimapThumbDownloads[mapName] = true
-		end
-		return filePath, true
+
+	filePath = MINIMAP_THUMB_DOWNLOAD_DIR .. mapName .. ".jpg"
+	if VFS.FileExists(filePath) then
+		return filePath, false
 	end
-	return filePath
+
+	if not self.minimapDownloadStarted[mapName] and WG.WrapperLoopback and WG.WrapperLoopback.DownloadImage then
+		Spring.CreateDir(MINIMAP_THUMB_DOWNLOAD_DIR)
+		WG.WrapperLoopback.DownloadImage({ImageUrl = "http://zero-k.info/Resources/" .. mapName .. ".thumbnail.jpg", TargetPath = filePath})
+		self.minimapDownloadStarted[mapName] = true
+	end
+
+	return filePath, true
 end
 
 function Configuration:GetMinimapImage(mapName)

--- a/LuaMenu/widgets/gui_maplist_panel.lua
+++ b/LuaMenu/widgets/gui_maplist_panel.lua
@@ -156,7 +156,13 @@ local function InitializeControls()
 	--Spring.Echo("LuaMenu KB", lmkb, "allocs", lmalloc, "Lua global KB", lgkb, "allocs", lgalloc)
 
 	wgChobbyConfig = WG.Chobby.Configuration
-	listFont = Font:New(wgChobbyConfig:GetFont(2))
+
+	-- Sharing font saves about 20%, but getting the config for the TextBox font isn't straightforward.
+	local fontSpec = wgChobbyConfig:GetFont(2)
+	local sacrificialTextBox = TextBox:New({})
+	fontSpec.font = sacrificialTextBox.font.font
+	sacrificialTextBox:Dispose()
+	listFont = Font:New(fontSpec)
 
 	local mapListWindow = Window:New {
 		classname = "main_window",

--- a/LuaMenu/widgets/gui_maplist_panel.lua
+++ b/LuaMenu/widgets/gui_maplist_panel.lua
@@ -16,6 +16,8 @@ end
 
 local mapListWindow
 local lobby
+local wgChobbyConfig
+local listFont
 local IMG_READY    = LUA_DIRNAME .. "images/ready.png"
 local IMG_UNREADY  = LUA_DIRNAME .. "images/unready.png"
 
@@ -24,9 +26,6 @@ local IMG_UNREADY  = LUA_DIRNAME .. "images/unready.png"
 -- Utilities
 
 local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"Name":"2_Mountains_Battlefield","SupportLevel":2,"Width":16,"Height":16,"IsAssymetrical":false,"Hills":2,"WaterLevel":1,"Is1v1":false,"IsTeams":true,"IsFFA":false,"IsChickens":false,"FFAMaxTeams":null,"RatingCount":3,"RatingSum":10,"IsSpecial":false},
-	local Configuration = WG.Chobby.Configuration
-	local fontSize = Configuration:GetFont(2).size
-
 	local mapButton = Button:New {
 		classname = "button_rounded",
 		x = 0,
@@ -54,7 +53,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 		parent = mapButton,
 	}
 
-	local mapImageFile, needDownload = Configuration:GetMinimapSmallImage(mapName)
+	local mapImageFile, needDownload = wgChobbyConfig:GetMinimapSmallImage(mapName)
 	Image:New {
 		name = "minimapImage",
 		x = 0,
@@ -63,7 +62,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 		bottom = 0,
 		keepAspect = true,
 		file = mapImageFile,
-		fallbackFile = (needDownload and Configuration:GetLoadingImage(2)) or nil,
+		fallbackFile = (needDownload and wgChobbyConfig:GetLoadingImage(2)) or nil,
 		checkFileExists = needDownload,
 		parent = minimap,
 	}
@@ -74,7 +73,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 		width = 200,
 		height = 20,
 		valign = 'center',
-		fontsize = fontSize,
+		objectOverrideFont = listFont,
 		text = mapName:gsub("_", " "),
 		parent = mapButton,
 	}
@@ -101,7 +100,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 			width = 68,
 			height = 20,
 			valign = 'center',
-			fontsize = fontSize,
+			objectOverrideFont = listFont,
 			text = mapSizeText,
 			parent = mapButton,
 		}
@@ -112,7 +111,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 			width = 68,
 			height = 20,
 			valign = 'center',
-			fontsize = fontSize,
+			objectOverrideFont = listFont,
 			text = mapType,
 			parent = mapButton,
 		}
@@ -123,7 +122,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 			width = 160,
 			height = 20,
 			valign = 'center',
-			fontsize = fontSize,
+			objectOverrideFont = listFont,
 			text = terrainType,
 			parent = mapButton,
 		}
@@ -156,7 +155,8 @@ local function InitializeControls()
 	--local lmkb, lmalloc, lgkb, lgalloc = Spring.GetLuaMemUsage()
 	--Spring.Echo("LuaMenu KB", lmkb, "allocs", lmalloc, "Lua global KB", lgkb, "allocs", lgalloc)
 
-	local Configuration = WG.Chobby.Configuration
+	wgChobbyConfig = WG.Chobby.Configuration
+	listFont = Font:New(wgChobbyConfig:GetFont(2))
 
 	local mapListWindow = Window:New {
 		classname = "main_window",
@@ -174,7 +174,7 @@ local function InitializeControls()
 		y = 17,
 		height = 20,
 		parent = mapListWindow,
-		font = Configuration:GetFont(3),
+		font = wgChobbyConfig:GetFont(3),
 		caption = "Select a Map",
 	}
 
@@ -253,7 +253,7 @@ local function InitializeControls()
 		mapItems[#mapItems + 1] = {mapName, control, sortData}
 	end
 
-	if not Configuration.onlyShowFeaturedMaps then
+	if not wgChobbyConfig.onlyShowFeaturedMaps then
 		for i, archive in pairs(VFS.GetAllArchives()) do
 			local info = VFS.GetArchiveInfo(archive)
 			if info and info.modtype == 3 and not mapFuncs[info.name] then
@@ -275,7 +275,7 @@ local function InitializeControls()
 		width = 80,
 		height = 45,
 		caption = i18n("close"),
-		font = Configuration:GetFont(3),
+		font = wgChobbyConfig:GetFont(3),
 		classname = "negative_button",
 		parent = mapListWindow,
 		OnClick = {
@@ -285,19 +285,19 @@ local function InitializeControls()
 		},
 	}
 
-	if Configuration.gameConfig.link_maps ~= nil then
+	if wgChobbyConfig.gameConfig.link_maps ~= nil then
 		local btnOnlineMaps = Button:New {
 			right = 98,
 			y = 7,
 			width = 180,
 			height = 45,
 			caption = i18n("download_maps"),
-			font = Configuration:GetFont(3),
+			font = wgChobbyConfig:GetFont(3),
 			classname = "option_button",
 			parent = mapListWindow,
 			OnClick = {
 				function ()
-					WG.BrowserHandler.OpenUrl(Configuration.gameConfig.link_maps())
+					WG.BrowserHandler.OpenUrl(wgChobbyConfig.gameConfig.link_maps())
 				end
 			},
 		}
@@ -315,7 +315,7 @@ local function InitializeControls()
 		height = 33,
 		text = '',
 		hint = i18n("type_to_filter"),
-		fontsize = Configuration:GetFont(2).size,
+		fontsize = wgChobbyConfig:GetFont(2).size,
 		parent = mapListWindow,
 		OnKeyPress = {
 			function(obj, key, ...)
@@ -360,7 +360,7 @@ local function InitializeControls()
 	function externalFunctions.UpdateHaveMap(thingName)
 		if mapFuncs[thingName] then
 			mapFuncs[thingName].UpdateHaveMap()
-		elseif not Configuration.onlyShowFeaturedMaps and VFS.HasArchive(thingName) then
+		elseif not wgChobbyConfig.onlyShowFeaturedMaps and VFS.HasArchive(thingName) then
 			local info = VFS.GetArchiveInfo(thingName)
 			if info and info.modtype == 3 and not mapFuncs[info.name] then
 				local control, sortData

--- a/LuaMenu/widgets/gui_maplist_panel.lua
+++ b/LuaMenu/widgets/gui_maplist_panel.lua
@@ -23,30 +23,9 @@ local IMG_UNREADY  = LUA_DIRNAME .. "images/unready.png"
 --------------------------------------------------------------------------------
 -- Utilities
 
-local function GetTerrainType(hillLevel, waterLevel)
-	if waterLevel == 3 then
-		return "Sea"
-	end
-	local first
-	if hillLevel == 1 then
-		first = "Flat "
-	elseif hillLevel == 2 then
-		first = "Hilly "
-	else
-		first = "Mountainous "
-	end
-	local second
-	if waterLevel == 1 then
-		second = "land"
-	else
-		second = "mixed"
-	end
-
-	return first .. second
-end
-
 local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"Name":"2_Mountains_Battlefield","SupportLevel":2,"Width":16,"Height":16,"IsAssymetrical":false,"Hills":2,"WaterLevel":1,"Is1v1":false,"IsTeams":true,"IsFFA":false,"IsChickens":false,"FFAMaxTeams":null,"RatingCount":3,"RatingSum":10,"IsSpecial":false},
 	local Configuration = WG.Chobby.Configuration
+	local fontSize = Configuration:GetFont(2).size
 
 	local mapButton = Button:New {
 		classname = "button_rounded",
@@ -71,12 +50,12 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 		y = 3,
 		width = 52,
 		height = 52,
-		padding = {1,1,1,1},
+		padding = {1, 1, 1, 1},
 		parent = mapButton,
 	}
 
 	local mapImageFile, needDownload = Configuration:GetMinimapSmallImage(mapName)
-	local minimapImage = Image:New {
+	Image:New {
 		name = "minimapImage",
 		x = 0,
 		y = 0,
@@ -84,7 +63,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 		bottom = 0,
 		keepAspect = true,
 		file = mapImageFile,
-		fallbackFile = Configuration:GetLoadingImage(2),
+		fallbackFile = (needDownload and Configuration:GetLoadingImage(2)) or nil,
 		checkFileExists = needDownload,
 		parent = minimap,
 	}
@@ -95,7 +74,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 		width = 200,
 		height = 20,
 		valign = 'center',
-		fontsize = Configuration:GetFont(2).size,
+		fontsize = fontSize,
 		text = mapName:gsub("_", " "),
 		parent = mapButton,
 	}
@@ -113,6 +92,8 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 	local sortData
 	if mapData then
 		local mapSizeText = (mapData.Width or " ?") .. "x" .. (mapData.Height or " ?")
+		local mapType = mapData.MapType
+		local terrainType = mapData.TerrainType
 
 		TextBox:New {
 			x = 274,
@@ -120,7 +101,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 			width = 68,
 			height = 20,
 			valign = 'center',
-			fontsize = Configuration:GetFont(2).size,
+			fontsize = fontSize,
 			text = mapSizeText,
 			parent = mapButton,
 		}
@@ -131,24 +112,23 @@ local function CreateMapEntry(mapName, mapData, CloseFunc)--{"ResourceID":7098,"
 			width = 68,
 			height = 20,
 			valign = 'center',
-			fontsize = Configuration:GetFont(2).size,
-			text = mapData.MapType,
+			fontsize = fontSize,
+			text = mapType,
 			parent = mapButton,
 		}
 
-		local terrainType = GetTerrainType(mapData.Hills, mapData.WaterLevel)
 		TextBox:New {
 			x = 438,
 			y = 12,
 			width = 160,
 			height = 20,
 			valign = 'center',
-			fontsize = Configuration:GetFont(2).size,
+			fontsize = fontSize,
 			text = terrainType,
 			parent = mapButton,
 		}
 
-		sortData = {string.lower(mapName), (mapData.Width or 0)*100 + (mapData.Height or 0), string.lower(mapData.MapType), string.lower(terrainType), (haveMap and 1) or 0}
+		sortData = {string.lower(mapName), (mapData.Width or 0)*100 + (mapData.Height or 0), string.lower(mapType), string.lower(terrainType), (haveMap and 1) or 0}
 		sortData[6] = sortData[1] .. " " .. mapSizeText .. " " .. sortData[3] .. " " .. sortData[4] -- Used for text filter by name, type, terrain or size.
 	else
 		sortData = {string.lower(mapName), 0, "", "", (haveMap and 1) or 0}

--- a/libs/chiliui/chili/controls/control.lua
+++ b/libs/chiliui/chili/controls/control.lua
@@ -120,13 +120,13 @@ function Control:New(obj)
 
 	if obj._hasCustomDrawControl then
 		if not obj.drawcontrolv2 then
-	local w = obj._widget or {whInfo = { name = "unknown" } }
-	local fmtStr = [[You are using a custom %s::DrawControl in widget "%s".
-	Please note that with Chili 2.1 the (self.x, self.y) translation is moved a level up and does not need to be done in DrawControl anymore.
-	When you adjusted your code set `drawcontrolv2 = true` in the respective control to disable this message.]]
-	Spring.Log("Chili", "warning", fmtStr:format(obj.name, w.whInfo.name))
+			local w = obj._widget or {whInfo = { name = "unknown" } }
+			local fmtStr = [[You are using a custom %s::DrawControl in widget "%s".
+			Please note that with Chili 2.1 the (self.x, self.y) translation is moved a level up and does not need to be done in DrawControl anymore.
+			When you adjusted your code set `drawcontrolv2 = true` in the respective control to disable this message.]]
+			Spring.Log("Chili", "warning", fmtStr:format(obj.name, w.whInfo.name))
 		else
-	obj._hasCustomDrawControl = false
+			obj._hasCustomDrawControl = false
 		end
 	end
 

--- a/libs/chiliui/chili/controls/control.lua
+++ b/libs/chiliui/chili/controls/control.lua
@@ -268,79 +268,42 @@ end
 
 
 function Control:DetectRelativeBounds()
-	--// we need min 2 x-dim coords to define a rect!
-	local numconstraints = 0
-	if (self.x) then
-		numconstraints = numconstraints + 1
+	--// we need min 2 x/y specifiers to define a rect!
+	local x, right, width, y, bottom, height = self.x, self.right, self.width, self.y, self.bottom, self.height
+	if not width and (not x and not right) then
+		width = self.defaultWidth or 0
+		x = x or (not right and 0 or nil)
 	end
-	if (self.right) then
-		numconstraints = numconstraints + 1
-	end
-	if (self.width) then
-		numconstraints = numconstraints + 1
-	end
-	if (numconstraints < 2) then
-		if (numconstraints == 0) then
-			self.x = 0
-			self.width = self.defaultWidth or 0
-		else
-			if (self.width) then
-				self.x = 0
-			else
-				self.width = self.defaultWidth or 0
-			end
-		end
-	end
-
-	--// we need min 2 y-dim coords to define a rect!
-	numconstraints = 0
-	if (self.y) then
-		numconstraints = numconstraints + 1
-	end
-	if (self.bottom) then
-		numconstraints = numconstraints + 1
-	end
-	if (self.height) then
-		numconstraints = numconstraints + 1
-	end
-	if (numconstraints < 2) then
-		if (numconstraints == 0) then
-			self.y = 0
-			self.height = self.defaultHeight or 0
-		else
-			if (self.height) then
-				self.y = 0
-			else
-				self.height = self.defaultHeight or 0
-			end
-		end
+	if not height and (not self.y and not bottom) then
+		height = self.defaultHeight or 0
+		y = y or (not bottom and 0 or nil)
 	end
 
 	--// check which constraints are relative
 	self._givenBounds  = {
-		left   = self.x,
-		top    = self.y,
-		width  = self.width,
-		height = self.height,
-		right  = self.right,
-		bottom = self.bottom,
+		left   = x,
+		top    = y,
+		width  = width,
+		height = height,
+		right  = right,
+		bottom = bottom,
 	}
 	local rb = {
-		left   = IsRelativeCoord(self.x) and self.x,
-		top    = IsRelativeCoord(self.y) and self.y,
-		width  = IsRelativeCoord(self.width) and self.width,
-		height = IsRelativeCoord(self.height) and self.height,
-		right  = self.right,
-		bottom = self.bottom,
+		left   = IsRelativeCoord(x) and x,
+		top    = IsRelativeCoord(y) and y,
+		width  = IsRelativeCoord(width) and width,
+		height = IsRelativeCoord(height) and height,
+		right  = right,
+		bottom = bottom,
 	}
 	self._relativeBounds = rb
 	self._isRelative = (rb.left or rb.top or rb.width or rb.height or rb.right or rb.bottom) and (true)
 
 	--// initialize relative constraints with 0
-	self.x = ((not rb.left) and self.x) or 0
-	self.y = ((not rb.top)  and self.y) or 0
-	self.width  = ((not rb.width) and self.width) or 0
-	self.height = ((not rb.height) and self.height) or 0
+	self.x = ((not rb.left) and x) or 0
+	self.y = ((not rb.top)  and y) or 0
+	self.width  = ((not rb.width) and width) or 0
+	self.height = ((not rb.height) and height) or 0
 	--self.right  = (type(self.right) == 'number') and (self.right > 0) and (self.right) or 0
 	--self.bottom = (type(self.bottom) == 'number') and (self.bottom > 0) and (self.bottom) or 0
 end

--- a/libs/chiliui/chili/controls/editbox.lua
+++ b/libs/chiliui/chili/controls/editbox.lua
@@ -131,7 +131,7 @@ local function explode(div, str)
 		elseif c == div then
 			arr[#arr + 1] = str:sub(i, j - 1)
 			i = j + 1
-      j = i
+			j = i
 		else
 			j = j + 1
 		end

--- a/libs/chiliui/chili/controls/editbox.lua
+++ b/libs/chiliui/chili/controls/editbox.lua
@@ -2,6 +2,8 @@
 
 --- EditBox module
 
+local spGetTimer = Spring.GetTimer
+
 --- EditBox fields.
 -- Inherits from Control.
 -- @see control.Control
@@ -81,10 +83,14 @@ local inherited = this.inherited
 
 function EditBox:New(obj)
 	obj = inherited.New(self, obj)
-	obj._interactedTime = Spring.GetTimer()
+	obj._interactedTime = spGetTimer()
 		--// create font
-	obj.hintFont = Font:New(obj.hintFont)
-	obj.hintFont:SetParent(obj)
+	if obj.hint then
+		obj.hintFont = Font:New(obj.hintFont)
+		obj.hintFont:SetParent(obj)
+	else
+	  obj.hintFont = false
+	end
 	local text = obj.text
 	obj.text = nil
 	obj:SetText(text)
@@ -92,8 +98,10 @@ function EditBox:New(obj)
 end
 
 function EditBox:Dispose(...)
+	if self.hintFont then
+		self.hintFont:SetParent()
+	end
 	Control.Dispose(self)
-	self.hintFont:SetParent()
 end
 
 function EditBox:HitTest(x, y)

--- a/libs/chiliui/chili/controls/editbox.lua
+++ b/libs/chiliui/chili/controls/editbox.lua
@@ -88,8 +88,6 @@ function EditBox:New(obj)
 	local text = obj.text
 	obj.text = nil
 	obj:SetText(text)
-	obj:RequestUpdate()
-	self._inRequestUpdate = true
 	return obj
 end
 
@@ -111,17 +109,21 @@ local function explode(div, str)
 	local N = str:len()
 
 	while j <= N do
-		local c = str:sub(j, j)
+		local c = str[j]
 		if c == '\255' then
-			j = j + 3
+			j = j + 4
 		elseif c == div then
 			arr[#arr + 1] = str:sub(i, j - 1)
 			i = j + 1
+      j = i
+		else
+			j = j + 1
 		end
-		j = j + 1
 	end
 
-	if i <= N then
+	if i == 1 then
+	  arr[1] = str -- POO
+	elseif i <= N then
 		arr[#arr + 1] = str:sub(i, N)
 	end
 

--- a/libs/chiliui/chili/controls/editbox.lua
+++ b/libs/chiliui/chili/controls/editbox.lua
@@ -2,7 +2,15 @@
 
 --- EditBox module
 
+local spGetClipboard = Spring.GetClipboard
+local spGetKeyCode = Spring.GetKeyCode
+local spGetModKeyState = Spring.GetModKeyState
 local spGetTimer = Spring.GetTimer
+local spLog = Spring.Log
+local spSdlSetTextInputRect = Spring.SDLSetTextInputRect
+local spSdlStartTextInput = Spring.SDLStartTextInput
+local spSdlStopTextInput = Spring.SDLStopTextInput
+local spSetClipboard = Spring.SetClipboard
 
 --- EditBox fields.
 -- Inherits from Control.
@@ -56,21 +64,21 @@ EditBox = Control:Inherit{
 	cursorY = 1,
 
 	inedibleInput = {
-		[Spring.GetKeyCode("enter")] = true,
-		[Spring.GetKeyCode("numpad_enter")] = true,
-		[Spring.GetKeyCode("esc")] = true,
-		[Spring.GetKeyCode("f1")] = true,
-		[Spring.GetKeyCode("f2")] = true,
-		[Spring.GetKeyCode("f3")] = true,
-		[Spring.GetKeyCode("f4")] = true,
-		[Spring.GetKeyCode("f5")] = true,
-		[Spring.GetKeyCode("f6")] = true,
-		[Spring.GetKeyCode("f7")] = true,
-		[Spring.GetKeyCode("f8")] = true,
-		[Spring.GetKeyCode("f9")] = true,
-		[Spring.GetKeyCode("f10")] = true,
-		[Spring.GetKeyCode("f11")] = true,
-		[Spring.GetKeyCode("f12")] = true,
+		[spGetKeyCode("enter")] = true,
+		[spGetKeyCode("numpad_enter")] = true,
+		[spGetKeyCode("esc")] = true,
+		[spGetKeyCode("f1")] = true,
+		[spGetKeyCode("f2")] = true,
+		[spGetKeyCode("f3")] = true,
+		[spGetKeyCode("f4")] = true,
+		[spGetKeyCode("f5")] = true,
+		[spGetKeyCode("f6")] = true,
+		[spGetKeyCode("f7")] = true,
+		[spGetKeyCode("f8")] = true,
+		[spGetKeyCode("f9")] = true,
+		[spGetKeyCode("f10")] = true,
+		[spGetKeyCode("f11")] = true,
+		[spGetKeyCode("f12")] = true,
 	},
 
 	noFont = false,
@@ -195,8 +203,8 @@ function EditBox:_SetSelection(selStart, selStartY, selEnd, selEndY)
 	self.selEndY   = selEndY         or self.selEndY
 	if selStart or selStartY then
 		if not self.lines[self.selStartY] then
-				Spring.Log("chiliui", LOG.ERROR, "self.lines[self.selStartY] is nil for self.selStartY: " .. tostring(self.selStartY) .. " and #self.lines: " .. tostring(#self.lines))
-				Spring.Log("chiliui", LOG.ERROR, debug.traceback())
+				spLog("chiliui", LOG.ERROR, "self.lines[self.selStartY] is nil for self.selStartY: " .. tostring(self.selStartY) .. " and #self.lines: " .. tostring(#self.lines))
+				spLog("chiliui", LOG.ERROR, debug.traceback())
 		else
 			local logicalLine = self.lines[self.selStartY]
 			self.selStartPhysical, self.selStartPhysicalY = self:_LineLog2Phys(logicalLine, self.selStart)
@@ -205,8 +213,8 @@ function EditBox:_SetSelection(selStart, selStartY, selEnd, selEndY)
 
 	if selEnd or selEndY then
 		if not self.lines[self.selEndY] then
-				Spring.Log("chiliui", LOG.ERROR, "self.lines[self.selEndY] is nil for self.selEndY: " .. tostring(self.selEndY) .. " and #self.lines: " .. tostring(#self.lines))
-				Spring.Log("chiliui", LOG.ERROR, debug.traceback())
+				spLog("chiliui", LOG.ERROR, "self.lines[self.selEndY] is nil for self.selEndY: " .. tostring(self.selEndY) .. " and #self.lines: " .. tostring(#self.lines))
+				spLog("chiliui", LOG.ERROR, debug.traceback())
 		else
 			local logicalLine = self.lines[self.selEndY]
 			self.selEndPhysical, self.selEndPhysicalY  = self:_LineLog2Phys(logicalLine, self.selEnd)
@@ -509,14 +517,14 @@ function EditBox:__GetStartX(text)
 end
 
 function EditBox:FocusUpdate(...)
-	if Spring.SDLStartTextInput and self.useSDLStartTextInput then
+	if spSdlStartTextInput and self.useSDLStartTextInput then
 		if not self.state.focused then
 			self.textEditing = ""
-			Spring.SDLStopTextInput()
+			spSdlStopTextInput()
 		else
-			Spring.SDLStartTextInput()
+			spSdlStartTextInput()
 			local x, y = self:CorrectlyImplementedLocalToScreen(self.x, self.y)
-			Spring.SDLSetTextInputRect(x, y, 30, 1000)
+			spSdlSetTextInputRect(x, y, 30, 1000)
 		end
 	end
 	self:InvalidateSelf()
@@ -655,7 +663,7 @@ function EditBox:MouseDown(x, y, ...)
 				for _, f in pairs(OnTextClick.OnTextClick) do
 					f(self, cx, cy, ...)
 				end
-				self._interactedTime = Spring.GetTimer()
+				self._interactedTime = spGetTimer()
 				inherited.MouseDown(self, x, y, ...)
 				self:Invalidate()
 				return self
@@ -666,7 +674,7 @@ function EditBox:MouseDown(x, y, ...)
 	if not self.selectable then
 		return false
 	end
-	local _, _, _, shift = Spring.GetModKeyState()
+	local _, _, _, shift = spGetModKeyState()
 	local cp, cpy = self.cursor, self.cursorY
 	self:_SetCursorByMousePos(x, y)
 	if shift then
@@ -681,7 +689,7 @@ function EditBox:MouseDown(x, y, ...)
 		self.selEndY = nil
 	end
 
-	self._interactedTime = Spring.GetTimer()
+	self._interactedTime = spGetTimer()
 	inherited.MouseDown(self, x, y, ...)
 	self:Invalidate()
 	return self
@@ -718,7 +726,7 @@ function EditBox:MouseMove(x, y, dx, dy, button)
 		return self
 	end
 	
-	local _, _, _, shift = Spring.GetModKeyState()
+	local _, _, _, shift = spGetModKeyState()
 	local cp, cpy = self.cursor, self.cursorY
 	self:_SetCursorByMousePos(x, y)
 	if not self.selStart then
@@ -727,7 +735,7 @@ function EditBox:MouseMove(x, y, dx, dy, button)
 	self:_SetSelection(nil, nil, self.cursor, self.cursorY)
 	--Spring.Echo(self:GetSelectionText())
 
-	self._interactedTime = Spring.GetTimer()
+	self._interactedTime = spGetTimer()
 	inherited.MouseMove(self, x, y, dx, dy, button)
 	self:Invalidate()
 	return self
@@ -827,7 +835,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 	local eatInput = true
 
 	-- deletions
-	if key == Spring.GetKeyCode("backspace") and self.editable then
+	if key == spGetKeyCode("backspace") and self.editable then
 		if self.selStart == nil then
 			if mods.ctrl then
 				repeat
@@ -840,7 +848,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 		else
 			self:ClearSelected()
 		end
-	elseif key == Spring.GetKeyCode("delete") and self.editable then
+	elseif key == spGetKeyCode("delete") and self.editable then
 		if self.selStart == nil then
 			if mods.ctrl then
 				repeat
@@ -858,7 +866,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 
 	-- TODO: Fix cursor movement for multiline
 	-- cursor movement
-	elseif key == Spring.GetKeyCode("left") and not self.multiline then
+	elseif key == spGetKeyCode("left") and not self.multiline then
 		if mods.ctrl then
 			repeat
 				self.cursor = Utf8PrevChar(txt, self.cursor)
@@ -866,7 +874,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 		else
 			self.cursor = Utf8PrevChar(txt, cp)
 		end
-	elseif key == Spring.GetKeyCode("right") and not self.multiline then
+	elseif key == spGetKeyCode("right") and not self.multiline then
 		if mods.ctrl then
 			repeat
 				self.cursor = Utf8NextChar(txt, self.cursor)
@@ -874,26 +882,26 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 		else
 			self.cursor = Utf8NextChar(txt, cp)
 		end
-	elseif key == Spring.GetKeyCode("home") and not self.multiline then
+	elseif key == spGetKeyCode("home") and not self.multiline then
 		self.cursor = 1
-	elseif key == Spring.GetKeyCode("end") and not self.multiline then
+	elseif key == spGetKeyCode("end") and not self.multiline then
 		self.cursor = #txt + 1
 
 	-- copy & paste
-	elseif (mods.ctrl and key == Spring.GetKeyCode("c")) or (mods.ctrl and key == Spring.GetKeyCode("insert")) or
-		(self.editable and ((mods.ctrl and key == Spring.GetKeyCode("x")) or (mods.shift and key == Spring.GetKeyCode("delete")))) then
+	elseif (mods.ctrl and key == spGetKeyCode("c")) or (mods.ctrl and key == spGetKeyCode("insert")) or
+		(self.editable and ((mods.ctrl and key == spGetKeyCode("x")) or (mods.shift and key == spGetKeyCode("delete")))) then
 		txt = self:GetSelectionText()
 		if self.selStart and self.selEnd then
-			Spring.SetClipboard(txt)
-			if key == Spring.GetKeyCode("x") or key == Spring.GetKeyCode("delete") then
+			spSetClipboard(txt)
+			if key == spGetKeyCode("x") or key == spGetKeyCode("delete") then
 				self:ClearSelected()
 			end
 		end
-	elseif ((mods.ctrl and key == Spring.GetKeyCode("v")) or (mods.shift and key == Spring.GetKeyCode("insert"))) and self.editable then
-		self:TextInput(Spring.GetClipboard())
+	elseif ((mods.ctrl and key == spGetKeyCode("v")) or (mods.shift and key == spGetKeyCode("insert"))) and self.editable then
+		self:TextInput(spGetClipboard())
 
 	-- select all
-	elseif mods.ctrl and key == Spring.GetKeyCode("a") then
+	elseif mods.ctrl and key == spGetKeyCode("a") then
 		if not self.multiline then
 			self:_SetSelection(1, 1, #txt + 1, 1)
 		else
@@ -904,7 +912,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 	end
 
 	-- text selection handling
-	if key == Spring.GetKeyCode("left") or key == Spring.GetKeyCode("right") or key == Spring.GetKeyCode("home") or key == Spring.GetKeyCode("end") then
+	if key == spGetKeyCode("left") or key == spGetKeyCode("right") or key == spGetKeyCode("home") or key == spGetKeyCode("end") then
 		if mods.shift then
 			if not self.selStart then
 				self:_SetSelection(cp, cpy, nil, nil)
@@ -918,7 +926,7 @@ function EditBox:KeyPress(key, mods, isRepeat, label, unicode, ...)
 		end
 	end
 
-	self._interactedTime = Spring.GetTimer()
+	self._interactedTime = spGetTimer()
 	eatInput = inherited.KeyPress(self, key, mods, isRepeat, label, unicode, ...) or eatInput
 	self:UpdateLayout()
 	self:Invalidate()
@@ -946,7 +954,7 @@ function EditBox:TextInput(utf8char, ...)
 		self.cursor = cp + unicode:len()
 	end
 
-	self._interactedTime = Spring.GetTimer()
+	self._interactedTime = spGetTimer()
 	inherited.TextInput(self, utf8char, ...)
 	inherited.TextModified(self, utf8char, ...)
 	self:UpdateLayout()

--- a/libs/chiliui/chili/controls/object.lua
+++ b/libs/chiliui/chili/controls/object.lua
@@ -110,18 +110,20 @@ function Object:New(obj)
 	for i, v in pairs(self) do --// `self` means the class here and not the instance!
 		if (i ~= "inherited") then
 			local t = type(v)
-			local ot = type(obj[i])
+			local ov = obj[i]
 			if (t == "table") or (t == "metatable") then
-				if (ot == "nil") then
-					obj[i] = {};
-					ot = "table";
-				end
-				if (ot ~= "table") and (ot ~= "metatable") then
-					Spring.Echo("Chili: " .. obj.name .. ": Wrong param type given to " .. i .. ": got " .. ot .. " expected table.")
-					obj[i] = {}
+				if (ov == nil) then
+					obj[i] = table.deepcopy(v)
+				else
+					local ot = type(ov)
+					if (ot ~= "table") and (ot ~= "metatable") then
+						Spring.Echo("Chili: " .. obj.name .. ": Wrong param type given to " .. i .. ": got " .. ot .. " expected table.")
+						obj[i] = table.deepcopy(v)
+					else
+						obj[i] = table.merge(ov, v)
+					end
 				end
 
-				table.merge(obj[i], v)
 				if (t == "metatable") then
 					setmetatable(obj[i], getmetatable(v))
 				end

--- a/libs/chiliui/chili/controls/object.lua
+++ b/libs/chiliui/chili/controls/object.lua
@@ -110,21 +110,22 @@ function Object:New(obj)
 	for i, v in pairs(self) do --// `self` means the class here and not the instance!
 		if (i ~= "inherited") then
 			local t = type(v)
-			local ov = obj[i]
-			if (t == "table") or (t == "metatable") then
+		  local vIsTable, vIsMetatable = t == 'table', t == 'metatable'
+			if vIsTable or vIsMetatable then
+				local ov = obj[i]
 				if (ov == nil) then
 					obj[i] = table.deepcopy(v)
 				else
 					local ot = type(ov)
-					if (ot ~= "table") and (ot ~= "metatable") then
+					if (ot == 'table') or (ot == 'metatable') then
+						obj[i] = table.merge(ov, v)
+					else
 						Spring.Echo("Chili: " .. obj.name .. ": Wrong param type given to " .. i .. ": got " .. ot .. " expected table.")
 						obj[i] = table.deepcopy(v)
-					else
-						obj[i] = table.merge(ov, v)
 					end
 				end
 
-				if (t == "metatable") then
+				if (vIsMetatable) then
 					setmetatable(obj[i], getmetatable(v))
 				end
 			-- We don't need to copy other types (allegedly)

--- a/libs/chiliui/chili/controls/object.lua
+++ b/libs/chiliui/chili/controls/object.lua
@@ -110,7 +110,7 @@ function Object:New(obj)
 	for i, v in pairs(self) do --// `self` means the class here and not the instance!
 		if (i ~= "inherited") then
 			local t = type(v)
-		  local vIsTable, vIsMetatable = t == 'table', t == 'metatable'
+			local vIsTable, vIsMetatable = t == 'table', t == 'metatable'
 			if vIsTable or vIsMetatable then
 				local ov = obj[i]
 				if (ov == nil) then

--- a/libs/chiliui/chili/controls/textbox.lua
+++ b/libs/chiliui/chili/controls/textbox.lua
@@ -21,6 +21,7 @@ TextBox = EditBox:Inherit{
 	selectable = false,
 	multiline = true,
 	noFont = false,
+	hint = false,
 
 	borderColor     = {0, 0, 0, 0},
 	focusColor      = {0, 0, 0, 0},

--- a/libs/chiliui/chili/headers/skinutils.lua
+++ b/libs/chiliui/chili/headers/skinutils.lua
@@ -613,7 +613,7 @@ function DrawEditBox(obj)
 	local font = _GetControlFont(obj)
 	local displayHint = false
 
-	if text == "" then
+	if text == "" and obj.hint then
 		text = obj.hint
 		displayHint = true
 		font = obj.hintFont

--- a/libs/chiliui/chili/headers/util.lua
+++ b/libs/chiliui/chili/headers/util.lua
@@ -322,8 +322,7 @@ end
 function table:deepcopy()
 	local newTable = {}
 	for k, v in pairs(self) do
-		local t = type(v)
-		if t == 'table' then
+		if type(v) == 'table' then
 			newTable[k] = table.deepcopy(v)
 		else
 			newTable[k] = v

--- a/libs/chiliui/chili/headers/util.lua
+++ b/libs/chiliui/chili/headers/util.lua
@@ -319,6 +319,19 @@ function table:shallowcopy()
 	return newTable
 end
 
+function table:deepcopy()
+	local newTable = {}
+	for k, v in pairs(self) do
+		local t = type(v)
+		if t == 'table' then
+			newTable[k] = table.deepcopy(v)
+		else
+			newTable[k] = v
+		end
+	end
+	return newTable
+end
+
 function table:arrayshallowcopy()
 	local newArray = {}
 	for i = 1, #self do
@@ -382,14 +395,14 @@ end
 
 function table:merge(table2)
 	for i, v in pairs(table2) do
-		if (type(v) == 'table') then
-			local sv = type(self[i])
-			if (sv == 'table') or (sv == 'nil') then
-				if (sv == 'nil') then self[i] = {} end
-				table.merge(self[i], v)
-			end
-		elseif (self[i] == nil) then
-			self[i] = v
+		local vIsTable = type(v) == 'table'
+		local sv = self[i]
+    if sv == nil and vIsTable then
+			self[i] = table.deepcopy(v)
+		elseif vIsTable and type(sv) == 'table' then
+			table.merge(sv, v)
+		else
+		  self[i] = sv or v
 		end
 	end
 	return self

--- a/libs/chiliui/chili/headers/util.lua
+++ b/libs/chiliui/chili/headers/util.lua
@@ -64,26 +64,10 @@ end
 
 function IsRelativeCoord(code)
 	local num = tonumber(code)
-
-	if (type(code) == "string") then
-		return true
-	elseif (num) and ((1/num) < 0) then
-		return true
-	else
+	if num and ((1/num) < 0) then
 		return false
 	end
-end
-
-function IsRelativeCoordType(code)
-	local num = tonumber(code)
-
-	if (type(code) == "string") then
-		return "relative"
-	elseif (num) and ((1/num) < 0) then
-		return "negative"
-	else
-		return "default"
-	end
+	return type(code) == "string"
 end
 
 --// =============================================================================
@@ -91,7 +75,6 @@ end
 function IsObject(v)
 	return ((type(v) == "metatable") or (type(v) == "userdata")) and (v.classname)
 end
-
 
 function IsNumber(v)
 	return (type(v) == "number")

--- a/libs/chiliui/chili/headers/util.lua
+++ b/libs/chiliui/chili/headers/util.lua
@@ -394,14 +394,15 @@ end
 
 function table:merge(table2)
 	for i, v in pairs(table2) do
-		local vIsTable = type(v) == 'table'
 		local sv = self[i]
-    if sv == nil and vIsTable then
-			self[i] = table.deepcopy(v)
-		elseif vIsTable and type(sv) == 'table' then
-			table.merge(sv, v)
-		else
-		  self[i] = sv or v
+		if type(v) == 'table' then
+			if sv == nil then
+				self[i] = table.deepcopy(v)
+			elseif type(sv) == 'table' then
+				self[i] = table.merge(sv, v)
+			end
+		elseif sv == nil then
+			self[i] = v
 		end
 	end
 	return self


### PR DESCRIPTION
I was surprised it took "so long" to show the map list so poked around trying to understand why.

The worst part by far is all the recursive copying that takes place during object init... I was able to make some very small improvements here.

Overall this sped up the time to initial show from 0.72s -> 0.45s. Many of the changes should be of general (small) benefit.

I'll add more comments inline or see the individual commits for details.