### PR TITLE
Chobby: Change replayTime to a pattern that is compatible with engine >2113.

### DIFF
--- a/LuaMenu/widgets/gui_replay_handler.lua
+++ b/LuaMenu/widgets/gui_replay_handler.lua
@@ -36,8 +36,10 @@ local function CreateReplayEntry(replayPath, engineName, gameName, mapName)
 	fileName = string.gsub(string.gsub(string.gsub(string.gsub(fileName, " BAR105", ""), " BAR", ""), " maintenance", ""), " develop", "")
 	fileName = string.gsub(fileName, "%.sdfz", "")
 
-	local replayTime = string.sub(fileName, 0, 15)
-	replayTime = string.sub(fileName, 0, 4) .. "-" .. string.sub(fileName, 5, 6) .. "-" .. string.sub(fileName, 7, 8) .. " at " .. string.sub(fileName, 10, 11) .. ":" .. string.sub(fileName, 12, 13) .. ":" .. string.sub(fileName, 14, 15)
+	local replayTime = string.format(
+		"%s-%s-%s %s:%s",
+		string.match(fileName, "(%d%d%d%d)-?(%d%d)-?(%d%d)_(%d%d)-?(%d%d)")
+	)
 
 	local replayPanel = Panel:New {
 		x = 0,


### PR DESCRIPTION
Recoil versions past 2113 have a different filename structure of saved replays, breaking compatibility with current gui_replay_handler.lua in ZK Chobby. This PR replaces the string.sub based pattern with the string.match one from BAR Chobby. It parses the filenames of both older and newer replays.

This is a replay generated from a newer engine version that can be loaded for testing purposes: https://www.beyondallreason.info/replays?gameId=ead35d6547d4387665e51caef343a03f

Before:
![Screenshot_371](https://github.com/ZeroK-RTS/Chobby/assets/124457076/0347376d-d679-4f36-924f-125695820d32)

After:
![Screenshot_373](https://github.com/ZeroK-RTS/Chobby/assets/124457076/0fee9c38-2fad-4fc0-9315-e184f21b6de5)
