### PR TITLE
Add minimap preview tooltip and enable it in map browser.

### DIFF
--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -166,6 +166,8 @@ return {
 		},
 		downloads_completed = "All downloads completed.",
 		type_to_filter = "Type to filter",
+		click_to_pick_map = "Click to choose this map",
+		click_to_download_map = "Click to download this map",
 
 		-- Settings
 		planetwars_notifications = "Planetwars notifications",

--- a/LuaMenu/widgets/chobby/i18n/chililobby.lua
+++ b/LuaMenu/widgets/chobby/i18n/chililobby.lua
@@ -166,8 +166,10 @@ return {
 		},
 		downloads_completed = "All downloads completed.",
 		type_to_filter = "Type to filter",
-		click_to_pick_map = "Click to choose this map",
-		click_to_download_map = "Click to download this map",
+
+		-- gui_maplist_panel.lua
+		click_to_pick_map = "Click to choose this map.",
+		click_to_download_map = "Click to download this map.",
 
 		-- Settings
 		planetwars_notifications = "Planetwars notifications",

--- a/LuaMenu/widgets/gui_maplist_panel.lua
+++ b/LuaMenu/widgets/gui_maplist_panel.lua
@@ -21,11 +21,23 @@ local oldOnlyFeaturedMaps = nil
 local IMG_READY    = LUA_DIRNAME .. "images/ready.png"
 local IMG_UNREADY  = LUA_DIRNAME .. "images/unready.png"
 
+local MINIMAP_TOOLTIP_PREFIX = "minimap_tooltip_"
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Utilities
 
 local function CreateMapEntry(mapName, mapData, CloseFunc, Configuration, listFont)--{"ResourceID":7098,"Name":"2_Mountains_Battlefield","SupportLevel":2,"Width":16,"Height":16,"IsAssymetrical":false,"Hills":2,"WaterLevel":1,"Is1v1":false,"IsTeams":true,"IsFFA":false,"IsChickens":false,"FFAMaxTeams":null,"RatingCount":3,"RatingSum":10,"IsSpecial":false},
+	local haveMap = VFS.HasArchive(mapName)
+
+    local mapButtonCaption = nil
+
+	if not haveMap then
+		mapButtonCaption = i18n("click_to_download_map")
+	else
+		mapButtonCaption = i18n("click_to_pick_map")
+	end
+
 	local mapButton = Button:New {
 		classname = "button_rounded",
 		x = 0,
@@ -35,6 +47,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc, Configuration, listFo
 		resizable = false,
 		draggable = false,
 		padding = {0, 0, 0, 0},
+		tooltip = MINIMAP_TOOLTIP_PREFIX .. mapName .. "|" .. mapButtonCaption,
 		OnClick = {
 			function()
 				if lobby then
@@ -46,6 +59,7 @@ local function CreateMapEntry(mapName, mapData, CloseFunc, Configuration, listFo
 	}
 
 	local mapImageFile, needDownload = Configuration:GetMinimapSmallImage(mapName)
+
 	Image:New {
 		name = "minimapImage",
 		x = 3,
@@ -71,7 +85,6 @@ local function CreateMapEntry(mapName, mapData, CloseFunc, Configuration, listFo
 		parent = mapButton,
 	}
 
-	local haveMap = VFS.HasArchive(mapName)
 	local imHaveGame = Image:New {
 		x = 612,
 		y = 12,
@@ -130,6 +143,8 @@ local function CreateMapEntry(mapName, mapData, CloseFunc, Configuration, listFo
 	function externalFunctions.UpdateHaveMap()
 		haveMap = VFS.HasArchive(mapName)
 		imHaveGame.file = (haveMap and IMG_READY) or IMG_UNREADY
+		mapButton.tooltip = not haveMap or MINIMAP_TOOLTIP_PREFIX .. mapName .. "|" .. i18n("click_to_pick_map")
+		mapButton:Invalidate()
 		imHaveGame:Invalidate()
 		sortData[5] = (haveMap and 1) or 0 -- This line is pretty evil.
 	end

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -21,6 +21,7 @@ local USER_TOOLTIP_PREFIX = "user_"
 local USER_SP_TOOLTIP_PREFIX = "user_single_"
 local USER_MP_TOOLTIP_PREFIX = "user_battle_"
 local USER_CH_TOOLTIP_PREFIX = "user_chat_s_"
+local MINIMAP_TOOLTIP_PREFIX = "minimap_tooltip_"
 
 local TOOLTIP_TEXT_NAME = "tooltipText"
 
@@ -538,6 +539,61 @@ end
 
 --------------------------------------------------------------------------
 --------------------------------------------------------------------------
+-- Minimap tooltip
+
+local minimapTooltip = {}
+
+local function GetMinimapTooltip(mapName, title)
+		local Configuration = WG.Chobby.Configuration
+
+		local width = MAX_WINDOW_WIDTH
+		local height = width
+
+		if not minimapTooltip.mainControl then
+			minimapTooltip.mainControl = Chili.Control:New {
+				x = 0,
+				y = 0,
+				width = width,
+				height = height,
+				padding = {0, 0, 0, 0},
+				title = title,
+			}
+		end
+
+		if not minimapTooltip.title then
+			minimapTooltip.title = GetTooltipLine(minimapTooltip.mainControl, nil, 2)
+		end
+
+		local mapImageFile, needDownload = Configuration:GetMinimapImage(mapName)
+		if minimapTooltip.mainControl:GetChildByName("minimapImageLarge") then
+			local minimapImage = minimapTooltip.mainControl:GetChildByName("minimapImageLarge")
+			minimapImage.file = mapImageFile
+			minimapImage:Invalidate()
+		else
+			local minimapImage = Image:New {
+				name = "minimapImageLarge",
+				x = 0,
+				y = 0,
+				width = width,
+				height = width,
+				keepAspect = true,
+				file = mapImageFile,
+				fallbackFile = Configuration:GetLoadingImage(3),
+				checkFileExists = needDownload,
+				padding = {0, 0, 0, 0},
+				parent = minimapTooltip.mainControl,
+			}
+		end
+
+		minimapTooltip.title.Update(7, mapName.. "\n" .. title)
+		-- Set tooltip sizes
+		minimapTooltip.mainControl:SetPos(nil, nil, width, height)
+
+		return minimapTooltip.mainControl
+end
+
+--------------------------------------------------------------------------
+--------------------------------------------------------------------------
 -- User tooltip
 local userTooltip = {}
 
@@ -882,6 +938,18 @@ local function UpdateTooltip(inputText)
 
 			tipWindow:ClearChildren()
 			tipWindow:AddChild(tooltipControl)
+		end
+	elseif inputText:starts(MINIMAP_TOOLTIP_PREFIX) then
+		local mapName = string.sub(inputText, 17)
+		local tooltiptext = ""
+		if mapName:find("|",1, true) then
+			tooltiptext = string.sub(mapName, mapName:find("|", 1, true) + 1) or ""
+			mapName = string.sub(mapName, 1, mapName:find("|", 1, true) -1) 
+		end
+		if mapName then
+			local tooltipcontrol = GetMinimapTooltip(mapName,tooltiptext)
+			tipWindow:ClearChildren()
+			tipWindow:AddChild(tooltipcontrol)
 		end
 	else -- For everything else display a normal tooltip
 		tipWindow:ClearChildren()


### PR DESCRIPTION
![Screenshot_413](https://github.com/ZeroK-RTS/Chobby/assets/124457076/ff7e73f8-4588-43ba-b775-91bbe7687f51)

The good: Adds a higher res true aspect preview of the minimap when moused over a map in the selection menu. Text description is context sensitive to local map availability and changes status after map download is completed.

The so-so: Current set of minimaps is inconsistent in many aspects, some don't have water, some are screenshots, some only show diffuse tex. BAR makes better use of this by having a hand-crafted set of top-down screenshots for each map. Lots of work to do them all.

The bad: Setting an image for `fallbackFile` isn't working and I don't know why, it (the grey reload roundsquare) works in other places but maps with no valid minimap just have a white square in tooltip.