### PR TITLE
Fix length of field error in map search when no map is found

### DIFF
--- a/LuaMenu/widgets/gui_maplist_panel.lua
+++ b/LuaMenu/widgets/gui_maplist_panel.lua
@@ -339,7 +339,7 @@ local function InitializeControls()
 					return
 				end
 				local visibleItemIds = mapList:GetVisibleItemIds()
-				if #visibleItemIds[1] and lobby then
+				if visibleItemIds[1] and #visibleItemIds[1] and lobby then
 					lobby:SelectMap(visibleItemIds[1])
 					CloseFunc()
 				end


### PR DESCRIPTION
This is a bugfix for the following error: 

In the maplist gui panel, if enter is pressed while searching for a mapname that doesn't exist (example ASDFGH), this appears in log:

```[Chili] Error: in `Maplist Panel`:editbox3 : [string "LuaMenu/Widgets/gui_maplist_panel.lua"]:604: attempt to get length of field '?' (a nil value)
[t=00:01:34.036217][f=-000001] [Chili] Error: stacktrace:
    [string "LuaMenu/Widgets/gui_maplist_panel.lua"]:604: in eventListener
    [string "libs/chiliui/chili/controls/object.lua"]:728: in CallListeners
    [string "libs/chiliui/chili/controls/object.lua"]:1074: in KeyPress
    [string "libs/chiliui/chili/controls/editbox.lua"]:939: in KeyPress
    ... (6 calls)
    [string "LuaHandler/Utilities/specialCallinHandlers.lua"]:132
    (tail call): in [?]```