### PR TITLE
Look for `devmode.txt.txt` as well

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -216,7 +216,7 @@ function Configuration:init()
 	self.friendNotifyIngame = true
 	self.simplifiedSkirmishSetup = true
 	self.debugMode = false
-	self.devMode = (VFS.FileExists("devmode.txt") and true) or false
+	self.devMode = VFS.FileExists("devmode.txt") or VFS.FileExists("devmode.txt.txt")
 	self.debugRawMessages = false
 	self.enableProfiler = false
 	self.showPlanetUnlocks = false


### PR DESCRIPTION
Zoomers struggle with file extensions since modern Windows hides them by default.

Also `VFS.FileExists` already returns a bool so no need for that "x and true or false" idiom.