### PR TITLE
FB_Tooltip_show_Moderator_Color

### DIFF
--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -139,7 +139,7 @@ local function GetTooltipLine(parent, hasImage, fontSize, xOffset, imageWidth)
 		textDisplay:SetPos(nil, newPosition)
 
 		if newColor then
-			textDisplay.font = WG.Chobby.Configuration:GetFont(fontSize, colorName, newColor)
+			textDisplay.font = WG.Chobby.Configuration:GetFont(fontSize, colorName, {color = newColor})
 			textDisplay:Invalidate()
 		else
 			textDisplay.font = WG.Chobby.Configuration:GetFont(fontSize)


### PR DESCRIPTION
Hi,
found a little issue while patching bar's chobby. Should be the same on ZK Chobby.
I have no ZK dev environment, can't test.

Hope it helps :)

Best regards
Fireball