### PR TITLE
Modified planet 1,2,3,5 optional objectives to reduce failability.

### DIFF
--- a/campaign/sample/planets/planet1.lua
+++ b/campaign/sample/planets/planet1.lua
@@ -417,8 +417,8 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			bonusObjectiveConfig = {
 				-- Indexed by bonusObjectiveID
-				[1] = { -- Have 3 mex by 1 minute.
-					satisfyByTime = 60,
+				[1] = { -- Have 3 mex
+                    satisfyOnce = true,
 					comparisionType = planetUtilities.COMPARE.AT_LEAST,
 					targetNumber = 3,
 					unitTypes = {
@@ -426,11 +426,11 @@ local function GetPlanet(planetUtilities, planetID)
 					},
 					image = planetUtilities.ICON_DIR .. "staticmex.png",
 					imageOverlay = planetUtilities.ICON_OVERLAY.REPAIR,
-					description = "Have 3 Metal Extractors by 1:00",
+					description = "Have 3 Metal Extractors",
 					experience = planetUtilities.BONUS_EXP,
 				},
-				[2] = { -- Have 3 solar by 2 minute.
-					satisfyByTime = 120,
+				[2] = { -- Have 3 solar
+                    satisfyOnce = true,
 					comparisionType = planetUtilities.COMPARE.AT_LEAST,
 					targetNumber = 3,
 					unitTypes = {
@@ -438,7 +438,7 @@ local function GetPlanet(planetUtilities, planetID)
 					},
 					image = planetUtilities.ICON_DIR .. "energysolar.png",
 					imageOverlay = planetUtilities.ICON_OVERLAY.REPAIR,
-					description = "Have 3 Solar Generators by 2:00",
+					description = "Have 3 Solar Generators",
 					experience = planetUtilities.BONUS_EXP,
 				},
 				[3] = { -- Build a radar
@@ -454,7 +454,20 @@ local function GetPlanet(planetUtilities, planetID)
 					description = "Build a Radar Tower",
 					experience = planetUtilities.BONUS_EXP,
 				},
-				[4] = { -- Build 3 Reavers
+                [4] = { -- Build 10 Glaives
+					satisfyOnce = true,
+					countRemovedUnits = true, -- count units that previously died.
+					comparisionType = planetUtilities.COMPARE.AT_LEAST,
+					targetNumber = 12,
+					unitTypes = {
+						"cloakraid",
+					},
+					image = planetUtilities.ICON_DIR .. "cloakraid.png",
+					imageOverlay = planetUtilities.ICON_OVERLAY.REPAIR,
+					description = "Build 10 more Glaives",
+					experience = planetUtilities.BONUS_EXP,
+				},
+				[5] = { -- Build 3 Reavers
 					satisfyOnce = true,
 					countRemovedUnits = true, -- count units that previously died.
 					comparisionType = planetUtilities.COMPARE.AT_LEAST,
@@ -465,12 +478,6 @@ local function GetPlanet(planetUtilities, planetID)
 					image = planetUtilities.ICON_DIR .. "cloakriot.png",
 					imageOverlay = planetUtilities.ICON_OVERLAY.REPAIR,
 					description = "Build 3 Reavers",
-					experience = planetUtilities.BONUS_EXP,
-				},
-				[5] = {
-					victoryByTime = 480,
-					image = planetUtilities.ICON_OVERLAY.CLOCK,
-					description = "Win by 8:00",
 					experience = planetUtilities.BONUS_EXP,
 				},
 			}

--- a/campaign/sample/planets/planet2.lua
+++ b/campaign/sample/planets/planet2.lua
@@ -406,8 +406,8 @@ local function GetPlanet(planetUtilities, planetID)
 					description = "Build 10 Ronins",
 					experience = planetUtilities.BONUS_EXP,
 				},
-				[4] = { -- Kill enemy Stardusts in 8 minutes.
-					satisfyByTime = 480,
+				[4] = { -- Kill enemy Stardusts
+                    satisfyOnce = true,
 					comparisionType = planetUtilities.COMPARE.AT_MOST,
 					targetNumber = 0,
 					enemyUnitTypes = {
@@ -415,7 +415,7 @@ local function GetPlanet(planetUtilities, planetID)
 					},
 					image = planetUtilities.ICON_DIR .. "turretriot.png",
 					imageOverlay = planetUtilities.ICON_OVERLAY.ATTACK,
-					description = "Find and destroy all 4 enemy Stardust turrets before 8:00",
+					description = "Find and destroy all 4 enemy Stardust turrets",
 					experience = planetUtilities.BONUS_EXP,
 				},
 			},

--- a/campaign/sample/planets/planet3.lua
+++ b/campaign/sample/planets/planet3.lua
@@ -476,10 +476,17 @@ local function GetPlanet(planetUtilities, planetID)
 					description = "Destroy the enemy Impaler",
 					experience = planetUtilities.BONUS_EXP,
 				},
-				[3] = {
-					victoryByTime = 360,
-					image = planetUtilities.ICON_OVERLAY.CLOCK,
-					description = "Win by 6:00",
+				[3] = { -- Build 4 Imps
+					satisfyOnce = true,
+					countRemovedUnits = true, -- count units that previously died.
+					comparisionType = planetUtilities.COMPARE.AT_LEAST,
+					targetNumber = 7, -- The player starts with three Imps
+					unitTypes = {
+						"cloakbomb",
+					},
+					image = planetUtilities.ICON_DIR .. "cloakbomb.png",
+					imageOverlay = planetUtilities.ICON_OVERLAY.REPAIR,
+					description = "Build 4 Imps",
 					experience = planetUtilities.BONUS_EXP,
 				},
 			},

--- a/campaign/sample/planets/planet5.lua
+++ b/campaign/sample/planets/planet5.lua
@@ -39,7 +39,7 @@ local function GetPlanet(planetUtilities, planetID)
 			},
 			{
 				image = "unitpics/staticradar.png",
-				text = [[Radar only reveals the approximate location of enemy forces so, in order to consistently hit their target, most artillery units require a spotter. Once a radar signature is identified as a structure it will no longer wobble.]]
+				text = [[Radar only reveals the approximate location of enemy forces so, in order to consistently hit their target, most artillery units require a spotter. Once a radar signature is identified as a structure it will no longer wobble. Destroying enemy Radar Towers may make them slower to respond to future attacks.]]
 			},
 			{
 				image = "unitpics/planelightscout.png",
@@ -465,6 +465,18 @@ local function GetPlanet(planetUtilities, planetID)
 							z = 2180,
 							facing = 2,
 						},
+                        {
+							name = "staticradar",
+							x = 60,
+							z = 1072,
+							facing = 2,
+						},
+                        {
+							name = "staticradar",
+							x = 4104,
+							z = 1898,
+							facing = 2,
+						},
 					}
 				},
 			},
@@ -505,23 +517,28 @@ local function GetPlanet(planetUtilities, planetID)
 					description = "Build 12 Slings",
 					experience = planetUtilities.BONUS_EXP,
 				},
-				[3] = { -- Win in 10 minutes
-					victoryByTime = 600,
-					image = planetUtilities.ICON_OVERLAY.CLOCK,
-					description = "Win by 10:00",
-					experience = planetUtilities.BONUS_EXP,
-				},
-				[2] = { -- Protect all mex
-					satisfyForever = true,
-					failOnUnitLoss = true, -- Fails the objective if any units being used to satisfy the objective are lost.
+				[2] = { -- Have 15 mex
+                    satisfyOnce = true,
 					comparisionType = planetUtilities.COMPARE.AT_LEAST,
-					targetNumber = 0,
+					targetNumber = 15,
 					unitTypes = {
 						"staticmex",
 					},
 					image = planetUtilities.ICON_DIR .. "staticmex.png",
-					imageOverlay = planetUtilities.ICON_OVERLAY.GUARD,
-					description = "Don't lose any Metal Extractors",
+					imageOverlay = planetUtilities.ICON_OVERLAY.REPAIR,
+					description = "Have 15 Metal Extractors",
+					experience = planetUtilities.BONUS_EXP,
+				},
+                [3] = { -- Kill enemy Radars
+                    satisfyOnce = true,
+					comparisionType = planetUtilities.COMPARE.AT_MOST,
+					targetNumber = 0,
+					enemyUnitTypes = {
+						"staticradar",
+					},
+					image = planetUtilities.ICON_DIR .. "staticradar.png",
+					imageOverlay = planetUtilities.ICON_OVERLAY.ATTACK,
+					description = "Find and destroy all 4 enemy Radar Towers",
 					experience = planetUtilities.BONUS_EXP,
 				},
 			},


### PR DESCRIPTION
Planet 1: removed time constraints on mex/solars, win by X -> build 10 glaives
Planet 2: removed time constraint on Stardust objective
Planet 3: win by X -> build 4 more Imps
Planet 5: win by X -> kill enemy Radars, don't lose mex -> have 15 mex