### PR TITLE
Fix thumbnail and minimap download for maps containing unusual chars

### DIFF
--- a/LuaMenu/widgets/chobby/components/configuration.lua
+++ b/LuaMenu/widgets/chobby/components/configuration.lua
@@ -838,7 +838,7 @@ function Configuration:ImageFileExists(filePath)
 end
 
 function Configuration:GetMinimapSmallImage(mapName)
-	mapName = string.gsub(mapName, " ", "_")
+	mapName = string.gsub(mapName, "[^a-zA-Z0-9%-%(%)%.]", "_")
 
 	local filePath = self.gameConfig.minimapThumbnailPath .. mapName .. ".png"
 	if self:ImageFileExists(filePath) then
@@ -863,7 +863,7 @@ function Configuration:GetMinimapImage(mapName)
 	if not self.gameConfig.minimapOverridePath then
 		return LUA_DIRNAME .. "images/minimapNotFound1.png"
 	end
-	mapName = string.gsub(mapName, " ", "_")
+	mapName = string.gsub(mapName, "[^a-zA-Z0-9%-%(%)%.]", "_")
 	local filePath = self.gameConfig.minimapOverridePath .. mapName .. ".jpg"
 	if not self:ImageFileExists(filePath) then
 		filePath = "LuaMenu/Images/Minimaps/" .. mapName .. ".jpg"


### PR DESCRIPTION
For example the thumbnail and minimaps for [Fool's mate v0.6](https://zero-k.info/Maps/Detail/63354) are at
https://zero-k.info/Resources/Fool_s_mate_v0.6.thumbnail.jpg
https://zero-k.info/Resources/Fool_s_mate_v0.6.minimap.jpg

Not
https://zero-k.info/Resources/Fool's_mate_v0.6.thumbnail.jpg
https://zero-k.info/Resources/Fool's_mate_v0.6.minimap.jpg



See [PlasmaShared.Utils.EscapePath(this string path)](https://github.com/ZeroK-RTS/Zero-K-Infrastructure/blob/690f506c27fd8c12ae28ea9b28ecde16b67fa3b2/Shared/PlasmaShared/Utils.cs#L382-L392)