### PR TITLE
Simple skirmish tweaks

### DIFF
--- a/LuaMenu/configs/gameConfig/zk/singleplayerQuickSkirmish.lua
+++ b/LuaMenu/configs/gameConfig/zk/singleplayerQuickSkirmish.lua
@@ -36,7 +36,7 @@ local skirmishSetupData = {
 		{
 			humanName = "Select Map",
 			name = "map",
-			tipText = "Click 'Advanced' for more maps and game modes.",
+			tipText = "You can customize game mode and modifiers on the next screen (under Options) before the match begins.",
 			minimap = true,
 			options = {
 				"TitanDuel 2.2",

--- a/LuaMenu/widgets/gui_battle_room_window.lua
+++ b/LuaMenu/widgets/gui_battle_room_window.lua
@@ -1572,9 +1572,9 @@ local function InitializeSetupPage(subPanel, screenHeight, pageConfig, nextPage,
 	local tipTextBox
 	if pageConfig.tipText then
 		tipTextBox = TextBox:New {
-			x = "26%",
-			y = 3*buttonScale + 20 + (#pageConfig.options)*buttonScale,
-			right = "26%",
+			x = "25%",
+			y = 2*buttonScale + 20 + (#pageConfig.options)*buttonScale,
+			right = "25%",
 			height = 200,
 			align = "left",
 			objectOverrideFont = Configuration:GetFont(2),
@@ -1678,7 +1678,17 @@ local function InitializeSetupPage(subPanel, screenHeight, pageConfig, nextPage,
 				fallbackFile = Configuration:GetLoadingImage(2),
 				checkFileExists = needDownload,
 				parent = buttons[i],
+				OnClick = {
+					function (obj)
+						WG.Analytics.SendOnetimeEvent("lobby:singleplayer:skirmish:advanced")
+						subPanel:SetVisibility(false)
+						ApplyFunction(false)
+					end
+				},
 			}
+			if tipTextBox then
+				tipTextBox:SetVisibility(true)
+			end
 		end
 		ButtonUtilities.SetButtonSelected(buttons[i])
 	end


### PR DESCRIPTION
Prevent quick skirmish flow from showing an advanced skirmish launcher that can't be interacted with for several seconds prior to launching.

Instead of clicking a map icon leading to a start button appearing, take the player to a pre-filled advanced skirmish where they can press the Start button (or make last minute changes)

Preview:
![screen1](https://github.com/ZeroK-RTS/Chobby/assets/49832728/3a3931c1-f34e-463b-b926-53a160f685a9)
![screen2](https://github.com/ZeroK-RTS/Chobby/assets/49832728/d098ff77-d94a-4dd4-aed8-91a614d93725)
