### PR TITLE
Update Circuit 1.2.15 configs

### DIFF
--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/behaviour.json
@@ -1,0 +1,1184 @@
+// Mono-space font required
+{
+"quota": {
+	"scout": 1,  // max scout units out of raiders
+	"raid": [6.0, 20.0],  // [<min>, <avg>] power of raider squad
+	"attack": 6.0,  // min power of attack group
+	"thr_mod": {
+		"attack": [0.1, 0.1],  // [<min>, <max>] enemy threat modifier for target selection of attack task
+		"defence": [0.1, 0.1],  // [<min>, <max>] enemy threat modifier for group size calculation of defence task
+		"mobile": 0.6,  // initial modifier for power of attack group based on mobile enemy threat
+		"static": 2,  // initial modifier for power of attack group based on static enemy threat
+		"comm": 0.75
+	},
+	"aa_threat": 80.0,  // anti-air threat threshold, air factories will stop production when AA threat exceeds
+	"slack_mod": {
+		"all": 0.5,  // threat map 64-elmos slack multiplier for all units
+		"static": 1.5,  // additional 64-elmo-cells for static units
+		"speed": [0.75, 4.0]  // [<64elmo_cells_speed_mod>, <max_64elmo_cells>]
+	}
+},
+
+// If unit's health drops below specified percent it will retreat
+"retreat": {
+	// units fighting to the death is more fun for noobs
+	"builder": [0.01, 1.0],  // [<default>, <UnitDef modifier>] for all builders
+	"fighter": [0.01, 1.0],  // [<default>, <UnitDef modifier>] for all not-builder units
+	"shield": [0.01, 0.275]  // [<empty>, <full>] shield power
+},
+
+"defence": {
+	"infl_rad": 7,  // influenece cell radius for defendAlly map
+	"base_rad": [1000.0, 2000.0],  // defend if enemy within clamp(distance(lane_pos, base_pos), 1000, 2000) radius
+	"comm_rad": [1000.0, 500.0]  // 0 distance from base ~ 1000, base_rad ~ 500.0
+},
+
+
+"behaviour": {
+	// factorycloak
+	"cloakcon": {
+		// "role": [<main>, <enemy>, <enemy>, ...]
+		// <main> is the role to make desicions of when to build it and what task to assign
+		// <enemy> is to decide how to counter enemy unit, if missing then equals to <main>
+		// Roles: builder, scout, raider, riot, assault, skirmish, artillery, anti_air, anti_sub, anti_heavy, bomber, support, mine, transport, air, sub, static, heavy, super, commander
+		// Auto-assigned roles: builder, air, static, super, commander
+		"role": ["builder", "mine"],
+
+		// Attributes - optinal states
+		// "melee" - always move close to target, disregard attack range
+		// "boost" - boost speed on retreat
+		// "no_jump" - disable jump on retreat
+		// "no_strafe" - disable gunship's strafe
+		// "stockpile" - load weapon before any task, auto-assigned
+		// "siege" - mostly use fight command instead of move
+		// "ret_hold" - hold fire on retreat
+		// "ret_fight" - fight on retreat
+		// "jump" - enable jump on regular move
+		// "dg_cost" - DGun by metal cost instead of by threat
+		// "anti_stat" - only static targets
+		// "no_dgun" - do not use DGun
+//		"attribute": ["boost", "no_strafe"],
+
+		// Fire state (open by default)
+		// "hold" - hold fire
+		// "return" - return fire
+		// "open" - fire at will
+//		"fire_state": "open",
+
+		// Overrides reloadTime in seconds
+//		"reload": 1.0,
+
+		// Limits number of units
+//		"limit": 10,
+		"limit": 1
+
+		// Unit can be built only since specific time in seconds
+//		"since": 60,
+
+		// Minimum hp percent before retreat
+//		"retreat": 0.8,
+
+		// Ally threat multiplier
+//		"pwr_mod": 1.0,
+		// Enemy threat multiplier
+//		"thr_mod": 1.0,
+
+		// Ignore enemy
+//		"ignore": false
+	},
+	"cloakraid": {
+		"role": ["raider", "scout"],
+		"attribute": ["scout"],
+		"retreat": 0.1,
+		"limit": 0,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.75
+	},
+	"cloakheavyraid": {
+		"role": ["cloaked_raider", "raider"],
+		"attribute": ["ret_fight"],
+		"since": 180,
+		"limit": 0,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.1,
+		"retreat": 0.4
+	},
+	"cloakskirm": {
+		"role": ["skirmish"],
+		"attribute": ["ret_fight"],
+		"pwr_mod": 0.85,
+		"since": 180,
+		"limit": 1,
+		"retreat": 0.35  // mostly disposable
+	},
+	"cloakriot": {
+		"role": ["riot", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"since": 180,
+		"limit": 1,
+		"retreat": 0.55,
+		"pwr_mod": 1.4,
+		"thr_mod": 2.3
+	},
+	"cloakassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.35,  // assaults need to assault
+		"since": 240,
+		"limit": 1,
+		"pwr_mod": 0.7,
+		"thr_mod": 1.1
+	},
+	"cloakarty": {
+		"role": ["artillery"],
+		"since": 550,
+		"limit": 1,
+		"retreat": 0.9,
+		"thr_mod": 0.0
+	},
+	"cloaksnipe": {
+		"role": ["snipe_target"],
+		"attribute": ["support"],
+		"pwr_mod": 3.0,
+		"limit": 0,
+		"since": 520,
+		"thr_mod": 0.0,
+		"retreat": 0.69
+	},
+	"cloakbomb": {
+		"role": ["mine"],
+		"limit": 0,
+		"retreat": 0.01
+	},
+	"cloakjammer": {
+		"role": ["assault"],
+		"since": 480,
+		"retreat": 0.5,
+		"limit": 0
+	},
+	"cloakaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"limit": 0,
+		"thr_mod": 1.2
+	},
+
+	// factorygunship
+	"gunshipcon": {
+		"role": ["builder", "air"],
+		"limit": 1,
+		"since": 240,
+		"retreat": 0.99
+	},
+	"gunshipbomb": {
+		"role": ["bomber", "air"],
+		"attribute": ["melee"],
+		"limit": 0,
+		"thr_mod": 1.0,
+		"retreat": 0.01
+	},
+	"gunshipemp": {
+		"role": ["anti_heavy", "air"],
+		"thr_mod": 0.1,
+		"pwr_mod": 0.1,
+		"since": 600,
+		"limit": 0,
+		"retreat": 0.9
+	},
+	"gunshipskirm": {
+		"role": ["air", "bullshit_raider"],
+		"retreat": 0.65,
+		"pwr_mod": 0.7,
+		"limit": 1,
+		"thr_mod": 0.66
+	},
+	"gunshipraid": {
+		"role": ["scout", "air"],
+		"retreat": 0.7,
+		"limit": 1,
+		"pwr_mod": 1.25,
+		"thr_mod": 1.1
+	},
+	"gunshipheavyskirm": {
+		"role": ["assault", "air"],
+		"since": 330,
+		"limit": 2,
+		"attribute": ["no_strafe"],
+		"retreat": 0.65,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.00
+	},
+	"gunshipassault": {
+		"role": ["anti_heavy", "air"],
+		"limit": 2,
+		"since": 330,
+		"retreat": 0.5,
+		"pwr_mod": 1.65,
+		"thr_mod": 1.00
+	},
+	"gunshipkrow": {
+		"role": ["anti_heavy", "air", "disarm_target"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"since": 720,
+		"pwr_mod": 0.3,
+		"thr_mod": 0.3,
+		"limit": 0
+	},
+	"gunshiptrans": {
+		"role": ["air"],
+		"limit": 0
+	},
+	"gunshipheavytrans": {
+		"role": ["air"],
+		"limit": 0,
+		"thr_mod": 0.0
+	},
+	"gunshipaa": {
+		"role": ["anti_air", "air"],
+		"limit": 1,
+		"retreat": 0.95,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryamph
+	"amphcon": {
+		"limit": 1,
+		"role": ["builder", "mine"]
+	},
+	"amphraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"limit": 0,
+		"retreat": 0.25  // pretty disposable
+	},
+	"amphimpulse": {
+		"role": ["riot"],
+		"limit": 0,
+		"retreat": 0.36,
+		"pwr_mod": 2.25,
+		"thr_mod": 2.25
+	},
+	"amphfloater": {
+		"role": ["assault", "snipe_target", "super"],
+		"limit": 2,
+		"since": 120,
+		"retreat": 0.25, // too slow to be retreating all the time
+		"pwr_mod": 1.3,
+		"thr_mod": 1.3
+	},
+	"amphriot": {
+		"role": ["riot"],
+		"attribute": ["melee", "ret_fight"],
+		"pwr_mod": 1.5,
+		"limit": 1,
+		"retreat": 0.35 // too slow to be retreating all the time
+	},
+	"amphassault": {
+		"role": ["heavy", "disarm_target"],
+		"retreat": 0.66,
+		"limit": 0,
+		"since": 520,
+		"pwr_mod": 1.4,
+		"thr_mod": 1.0
+	},
+	"amphtele": {
+		"role": ["transport"],
+		"limit": 0
+	},
+	"amphaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight", "support"],
+		"retreat": 0.3,
+		"limit": 1,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.5
+	},
+
+	// factoryspider
+	"spidercon": {
+		"limit": 1,
+		"role": ["builder", "mine"]
+	},
+	"spiderscout": {
+		"role": ["scout", "raider"],
+		"limit": 0,
+		"thr_mod": 0.5,
+		"retreat": 0.01
+	},
+	"spiderassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 1,
+		"pwr_mod": 1.15,
+		"retreat": 0.35
+	},
+	"spideremp": {
+		"role": ["raider", "riot"],
+		"pwr_mod": 3.0,
+		"limit": 1,
+		"retreat": 0.5
+	},
+	"spiderriot": {
+		"role": ["riot"],
+		"pwr_mod": 2.0,
+		"limit": 2,
+		"attribute": ["support"],
+		"retreat": 0.35
+	},
+	"spiderskirm": {
+		"role": ["skirmish", "snipe_target", "super"],
+		"pwr_mod": 2.0,
+		"thr_mod": 1.0,
+		"limit": 2,
+		"since": 180,
+		"retreat": 0.4
+	},
+	"spidercrabe": {
+		"role": ["heavy", "disarm_target", "turtle"],
+		"attribute": ["siege", "ret_fight", "support"],
+		"retreat": 0.5,
+		"thr_mod": 2.5,
+		"pwr_mod": 2.5,
+		"limit": 0,
+		"since": 300,
+		"thr_mod": 1.0
+	},
+	"spiderantiheavy": {
+		"role": ["anti_heavy", "mine"],
+		"retreat": 0.99,
+		"pwr_mod": 2.0,
+		"thr_mod": 0.1,
+		"since": 600,
+		"limit": 0
+	},
+	"spideraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 3.0,
+		"limit": 0,
+		"thr_mod": 1.2
+	},
+
+	// factoryshield
+	"shieldcon": {
+		"role": ["builder", "shieldball", "mine"],
+		"limit": 1,
+		"retreat": 1.3
+	},
+	"shieldscout": {
+		"role": ["transport", "raider"],
+		"limit": 0,
+		"attribute": ["siege", "melee"],
+		"pwr_mod": 0.11,
+		"thr_mod": 0.1,
+		"retreat": 0.0
+	},
+	"shieldraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"retreat": 0.25,
+		"limit": 0,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.9
+	},
+	"shieldskirm": {
+		"role": ["skirmish"],
+		"limit": 1,
+		"since": 200,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"retreat": 0.3
+	},
+	"shieldassault": {
+		"role": ["assault", "support", "shieldball"],
+		"attribute": ["melee"],
+		"limit": 1,
+		"retreat": 0.3,
+		"since": 120,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.35
+	},
+	"shieldriot": {
+		"role": ["riot", "shieldball"],
+		"fire_state": "hold",
+		"since": 100,
+		"limit": 1,
+		"retreat": 0.3,
+		"pwr_mod": 1.7,
+		"thr_mod": 1.7
+	},
+	"shieldfelon": {
+		"role": ["heavy", "shieldball", "snipe_target"],
+		"since": 420,
+		"limit": 0,
+		"retreat": 0.35,
+		"pwr_mod": 1.1,
+		"thr_mod": 1.1
+	},
+	"shieldarty": {
+		"role": ["disarm_target"],
+		"since": 300,
+		"limit": 0,
+		"retreat": 0.3,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"shieldbomb": {
+		"limit": 0,
+		"role": ["mine"]
+	},
+	"shieldshield": {
+		"role": ["super", "heavy", "shieldball"],
+		"since": 540,
+		"limit": 0,
+		"attribute": ["support"],
+		"retreat": 0.36,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.25
+	},
+	"shieldaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 1,
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryveh
+	"vehcon": {
+		"limit": 1,
+		"role": ["builder", "mine"]
+	},
+	"vehscout": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"thr_mod": 0.6,
+		"pwr_mod": 1.2,
+		"retreat": 0.01,
+		"limit": 0
+	},
+	"vehraid": {
+		"role": ["raider"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.3,
+		"limit": 0,
+		"pwr_mod": 1.1,
+		"thr_mod": 0.8
+	},
+	"vehsupport": {
+		"role": ["artillery", "missileskirm"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 2,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.4,
+		"retreat": 0.6  // cannot retreat
+	},
+	"vehriot": {
+		"role": ["riot"],
+		"retreat": 0.6,
+		"limit": 2,
+		"pwr_mod": 1.5,
+		"thr_mod": 1.5
+	},
+	"vehassault": {
+		"role": ["assault"],
+		"attribute": ["melee"],
+		"retreat": 0.4,  // slow to turn around
+		"limit": 1,
+		"since": 180,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9
+	},
+	"vehcapture": {
+		"role": ["support", "disarm_target", "snipe_target"],
+		"since": 180,
+		"limit": 0,
+		"pwr_mod": 1,
+		"thr_mod": 1,
+		"retreat": 0.8
+	},
+	"veharty": {
+		"role": ["transport", "super"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 15,
+		"since": 460,
+		"limit": 0,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0,
+		"retreat": 0.8
+	},
+	"vehheavyarty": {
+		"role": ["artillery", "heavy", "turtle"],
+		"since": 300,
+		"limit": 0,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.00
+	},
+	"vehaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.75,
+		"limit": 1,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryjump
+	"jumpcon": {
+		"limit": 1,
+		"role": ["builder", "mine"]
+	},
+	"jumpscout": {
+		"role": ["riot", "raider"],
+		"limit": 0,
+		"attribute": ["melee", "siege"],
+		"retreat": 3
+	},
+	"jumpraid": {
+		"role": ["raider", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.4,
+		"limit": 0,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.9
+	},
+	"jumpblackhole": {
+		"role": ["support"],
+		"since": 300,
+		"limit": 0,
+		"retreat": 0.36
+	},
+	"jumpskirm": {
+		"role": ["skirmish", "super", "snipe_target"],
+		"limit": 1,
+		"retreat": 0.4
+	},
+	"jumpassault": {
+		"role": ["assault", "anti_sub", "disarm_target"],
+		"attribute": ["melee", "siege", "ret_fight"],
+		"retreat": 0.4,
+		"limit": 0,
+		"pwr_mod": 1.3,
+		"thr_mod": 0.5
+	},
+	"jumpsumo": {
+		"role": ["heavy", "support", "disarm_target"],
+		"limit": 0,
+		"attribute": ["melee", "no_jump"]  // jump on attack
+	},
+	"jumparty": {
+		"role": ["heavy", "turtle", "snipe_target"],
+		"attribute": ["support"],
+		"since": 600,
+		"pwr_mod": 0.1,
+		"limit": 0,
+		"thr_mod": 0.00,
+		"retreat": 0.99
+	},
+	"jumpbomb": {
+		"role": ["anti_heavy", "builder"],
+		"attribute": ["melee", "mine"],
+		"fire_state": "open",
+		"since": 720,
+		"limit": 0,
+		"retreat": 0.01,
+		"pwr_mod": 3.0,
+		"thr_mod": 0.01
+	},
+	"jumpaa": {
+		"role": ["anti_air"],
+		"limit": 1,
+		"attribute": ["melee"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryhover
+	"hovercon": {
+		"limit": 1,
+		"role": ["builder", "mine"]
+	},
+	"hoverraid": {
+		"role": ["scout"],
+		"attribute": ["melee"],		
+		"pwr_mod": 0.9,
+		"thr_mod": 0.8,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9,
+		"limit": 0,
+		"retreat": 0.5
+	},
+	"hoverheavyraid": {
+		"role": ["raider", "bullshit_raider"],	
+		"limit": 0,
+		"retreat": 0.35,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.8
+	},
+	"hoverskirm": {
+		"role": ["skirmish", "support"],
+		"retreat": 0.55,
+		"limit": 2,
+		"reload": 4.0,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.6
+	},
+	"hoverassault": {
+		"role": ["assault", "raider"],
+		"attribute": ["melee", "ret_hold"],
+		"retreat": 0.4,
+		"limit": 1,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.45
+	},
+	"hoverdepthcharge": {
+		"role": ["anti_sub", "riot"],
+		"limit": 2,
+		"attribute": ["melee"],
+		"retreat": 0.6
+	},
+	"hoverriot": {
+		"role": ["riot", "snipe_target"],
+		"limit": 1,
+		"retreat": 0.4,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.25
+	},
+	"hoverarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"attribute": ["siege"],
+		"limit": 0,
+		"retreat": 0.99,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"hoveraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"limit": 2,
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryplane
+	"planecon": {
+		"role": ["builder", "air"],
+		"since": 240,
+		"limit": 1,
+		"retreat": 0.99
+	},
+	"planefighter": {
+		"role": ["scout", "air"],
+		"attribute": ["boost"],
+		"pwr_mod": 1.5,
+		"limit": 1,
+		"thr_mod": 3.0,
+		"retreat": 0.8
+	},
+	"planeheavyfighter": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"limit": 2,
+		"retreat": 0.4,
+		"pwr_mod": 2.5,
+		"thr_mod": 3.0
+	},
+	"bomberprec": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"attribute": ["siege"],
+		"limit": 2,
+		"retreat": 0.8,
+		"pwr_mod": 0.10,
+		"thr_mod": 0.01
+	},
+	"bomberriot": {
+		"role": ["bomber", "air"],
+		"limit": 2,
+		"retreat": 0.6,
+		"pwr_mod": 0.01,
+		"thr_mod": 0.01
+	},
+	"bomberdisarm": {
+		"role": ["anti_heavy", "air"],
+		"attribute": ["siege", "bomber"],
+		"limit": 1,
+		"since": 1200,
+		"retreat": 0.95,
+		"pwr_mod": 100.00,
+		"thr_mod": 0.01
+	},
+	"bomberheavy": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"fire_state": "return",
+		"limit": 0,
+		"since": 420,
+		"retreat": 0.95,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.1
+	},
+	"bomberassault": {
+		"role": ["bomber", "air"],
+		"attribute": ["anti_stat", "no_dgun"],
+		"fire_state": "hold",
+		"limit": 1,
+		"since": 1800,
+		"retreat": 0.65,
+		"pwr_mod": 1.25,
+		"thr_mod": 0.01
+	},
+	"planescout": {
+		"role": ["scout", "air"],
+		"since": 360,
+		"limit": 1,
+		"retreat": 0.8
+	},
+
+	// factorytank
+	"tankcon": {
+		"role": ["builder"],
+		"limit": 1,
+		"pwr_mod": 0.40,
+		"thr_mod": 0.40,
+		"retreat": 0.9
+	},
+	"tankraid": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"limit": 0,
+		"thr_mod": 0.66,
+		"pwr_mod": 0.8,
+		"retreat": 0.45
+	},
+	"tankheavyraid": {
+		"role": ["raider", "bullshit_raider"],
+		"thr_mod": 0.6,
+		"limit": 0,
+		"pwr_mod": 0.65,
+		"retreat": 0.65
+	},
+	"tankriot": {
+		"role": ["riot", "heavy", "snipe_target"],
+		"thr_mod": 1.25,
+		"limit": 1,
+		"pwr_mod": 0.75,
+		"retreat": 0.55
+	},
+	"tankassault": {
+		"role": ["assault", "heavy", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"limit": 1,
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7
+	},
+	"tankheavyassault": {
+		"role": ["heavy", "disarm_target", "super"],
+		"attribute": ["melee"],
+		"pwr_mod": 0.85,
+		"limit": 0,
+		"thr_mod": 0.7,
+		"since": 480,
+		"retreat": 0.55
+	},
+	"tankarty": {
+		"role": ["artillery", "snipe_target", "heavy"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 0,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.0
+	},
+	"tankheavyarty": {
+		"role": ["transport"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 0,
+		"retreat": 0.99,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0
+	},
+	"tankaa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.8,
+		"limit": 2,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryship
+	"shipcon": {
+		"limit": 1,
+		"role": ["builder"]
+	},
+	"shipscout": {
+		"limit": 0,
+		"role": ["scout"]
+	},
+	"shiptorpraider": {
+		"limit": 0,
+		"role": ["raider"]
+	},
+	"subraider": {
+		"limit": 1,
+		"role": ["raider"]
+	},
+	"shipriot": {
+		"limit": 1,
+		"role": ["riot"]
+	},
+	"shipskirm": {
+		"limit": 1,
+		"role": ["skirmish"]
+	},
+	"shipassault": {
+		"limit": 0,
+		"role": ["assault"]
+	},
+	"shiparty": {
+		"limit": 0,
+		"role": ["artillery"]
+	},
+	"shipaa": {
+		"limit": 1,
+		"role": ["anti_air"]
+	},
+
+	// striderhub
+	"striderantiheavy": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 0,
+		"pwr_mod": 0.5,
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.35
+	},
+	"striderscorpion": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 0,
+		"fire_state": "return",
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"since": 1800,
+		"thr_mod": 0.5
+	},
+	"striderdante": {
+		"role": ["heavy", "disarm_target", "snipe_target"],
+		"attribute": ["melee"],
+		"limit": 0,
+		"retreat": 0.45,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.75
+	},
+	"striderarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"pwr_mod": 5.0,
+		"limit": 0,
+		"thr_mod": 0.0,
+		"retreat": 0.9
+	},
+	"striderfunnelweb": {
+		"role": ["heavy", "turtle", "shieldball"],
+		"attribute": ["support"],
+		"retreat": 1.4,
+		"pwr_mod": 1.0,
+		"limit": 1,
+		"since": 3000,
+		"thr_mod": 0.0
+	},
+	"striderbantha": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"limit": 0,
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.5
+	},
+	"striderdetriment": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"limit": 0,
+		"retreat": 0.50,  // deffo retreat, running into nab annihlator farm and sploding is silly :)
+		"pwr_mod": 0.34,
+		"thr_mod": 0.34
+	},
+	"subtacmissile": {
+		"limit": 0,
+		"role": ["artillery", "heavy"],
+		"attribute": ["stockpile"]
+	},
+	"shipcarrier": {
+		"limit": 0,
+		"role": ["artillery", "heavy"]
+	},
+	"shipheavyarty": {
+		"limit": 0,
+		"role": ["artillery", "heavy"]
+	},
+
+	// statics
+	"staticnuke": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 30.0,
+		"limit": 1,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"staticmissilesilo": {
+		"role": ["static", "support", "heavy"],
+		"thr_mod": 0.01
+	},
+	"raveparty": {
+		"role": ["static", "heavy"],
+		"limit": 0,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"zenith": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 105.0,  // 105sec / 0.7sec/met = 150 meteorsControlled
+		"limit": 0,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"mahlazer": {
+		"role": ["static", "heavy"],
+		"limit": 0,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"staticheavyarty": {
+		"role": ["artillery", "turtle", "heavy"],
+		"limit": 0,
+		"thr_mod": 0.0,
+		"pwr_mod": 10.00
+	},
+	"turretheavy": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 1.00
+	},
+	"turretantiheavy": {
+		"role": ["static", "turtle", "static"],
+		"thr_mod": 0.55
+	},
+	"staticarty": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 0.55
+	},
+	"staticantinuke": {
+		"role": ["static", "heavy", "support"],
+		"since": 720,
+		"limit": 1
+	},
+	"turretheavylaser": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.0
+	},
+	"energysingu": {
+		"role": ["static", "turtle", "heavy"],
+		"since": 660
+	},
+	"energyfusion": {
+		"role": ["static", "mine", "heavy"],
+		"since": 280
+	},
+	"turretaalaser": {
+		"role": ["anti_air"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.0
+	},
+	"turretaaheavy": {
+		"role": ["anti_air", "heavy", "turtle"],
+		"limit": 1,
+		"thr_mod": 1.0
+	},
+	"turretlaser": {
+		"role": ["static", "riot", "builder"],
+		"thr_mod": 1.5
+	},
+	"turretmissile": {
+		"role": ["missileskirm", "riot", "builder"],
+		"thr_mod": 0.34
+	},
+	"turretriot": {
+		"role": ["static", "riot", "snipe_target"],
+		"thr_mod": 1.65
+	},
+	"turretaafar": {
+		"role": ["anti_air", "heavy", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaflak": {
+		"role": ["anti_air", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaclose": {
+		"role": ["anti_air"],
+		"thr_mod": 1.0
+	},
+	"turretgauss": {
+		"role": ["static", "turtle", "transport"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.6
+	},
+	"turretemp": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.5
+	},
+
+	// support factories won't be built in front
+	"factoryplane": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"factorygunship": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"striderhub": {
+		"role": ["static"],
+		"since": 900,
+		"attribute": ["support"]
+	},
+
+	// Enemy Eco!! //
+	"staticmex": {
+		"role": ["mine"]
+	},
+	"energywind": {
+		"role": ["mine"]
+	},
+	"staticradar": {
+		"role": ["mine"]
+	},
+	"staticcon": {
+		"role": ["mine"]
+	},
+	"energypylon": {
+		"role": ["mine"],
+		"since": 600
+	},
+	"staticheavyradar": {
+		"role": ["mine", "turtle"],
+		"limit": 1
+	},
+	"staticstorage": {
+		"role": ["mine", "turtle"],
+		"limit": 5
+	},
+	"energysolar": {
+		"role": ["mine"]
+	},
+	"staticshield": {
+		"role": ["static", "turtle"]
+	},
+
+	// Chickens!! //
+	"dronecarry": {
+		"role": ["transport"]
+	},
+	"chicken": {
+		"role": ["raider"]
+	},
+	"chicken_blimpy": {
+		"role": ["mine"]
+	},
+	"chicken_digger": {
+		"role": ["riot"]
+	},
+	"chicken_dodo": {
+		"role": ["mine"]
+	},
+	"chicken_dragon": {
+		"role": ["heavy"],
+		"thr_mod": 0.4
+	},
+	"chicken_drone": {
+		"role": ["raider"]
+	},
+	"chicken_drone_starter": {
+		"role": ["raider"]
+	},
+	"chicken_leaper": {
+		"role": ["raider"]
+	},
+	"chicken_listener": {
+		"role": ["static"]
+	},
+	"chicken_pigeon": {
+		"role": ["air"]
+	},
+	"chicken_roc": {
+		"role": ["air"]
+	},
+	"chicken_shield": {
+		"role": ["support"]
+	},
+	"chicken_spidermonkey": {
+		"role": ["anti_air"]
+	},
+	"chicken_tiamat": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenblobber": {
+		"role": ["artillery"]
+	},
+	"chickenbroodqueen": {
+		"role": ["heavy"],
+		"thr_mod": 0.05
+	},
+	"chickenflyerqueen": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenlandqueen": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenspire": {
+		"role": ["static"]
+	},
+	"chickena": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenc": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickend": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenf": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenr": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenwurm": {
+		"role": ["heavy"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/block_map.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/block_map.json
@@ -1,0 +1,138 @@
+// Mono-space font required
+{
+"building": {
+	"class_land": {
+		"fac_land": {
+			// "type": [<blocker_shape>, <structure_type>]
+			// Available blocker_shape: rectangle, circle.
+			// Available structure_type: factory, mex, engy_low, engy_mid, engy_high, pylon, def_low, def_mid, def_high, special, nano, terra, unknown
+			"type": ["rectangle", "factory"],
+
+			// Unit of measurement: 1 size/yard/radius = SQUARE_SIZE * 2 = 16 elmos, integer.
+			// Offset in South facing
+			"offset": [0, 6],  // default: [0, 0]
+
+			// Size of a blocker without yard
+//			"size": [7, 7],  // default: size of a unit
+
+			// Spacer, blocker_size = size + yard
+			"yard": [12, 12]  // default: [0, 0]
+
+			// "ignore": [<structure_type>, <structure_type>, ...]
+			// Ignore specified structures.
+			// Additional values: none, all
+//			"ignore": ["none"]  // default: ["none"]
+		},
+		"fac_air": {
+			"type": ["rectangle", "factory"],
+			"yard": [8, 8]
+		},
+		"fac_water": {
+			"type": ["rectangle", "factory"],
+			"offset": [0, 4],
+			"yard": [10, 12]
+		},
+		"fac_strider": {
+			"type": ["rectangle", "special"],
+			"offset": [0, 12],
+			"yard": [16, 16]
+		},
+		"solar": {
+			"type": ["circle", "engy_low"],
+			"ignore": ["mex", "engy_mid", "engy_high", "def_low", "pylon", "nano"],
+			"radius": 7
+		},
+		"wind": {
+			"type": ["circle", "engy_low"],
+			// Integer radius of a blocker or description string.
+			// Available string values: explosion, expl_ally
+//			"radius": "explosion",  // default: "explosion"
+			"radius": 4,
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"fusion": {
+			"type": ["circle", "engy_mid"],
+			"ignore": ["mex", "pylon", "def_low"]
+		},
+		"singu": {
+			"type": ["rectangle", "engy_high"],
+			"ignore": ["mex", "engy_low", "def_low", "pylon", "nano"]
+		},
+		"pylon": {
+			"type": ["circle", "pylon"],
+			"not_ignore": ["factory", "engy_low", "pylon", "terra"]  // default: ["all"]
+		},
+		"store": {
+			"type": ["rectangle", "mex"],
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"mex": {
+			"type": ["rectangle", "mex"],
+			"ignore": ["all"]
+		},
+		"def_low": {
+			"type": ["circle", "def_low"],
+			"radius": 10,  // 160 / (SQUARE_SIZE * 2)
+			"ignore": ["engy_mid", "engy_high", "pylon", "nano"]
+		},
+		"caretaker": {
+			"type": ["rectangle", "nano"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+		"small": {
+			"type": ["rectangle", "unknown"],
+			"not_ignore": ["factory", "def_low", "terra"]
+		},
+		"superweapon": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "pylon", "engy_high"]
+		},
+		"protector": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+//		"terraform": {
+//			"type": ["rectangle", "special"],
+//			"size": [7, 7]  // int2(3 + 4, 3 + 4)
+//		},
+		"strider": {
+			"type": ["rectangle", "special"],
+			"yard": [2, 2],
+			"ignore": ["all"]
+		},
+		"_default_": {
+			"type": ["rectangle", "unknown"],
+			"yard": [4, 4],
+			"ignore": ["pylon", "engy_high"]
+		}
+	},
+	// Water overrides land. Map considered as water if amount of land < 40%
+	"class_water" : {
+		"wind": {
+			"type": ["circle", "engy_low"],
+			"radius": 1,  // default: "explosion"
+			"ignore": ["mex", "engy_mid", "engy_high", "pylon", "nano"]
+		}
+	},
+	"instance": {
+		"fac_land": ["factorycloak", "factoryamph", "factoryhover", "factoryjump", "factoryshield", "factoryspider", "factorytank", "factoryveh"],
+		"fac_air": ["factoryplane", "factorygunship"],
+		"fac_water": ["factoryship"],
+		"fac_strider": ["striderhub"],
+		"solar": ["energysolar"],
+		"wind": ["energywind"],
+		"fusion": ["energyfusion"],
+		"singu": ["energysingu"],
+		"pylon": ["energypylon"],
+		"store": ["staticstorage"],
+		"mex": ["staticmex"],
+		"def_low": ["turretmissile", "turretlaser", "staticarty"],
+		"caretaker": ["staticcon", "staticrearm"],
+		"superweapon": ["raveparty", "staticnuke", "zenith", "turretaaheavy", "staticheavyarty", "staticantinuke", "staticheavyradar"],
+//		"protector": ["staticantinuke"],
+//		"terraform": ["terraunit"],
+		"strider": ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"small": ["staticradar"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/build_chain.json
@@ -1,0 +1,249 @@
+// Mono-space font required
+{
+"porcupine": {
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//        5              6                7             8                 9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10             11               12            13                14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		        16
+		"staticantinuke", "staticheavyradar"
+	],
+	// Actual number of defences per cluster bounded by income
+	"land":  [0, 0, 1, 3, 5, 1, 2, 14, 1, 9, 5, 6, 2, 3, 5, 0, 8, 9, 14, 1, 3, 6, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
+	"prevent": 1,  // number of preventive defences
+	"amount": {  // income bound factor
+		"offset": [-0.15, 0.4],
+		// Amount factor: 4x4 ~ 1.85, 20x20 ~ 1.45
+		"factor": [1.55, 1.30],
+		"map": [4, 20]
+	},
+
+
+	// Base defence and time to build it, in seconds
+	"base": [[0, 10], [1, 300], [0, 310], [1, 400], [6, 450], [0, 500], [16, 600], [5, 660], [1, 990], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [15, 1850]],
+
+	"superweapon": {
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "mahlazer", "staticantinuke"],  // FIXME: last aren't superweapon
+		"weight": [ 0.10,         0.20,        0.20,              0.10,     0.10,    0.10],
+
+		"condition": [16, 20000]  // [<Minimum income>, <maximum seconds to build>]
+	},
+
+	// Fallback defence
+	"default": "turretmissile"
+},
+
+// Actions on building finished event
+"build_chain": {
+	// WARNING: Avoid recursion
+	// <category>: factory, nano, store, pylon, energy, defence, bunker, big_gun, radar, sonar, mex, repair
+	"energy": {
+		// <UnitDef>: {<elements>}
+		"energysingu": {
+			// Available elements:
+			// "energy": [max energy income, <"mex"|true>]
+			// "pylon": <boolean>
+			// "porc": <boolean>
+			// "terra": <boolean>
+			// "hub": [
+			//     // chain1
+			//     [{<unit1>, <category>, <offset>, <condition>}, {<unit2>, <category>, <offset>, <condition>}, ...],
+			//     // chain2
+			//     [{...}, {...}, ...],
+			//     ...
+			// ]
+			// <unit>: UnitDef
+			// <offset>:
+			//     1) [x, z] in South facing, elmos
+			//     2) {<direction>: <delta>} - left, right, front, back
+			// <condition>: air, no_air, maybe
+
+			// Build pylon in direction of nearby mex cluster
+//			"pylon": true,
+
+			// Build chain of units
+			"hub": [
+				[  // chain1
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				],
+				[  // chain2
+					{"unit": "turretlaser", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 80}},
+					{"unit": "turretmissile", "category": "defence", "offset": [70, -70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				]
+			]
+		},
+		"energyfusion": {
+//			"pylon": true,
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, 80]}
+				]]
+		}
+	},
+	"factory": {
+		"factoryplane": {
+			"hub": [[{"unit": "staticrearm", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"factorygunship": {
+			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"striderhub": {
+			"pylon": true
+		}
+	},
+	"mex": {
+		"staticmex": {
+//			"terra": true,
+			"energy": [20, "mex"],
+			"porc": true
+		}
+	},
+	"big_gun": {
+		"staticheavyarty": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"raveparty": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"mahlazer": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"zenith": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticheavyradar": {
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]}
+				]]
+		},
+		"staticnuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"energypylon": {
+			"hub": [[
+					{"unit": "turretmissile", "category": "radar", "offset": {"back": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": {"left": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": {"back": -100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]}
+				]]
+		},
+		"turretaaheavy": {
+			"pylon": true,
+			"hub": [
+					[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		}
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/commander.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/commander.json
@@ -1,0 +1,383 @@
+// Mono-space font required
+{
+"commander": {
+	"prefix": "dyntrainer_",
+	"suffix": "_base",
+	"unit": {
+		"support": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["builder", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "builder", "scout", "skirmish", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["scout", "builder", "scout", "riot", "raider", "raider", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.9, ["builder", "raider", "scout", "raider", "raider", "scout", "raider", "raider", "scout", "builder"]],
+						[0.1, ["builder", "raider", "raider", "scout",  "skirmish", "builder", "skirmish", "scout"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "riot"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "scout", "scout", "raider", "raider", "builder", "builder"]],
+						[0.5, ["builder", "scout", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout","builder", "scout", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["riot", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[13, 42],  // shotgun
+					[31, 42],  // Cloak, Nano
+					[15, 41, 37],  // sniper, range, health
+					[34, 34, 34],  // companion drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 34],  // battle drones, companion drones
+					[34, 34, 34],  // companion drones
+					[34, 40, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 36, 36],  // health, regen
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 27, 29],  // nano, disruptor ammo, jammer
+					[32, 33, 30],  // area cloak, lazarus, radar
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 38, 38],  // range, high density
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39]  // damage
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 360,  // seconds
+				"threat": 30,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"recon": {
+			// Choice importance, 0 by default
+			"importance": 0.65,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["builder", "raider", "riot", "raider", "raider", "raider", "raider"]]
+						],
+					"factorygunship": [
+						[0.8, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.2, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.2, ["scout", "scout", "builder", "raider", "raider", "raider", "raider", "scout"]],
+						[0.8, ["builder", "scout",  "raider", "scout", "raider", "raider", "raider", "scout", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider"]],
+						[0.5, ["builder", "raider", "raider", "scout", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider", "raider",  "raider"]],
+						[0.5, ["builder", "scout", "scout", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["builder", "scout", "scout", "raider", "builder", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "scout", "builder", "scout", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 240,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[7, 37],  // Machinegun
+					[31, 36],  // Cloak, Regen
+					[19, 38, 39],  // disruptor bomb, high density, damage boost
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 37, 37],  // speed, health
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, builder
+					[42, 42, 42],  // builder
+					[42, 42, 42],  // builder
+					[30, 27, 29],  // radar, disruptor ammo, jammer
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 41, 39],  // range, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 600,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"assault": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["anti_heavy"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.10, ["scout", "builder", "skirmish", "builder", "riot", "builder", "scout", "scout", "scout", "skirmish", "skirmish", "skirmish"]],
+						[0.15, ["scout", "scout", "builder", "riot", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "skirmish", "builder", "riot"]],
+						[0.75, ["scout", "scout", "raider", "raider", "builder", "builder", "raider", "raider", "raider", "raider", "raider", "builder", "scout"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "raider", "raider", "raider", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "heavy"]],
+						[0.25, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "raider", "raider", "raider", "builder", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "scout", "scout", "scout", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout", "builder", "assault"]],
+						[0.5, ["scout", "scout", "builder", "raider", "scout", "raider", "builder", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[11],  // shotgun
+					[24, 37],  // shield, health
+					[11, 41, 41],  // Double Riot, range
+					[38, 41, 41],  // high density, range
+					[36, 41, 36],  // regen, range, regen
+					[41, 41, 41],  // range
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39, 25],  // damage, area shield
+					[26, 29, 30],  // napalm, jammer, radar
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 36, 36],  // speed, regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 38, 38],  // health, high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 140,  // seconds
+				"threat": 70,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"strike": {
+		   // Choice importance, 0 by default
+			"importance": 0.1,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "scout", "scout", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "scout", "builder", "riot"]],
+						[0.9, ["builder", "scout",  "scout",  "raider", "raider", "raider", "raider", "raider", "builder", "builder", "scout",  "raider", "raider", "raider", "raider", "raider", "builder"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "scout", "scout", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "raider", "raider", "skirmish", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.25, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "assault"]],
+						[0.5, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "scout", "scout", "raider", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 315,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[8, 37],  // beam laser
+					[31, 36],  // cloak, regen
+					[8, 40, 36],  // lightning, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[40, 40, 40],  // speed
+					[28, 29, 30],  // flux, jammer, radar
+					[36, 36, 37],  // regen, health
+					[37, 37, 37],  // health
+					[32, 41, 41],  // area cloak, range
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 42],  // companion drones, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 39, 39],  // nano, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 480,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		}
+	}
+}
+} 

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/economy.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/economy.json
@@ -1,0 +1,69 @@
+// Mono-space font required
+{
+"economy": {
+	// Plain list of energy UnitDef and its limit. AI sorts list by efficiency (inverse)
+	// which is = cost * sizeX * sizeZ / make^2
+	// With ZK v1.8.5.2:
+	//   energysingu = 15.486420
+	//   energygeo = 65.306122
+	//   energyfusion = 80.000000
+	//   energywind = 874.999939
+	//   energysolar = 1750.000000
+	// When e-stalling AI will build bottom-most energy that didn't reach its limit.
+	// On normal AI will select top-most energy that it can build under 40 seconds.
+	"energy": {
+		// If land area >= 40% of the map then "land" config used, "water" otherwise
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>]
+			// limit = random(<lower limit>..<upper limit>)
+			"energysingu": [6],
+			"energygeo": [0, 2],
+			"energyfusion": [6, 10],
+			"energywind": [8, 12],
+			"energysolar": [40]
+		},
+		"water": {
+			"energysingu": [1],
+			"energygeo": [0],
+			"energyfusion": [4],
+			"energywind": [20],
+			"energysolar": [8, 12]
+		},
+		// income factor for energy, time is in seconds
+		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]
+		"factor": [[0.15, 1], [7.0, 3600]],
+
+		"link_inc": 16.0,  // minimum metal-income for energy linking
+		"pylon": ["energypylon", "energysolar", "energywind"]
+	},
+
+	// Scales metal income
+	// ecoFactor = teamSize*eps_step+(1-eps_step)
+	"eps_step": 0.25,
+
+	// Mobile buildpower to metal income ratio
+	"buildpower": 1.075,
+	// Metal excess to income ratio, -1 to disable
+	"excess": -1.0,
+	// Mobile constructor to static constructor metal pull ratio
+	// [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
+	//"ms_pull": [[0.75, 0.0], [0.45, 0.10], [0.53, 0.25], [0.56, 0.40], [0.63, 0.44],[0.52, 0.48],[0.66, 0.52],[0.50, 0.56],[0.66, 0.60], [0.60, 0.65], [0.7, 0.66], [0.8, 0.66], [0.9, 0.75], [0.99, 0.90]],
+	"ms_pull": [[2.0, 0.0], [0.45, 0.20], [0.99, 0.90]],
+	// Max percent of mexes circuit team allowed to take.
+	// If its <1.0 then expansion obeys ms_pull rule, if >=1.0 then ms_pull doesn't affect expansion (mex, pylon, energy).
+	// [<cap_percent>, <is_ally_cap>]
+	"mex_max": [0.15, true],  // 15%
+	// Construction order delay in seconds, -1 to disable
+	"build_delay": [[70, 600], [60, 2400]],
+
+	// New factory switch interval, in seconds (each new factory resets timer, switch event is also based on eco + caretakers)
+	// switch = random(<min_interval>..<max_interval>)
+	"switch": [800, 900],
+
+	"terra": "terraunit",
+	"airpad": "staticrearm",
+
+	// Unknown UnitDef replacer
+	"default": "turretmissile"
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/factory.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/factory.json
@@ -1,0 +1,380 @@
+// Mono-space font required
+{
+// Factory selection parameters
+"select": {
+	"air_map": 80,
+	"offset": [-20, 20],
+	// Speed factor: 8x8 ~ 0%, 24x24 ~ 40%
+	"speed": [0, 40],
+	"map": [8, 24],
+	"no_air": 3
+},
+
+// Utility param: warning on unit's total probability not equal to 100%
+"warn_probability": true,
+
+// Define factories
+"factory": {
+	"factorycloak": {
+		// Adjusts the priority of factory choice (factories with map_percent < 20 are ignored)
+		// map_percent is [20..100]
+		// On start:
+		//   if factory has available builder in current frame: priority ~= map_percent * importance0 + random(-20..+20)
+		//   if factory's builder unavailable in current frame: priority ~= map_percent * importance0 / 10 + random(-20..+20)
+		// During game: priority ~= map_percent * importance1 + random(-20..+20)
+		// importanceN = 1.0 by default if not set
+		"importance": [0.78, 0.2],
+
+		// 'require_energy' adds energy requirement for tierN (N>0): fallback to lowest tier on low energy
+		"require_energy": true,
+
+		// If income*ecoFactor < income_tier[N] then 'tierN' probability will be used
+		"income_tier": [20, 30, 40],
+
+		//             conjurer,   glaive,      scythe,           rocko,        warrior,     zeus,           hammer,      sniper,       tick,        eraser,        gremlin
+		"unit":      ["cloakcon", "cloakraid", "cloakheavyraid", "cloakskirm", "cloakriot", "cloakassault", "cloakarty", "cloaksnipe", "cloakbomb", "cloakjammer", "cloakaa"],
+
+		"land": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.03,             0.30,         0.03,        0.00,           0.00,        0.00,         0.00,        0.00,          0.00],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.20,       0.10,        0.06,             0.51,         0.10,        0.00,           0.00,        0.03,         0.00,        0.00,          0.00],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.25,       0.01,        0.20,             0.20,         0.03,        0.00,           0.00,        0.20,         0.00,        0.11,          0.00]
+
+			// 25-32m Expansions meet - Economy can afford to begin producing in bulk so unit compositions alter.
+	//		"tier3": [ 0.10,       0.40,        0.05,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 33m -40m Solid Fronts - Now we stop raiding and start pushing.
+	//		"tier4": [ 0.10,       0.35,        0.10,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 41m - 56m Mid Game - we must have 2 facs by now, stop making balanced compositions and start being abusive.
+	//		"tier5": [ 0.10,       0.05,        0.25,             0.10,         0.00,        0.20,           0.10,        0.00,         0.00,        0.10,          0.00],
+
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+	//		"tier6": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00],
+
+			// 72m - inf+ Late late Game - This fac sucks!
+	//		"tier7": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00]
+		},
+		"air": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.26,             0.00,         0.00,        0.00,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.10,       0.25,        0.11,             0.38,         0.00,        0.06,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.20,       0.10,        0.10,             0.33,         0.00,        0.12,           0.00,        0.00,         0.00,        0.05,          0.10]
+		},
+		"caretaker": 6
+	},
+
+	"factorygunship": {
+		"importance": [15.0, 1.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 85],
+		//             wasp,         blastwing,     gnat,         banshee,       rapier,         brawler,             blackdawn,        krow,          valkyrie,       vindicator,          trident
+		"unit":      ["gunshipcon", "gunshipbomb", "gunshipemp", "gunshipraid", "gunshipskirm", "gunshipheavyskirm", "gunshipassault", "gunshipkrow", "gunshiptrans", "gunshipheavytrans", "gunshipaa"],
+		"land": {
+			// 0-8m Opening - Blastwing and banshee Harass
+			"tier0": [ 0.00,         0.00,          0.00,         0.00,          0.98,           0.00,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 9-16m Early Game - Banshee with a chance of Blackdawn
+			"tier1": [ 0.00,         0.20,          0.00,         0.02,          0.45,           0.31,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 17-24m Expanding - Time to start a-makin Brawlers
+			"tier2": [ 0.00,         0.02,          0.00,         0.00,          0.04,           0.90,                0.04,             0.00,          0.00,           0.00,                0.00],
+			// 25-32m Expansions meet - Time to keep a-makin Brawlers
+			"tier3": [ 0.00,         0.05,          0.00,         0.00,          0.04,           0.83,                0.08,             0.00,          0.00,           0.00,                0.00],
+			// 33m -40m Solid Fronts - Brawlers with a chance of Krow
+			"tier4": [ 0.00,         0.04,          0.00,         0.00,          0.05,           0.80,                0.10,             0.01,          0.00,           0.00,                0.00],
+			// 41m - 56m Mid Game - Brawlers with a bigger chance of Krow
+			"tier5": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.87,                0.06,             0.02,          0.00,           0.00,                0.00],
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+			"tier6": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.84,                0.07,             0.04,          0.00,           0.00,                0.00],
+			// 72m - inf+ Late late Game - Spam Krows!
+			"tier7": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.90,                0.00,             0.05,          0.00,           0.00,                0.00]
+		},
+		"caretaker": 6
+	},
+
+	"factoryamph": {
+		"importance": [0.85, 1.0],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             conch,     duck,       archer,        buoy,          scallop,    grizzly,       djinn,      angler
+		"unit":      ["amphcon", "amphraid", "amphimpulse", "amphfloater", "amphriot", "amphassault", "amphtele", "amphaa"],
+		"land": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.53,       0.25,          0.20,          0.02,       0.00,          0.00,       0.00],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.16,          0.47,          0.22,       0.00,          0.00,       0.00],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.10,       0.09,          0.51,          0.15,       0.05,          0.00,       0.00],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.47,          0.12,       0.13,          0.00,       0.00],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.16,      0.11,       0.02,          0.52,          0.04,       0.15,          0.00,       0.00],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.20,      0.10,       0.02,          0.49,          0.02,       0.17,          0.00,       0.00],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.48,          0.02,       0.18,          0.00,       0.00],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.46,          0.02,       0.22,          0.00,       0.00]
+		},
+		"air": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.58,       0.25,          0.10,          0.02,       0.00,          0.00,       0.05],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.11,          0.47,          0.22,       0.00,          0.00,       0.05],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.11,       0.04,          0.53,          0.12,       0.05,          0.00,       0.05],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.42,          0.12,       0.13,          0.00,       0.05],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.15,      0.10,       0.02,          0.49,          0.04,       0.15,          0.00,       0.05],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.16,      0.13,       0.02,          0.45,          0.02,       0.17,          0.00,       0.05],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.43,          0.02,       0.18,          0.00,       0.05],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.41,          0.02,       0.22,          0.00,       0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryspider": {
+		"importance": [0.71, 0.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             weaver,      flea,          hermit,          venom,       redback,      recluse,       crabe,         infiltrator,       tarantula
+		"unit":      ["spidercon", "spiderscout", "spiderassault", "spideremp", "spiderriot", "spiderskirm", "spidercrabe", "spiderantiheavy", "spideraa"],
+		"land": {
+			// 0-12m Opening - Opening turbo Flea spam & Riots
+			"tier0": [ 0.00,        0.73,          0.00,            0.22,        0.05,         0.00,          0.00,          0.00,              0.00],
+			// 13-18m Early Game - Reducing Flea spam, still mostly Riots
+			"tier1": [ 0.00,        0.59,          0.00,            0.05,        0.05,         0.31,          0.00,          0.00,              0.00],
+			// 17-24m Expanding - Slant production towards Hermit & Redback
+			"tier2": [ 0.06,        0.48,          0.04,            0.05,        0.00,         0.35,          0.02,          0.00,              0.00],
+			// 25-32m Expansions meet - Slant production towards Hermit & Recluse
+			"tier3": [ 0.08,        0.45,          0.06,            0.03,        0.00,         0.33,          0.05,          0.00,              0.00],
+			// 33m -40m Solid Fronts - 	Greater Emphasis on Hermit & Crabbe
+			"tier4": [ 0.08,        0.40,          0.09,            0.03,        0.00,         0.32,          0.08,          0.00,              0.00],
+			// 41m - 56m Mid Game - We need more Crabbes
+			"tier5": [ 0.08,        0.42,          0.07,            0.02,        0.00,         0.31,          0.10,          0.00,              0.00],
+			// 57m - 72m Late Game -  MORE CRABBES
+			"tier6": [ 0.09,        0.40,          0.11,            0.00,        0.00,         0.29,          0.11,          0.00,              0.00],
+			// 72m - inf+ Late late Game - TURBO CRABBES
+			"tier7": [ 0.10,        0.35,          0.20,            0.00,        0.00,         0.22,          0.13,          0.00,              0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryveh": {
+		"importance": [0.95, 0.2],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             mason,    dart,       scorcher,  slasher,      leveler,   ravager,      dominatrix,   wolverine, impaler,        crasher
+		"unit":      ["vehcon", "vehscout", "vehraid", "vehsupport", "vehriot", "vehassault", "vehcapture", "veharty", "vehheavyarty", "vehaa"],
+		"land": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.12,       0.00,      0.00,         0.20,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.20,      0.60,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.59,         0.01,         0.00,      0.04,           0.00],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.10,       0.00,      0.00,         0.10,      0.56,         0.02,         0.00,      0.07,           0.00],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.10,       0.00,      0.00,         0.06,      0.57,         0.05,         0.00,      0.07,           0.00]
+		},
+		"air": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.10,       0.00,      0.00,         0.22,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.15,      0.65,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.05,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.05],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.56,         0.02,         0.00,      0.03,           0.05],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.56,         0.01,         0.00,      0.04,           0.03],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.15,       0.00,      0.00,         0.10,      0.46,         0.02,         0.00,      0.07,           0.05],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.05,       0.00,      0.00,         0.16,      0.47,         0.05,         0.00,      0.07,           0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryhover": {
+		"importance": [1.00, 1.1],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             quill,      dagger,      scalpel,      halberd,        claymore,           mace,        penetrator,  flail,        bolas
+		"unit":      ["hovercon", "hoverraid", "hoverskirm", "hoverassault", "hoverdepthcharge", "hoverriot", "hoverarty", "hoveraa", "hoverheavyraid"],
+		"land": {
+			// 0-8m Opening - Raiders and Riots
+			"tier0": [ 0.00,       0.55,        0.10,         0.00,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 9-16m Early Game - Mostly Mace, some support
+			"tier1": [ 0.00,       0.10,        0.44,         0.11,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 17-24m Expanding - MAXIMUM OP Scalpel time
+			"tier2": [ 0.05,       0.10,        0.43,         0.20,           0.00,               0.14,        0.08,        0.00,        0.00],
+			// 25-32m Expansions meet - Mix in some Halberds
+			"tier3": [ 0.15,       0.10,        0.26,         0.20,           0.01,               0.16,        0.12,        0.00,        0.00],
+			// 33m -40m Solid Fronts - 	More Halberd and Pene
+			"tier4": [ 0.17,       0.13,        0.19,         0.31,           0.01,               0.05,        0.14,        0.00,        0.00],
+			// 41m - 56m Mid Game - Even more Halberd and Pene
+			"tier5": [ 0.17,       0.11,        0.17,         0.30,           0.01,               0.05,        0.19,        0.00,        0.00],
+			// 57m - 72m Late Game - More Pene
+			"tier6": [ 0.20,       0.04,        0.10,         0.34,           0.01,               0.10,        0.21,        0.00,        0.00],
+			// 72m - inf+ Late late Game - MAXIMUM PENE
+			"tier7": [ 0.25,       0.02,        0.07,         0.21,           0.00,               0.10,        0.35,        0.00,        0.00]
+		},
+		"water": {
+			// 33m -40m
+			"tier4": [ 0.00,       0.49,        0.10,         0.20,           0.10,               0.10,        0.01,        0.00],
+			// 41m - inf+4
+			"tier5": [ 0.00,       0.24,        0.05,         0.41,           0.20,               0.05,        0.05,        0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryplane": {
+		"importance": [12.0, 12.1],
+		"require_energy": false,
+
+		"income_tier": [30, 60],
+		//             crane,      swift,          hawk,                raven,        phoenix,      thunderbird,    wyvern,        vulture
+		"unit":      ["planecon", "planefighter", "planeheavyfighter", "bomberprec", "bomberriot", "bomberdisarm", "bomberheavy", "planescout"],
+		"air": {
+			// 0-10m Early Game
+			"tier0": [ 0.00,       0.00,           0.75,                0.15,         0.00,         0.00,           0.05,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.00,       0.00,           0.51,                0.00,         0.02,         0.01,           0.24,          0.22]
+		},
+		"land": {
+			// 0-10m Early Game
+			"tier0": [ 0.10,       0.00,           0.00,                0.60,         0.05,         0.00,           0.20,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.10,       0.00,           0.00,                0.05,         0.00,         0.00,           0.40,          0.45]
+		},
+		"caretaker": 6
+	},
+
+	"factorytank": {
+		"importance": [0.9, 1.5],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             welder,    kodachi,    panther,         banisher,   reaper,        goliath,            pillager,   tremor,          copperhead
+		"unit":      ["tankcon", "tankraid", "tankheavyraid", "tankriot", "tankassault", "tankheavyassault", "tankarty", "tankheavyarty", "tankaa"],
+		"land": {
+			// 0-8m Opening - Koda and Banisher
+			"tier0": [ 0.10,      0.60,       0.10,            0.20,       0.00,          0.00,               0.00,       0.00,            0.00],
+			// 9-16m Early Game - Mostly Banisher
+			"tier1": [ 0.10,      0.15,       0.10,            0.23,       0.42,          0.00,               0.00,       0.00,            0.00],
+			// 17-24m Expanding - Begin mixing in Reapers!
+			"tier2": [ 0.30,      0.13,       0.07,            0.16,       0.34,          0.00,               0.00,       0.00,            0.00],
+			// 25-32m Expansions meet - More Reapers!
+			"tier3": [ 0.46,      0.15,       0.03,            0.04,       0.32,          0.00,               0.00,       0.00,            0.00],
+			// 33m -40m Solid Fronts - 	MAXIMUM REAPERS
+			"tier4": [ 0.45,      0.14,       0.00,            0.02,       0.37,          0.02,               0.00,       0.00,            0.00],
+			// 41m - 56m Mid Game - More arty & Golly
+			"tier5": [ 0.46,      0.16,       0.00,            0.02,       0.32,          0.04,               0.00,       0.00,            0.00],
+			// 57m - 72m Late Game - Even more arty & Golly
+			"tier6": [ 0.40,      0.13,       0.00,            0.02,       0.34,          0.11,               0.00,       0.00,            0.00],
+			// 72m - inf+ Late late Game - MAXIMUM GOLLY
+			"tier7": [ 0.42,      0.08,       0.00,            0.02,       0.32,          0.16,               0.00,       0.00,            0.00]
+		},
+
+		"caretaker": 15
+	},
+
+	"factoryjump": {
+		"importance": [0.73, 1.1],
+		"require_energy": false,
+
+		"income_tier": [20, 40, 60, 80],
+		//             freaker,   puppy,       pyro,       placeholder,     moderator,   jack,          sumo,       firewalker, skuttle,    archangel
+		"unit":      ["jumpcon", "jumpscout", "jumpraid", "jumpblackhole", "jumpskirm", "jumpassault", "jumpsumo", "jumparty", "jumpbomb", "jumpaa"],
+		"land": {
+			"tier0": [ 0.05,      0.24,        0.50,       0.00,            0.15,        0.06,          0.00,       0.00,       0.00,       0.00],
+			"tier1": [ 0.10,      0.20,        0.20,       0.10,            0.16,        0.24,          0.00,       0.00,       0.00,       0.00],
+			"tier2": [ 0.20,      0.20,        0.00,       0.15,            0.04,        0.31,          0.00,       0.10,       0.00,       0.00],
+			"tier3": [ 0.25,      0.15,        0.00,       0.15,            0.00,        0.33,          0.00,       0.12,       0.00,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryshield": {
+		"importance": [0.88, 0.6],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 48, 66],
+		//             convict,     dirtbag,       bandit,       rogue,         thug,            outlaw,       felon,         racketeer,    roach,        aspis,          vandal
+		"unit":      ["shieldcon", "shieldscout", "shieldraid", "shieldskirm", "shieldassault", "shieldriot", "shieldfelon", "shieldarty", "shieldbomb", "shieldshield", "shieldaa"],
+		"land": {
+			"tier0": [ 0.05,        0.05,          0.70,         0.00,          0.20,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier1": [ 0.08,        0.01,          0.10,         0.24,          0.57,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier2": [ 0.12,        0.03,          0.00,         0.20,          0.54,            0.00,         0.05,          0.00,         0.00,         0.06,           0.00],
+			"tier3": [ 0.15,        0.07,          0.00,         0.00,          0.62,            0.00,         0.08,          0.00,         0.00,         0.08,           0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryship": {
+		"importance": [5.5, 5.5],
+		"require_energy": false,
+
+		"income_tier": [30],
+		//             mariner    cutter,      hunter,           seawolf,     corsair,    mistral,     siren,         ronin,      zephyr
+		"unit":      ["shipcon", "shipscout", "shiptorpraider", "subraider", "shipriot", "shipskirm", "shipassault", "shiparty", "shipaa"],
+		"water": {
+			"tier0": [ 0.05,      0.15,        0.35,             0.10,        0.10,       0.10,        0.15,          0.00,       0.00],
+			"tier1": [ 0.05,      0.10,        0.20,             0.10,        0.05,       0.10,        0.25,          0.15,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"striderhub": {
+		"importance": [0, 1.5],
+		"require_energy": false,
+
+		"income_tier": [60, 80, 100],
+		//             ultimatum,          scorpion,          dante,          catapult,      funnelweb,          bantha,          detriment,          scylla,          reef,          battleship
+		"unit":      ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"land": {
+			"tier0": [ 0.01,               0.10,              0.81,           0.00,          0.05,               0.03,            0.00,               0.00,            0.00,          0.00],
+			"tier1": [ 0.03,               0.14,              0.22,           0.24,          0.20,               0.16,            0.01,               0.00,            0.00,          0.00],
+			"tier2": [ 0.05,               0.10,              0.16,           0.35,          0.10,               0.21,            0.03,               0.00,            0.00,          0.00],
+			"tier3": [ 0.05,               0.10,              0.01,           0.26,          0.10,               0.35,            0.13,               0.00,            0.00,          0.00]
+		},
+		"water": {
+			"tier1": [ 0.50,               0.00,              0.00,           0.00,          0.00,               0.00,            0.00,               0.00,            0.25,          0.25],
+			"tier2": [ 0.10,               0.00,              0.00,           0.00,          0.00,               0.00,            0.10,               0.00,            0.40,          0.40]
+		},
+
+		"caretaker": 100
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/response.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/response.json
@@ -1,0 +1,136 @@
+// Mono-space font required
+{
+// Build special units when enemy_metal*ratio > response_metal*eps; eps=teamSize*eps_step+(1-eps_step)
+// AA condition for 3v3: (enemy_air_metal*0.67 > (aa_metal+aa_cost)*1.12) and (aa_metal+aa_cost < army_metal*0.5)
+//
+// Probability of UnitDef for AA role depends on income tier: (tierN[UnitDef]+_weight_)*enemy_air_metal/aa_metal*importance
+// armjeth probability for tier 1: (0.00+10.00)*enemy_air_metal*600.0
+"response": {
+	"_weight_": 70.0,  // base weight of response probability, default=0.5
+
+	"assault": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "super", "missileskirm", "turtle"],
+		"ratio":      [ 0.75,   2.0,      0.00,      0.20,        0.00,    0.75,    1.5,            3.0],
+		"importance": [ 15.00,  45.00,    25.00,     75.00,       0.00,    45.00,   125.00,         50.0],
+		"max_percent": 1.00
+	},
+	"skirmish": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "anti_heavy"],
+		"ratio":      [ 1.50,   0.75,     1.00,      0.00,        0.00,    0.00],
+		"importance": [ 35.00,  25.00,    25.00,     75.00,       0.00,    0.00],
+		"max_percent": 1.00
+	},
+	"raider": {
+		"vs":         ["anti_air", "scout", "raider", "anti_heavy", "mine", "skirmish", "artillery"],
+		"ratio":      [ 0.00,       1.00,    1.0,      0.10,         0.35,   0.40,       0.8],
+		"importance": [ 15.00,      75.00,   75.00,    15.00,        60.00,  45.00,      10.00],
+		"max_percent": 1.00,
+		"eps_step": 0.75
+	},
+	"riot": {
+		"vs":         ["raider", "scout", "commander", "bullshit_raider"],
+		"ratio":      [ 0.8,      0.8,     0.33,        1.5],
+		"importance": [ 100.00,   100.00,  75.00,       125.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"missileskirm": {
+		"vs":         ["raider", "scout", "riot"],
+		"ratio":      [ 0.25,     0.5,     0.25],
+		"importance": [ 35.00,    50.00,   35.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"transport": {
+		"vs":         ["super", "support", "shieldball"],
+		"ratio":      [ 0.75,    0.75,      0.75],
+		"importance": [ 50.00,   50.00,     50.00],
+		"max_percent": 0.30,
+		"eps_step": 0.015
+	},
+	"scout": {
+		"vs":         ["mine", "artillery", "anti_air", "scout", "static", "heavy", "anti_heavy", "cloaked_raider"],
+		"ratio":      [ 0.35,   0.05,        0.10,       1.00,    0.00,     0.00,    0.05,         0.5],
+		"importance": [ 60.00,  60.0,        60.0,       35.00,   0.00,     0.00,    10.00,        100.00],
+		"max_percent": 0.09,
+		"eps_step": 0.025
+	},
+	"artillery": {
+		"vs":         ["static", "artillery", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.66,     0.00,        0.66,    0.25,         3.0],
+		"importance": [ 20.00,    0.00,        40.00,   40.00,        40.0],
+		"max_percent": 0.66,
+		"eps_step": 0.02
+	},
+	"anti_air": {
+		"vs":         ["air"],
+		"ratio":      [ 0.8],
+		"importance": [ 75.0],
+		"max_percent": 0.4,
+		"eps_step": 0.75
+	},
+	"anti_sub": {
+		"vs":         ["sub"],
+		"ratio":      [ 0.0],
+		"importance": [ 0.0],
+		"max_percent": 0.00,
+		"eps_step": 0.0
+	},
+	"anti_heavy": {
+		"vs":         ["heavy", "artillery", "support", "anti_heavy", "commander", "super", "turtle"],
+		"ratio":      [ 0.45,    0.00,        0.00,      0.00,         0.4,         0.50,    3.00],
+		"importance": [ 85.00,   0.00,        0.00,      0.00,         50.00,       85.0,    50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"disarm_target": {
+		"vs":         ["disarm_target"],
+		"ratio":      [ 0.50],
+		"importance": [ 100.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"snipe_target": {
+		"vs":         ["snipe_target", "commander"],
+		"ratio":      [ 1.00,           0.20],
+		"importance": [ 100.00,         50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"cloaked_raider": {
+		"vs":         ["snipe_target", "commander", "transport"],
+		"ratio":      [ 0.50,           0.20,        2.00],
+		"importance": [ 35.00,          35.00,       125.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"heavy": {
+		"vs":         ["heavy", "static", "support", "skirmish", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.75,    0.5,      0.00,      0.75,       0.75,    0.75,         3.00],
+		"importance": [ 75.00,   15.00,    0.00,      15.00,      75.00,   75.00,        75.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"bomber": {
+		"vs":         ["shieldball", "anti_heavy", "artillery", "super"],
+		"ratio":      [ 0.50,         0.50,         0.50,        0.50],
+		"importance": [ 0.50,         50.00,        50.00,       50.00],
+		"max_percent": 1.0,
+		"eps_step": 0.00
+	},
+	"super": {
+		"vs":         ["heavy", "static", "support", "skirmish", "artillery", "super", "turtle"],
+		"ratio":      [ 0.3,     0.55,     0.00,      0.00,       0.00,        0.00,    0.5],
+		"importance": [ 45.00,   25.00,    0.00,      0.00,       0.00,        0.00,    45.00],
+		"max_percent": 0.2,
+		"eps_step": 0.00
+	},
+	"support": {
+		"vs":         ["assault", "bullshit_raider"],
+		"ratio":      [ 1.00,      0.4],
+		"importance": [ 35.00,     75.00],
+		"max_percent": 0.25,
+		"eps_step": 0.00
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/behaviour.json
@@ -1,0 +1,1122 @@
+// Mono-space font required
+{
+"quota": {
+	"scout": 1,  // max scout units out of raiders
+	"raid": [7.0, 42.0],  // [<min>, <avg>] power of raider squad
+	"attack": 20.0,  // min power of attack group
+	"thr_mod": {
+		"attack": [0.45, 0.45],  // [<min>, <max>] enemy threat modifier for target selection of attack task
+		"defence": [0.80, 0.80],  // [<min>, <max>] enemy threat modifier for group size calculation of defence task
+		"mobile": 1.075,  // initial modifier for power of attack group based on mobile enemy threat
+		"static": 4.25,  // initial modifier for power of attack group based on static enemy threat
+		"comm": 0.75
+	},
+	"aa_threat": 80.0,  // anti-air threat threshold, air factories will stop production when AA threat exceeds
+	"slack_mod": {
+		"all": 0.5,  // threat map 64-elmos slack multiplier for all units
+		"static": 1.5,  // additional 64-elmo-cells for static units
+		"speed": [0.75, 4.0]  // [<64elmo_cells_speed_mod>, <max_64elmo_cells>]
+	}
+},
+
+// If unit's health drops below specified percent it will retreat
+"retreat": {
+	"builder": [0.70, 1.0],  // [<default>, <UnitDef modifier>] for all builders
+	"fighter": [0.45, 1.0],  // [<default>, <UnitDef modifier>] for all not-builder units
+	"shield": [0.25, 0.275]  // [<empty>, <full>] shield power
+},
+
+"defence": {
+	"infl_rad": 7,  // influenece cell radius for defendAlly map
+	"base_rad": [1000.0, 2000.0],  // defend if enemy within clamp(distance(lane_pos, base_pos), 1000, 2000) radius
+	"comm_rad": [1000.0, 500.0]  // 0 distance from base ~ 1000, base_rad ~ 500.0
+},
+
+
+"behaviour": {
+	// factorycloak
+	"cloakcon": {
+		// "role": [<main>, <enemy>, <enemy>, ...]
+		// <main> is the role to make desicions of when to build it and what task to assign
+		// <enemy> is to decide how to counter enemy unit, if missing then equals to <main>
+		// Roles: builder, scout, raider, riot, assault, skirmish, artillery, anti_air, anti_sub, anti_heavy, bomber, support, mine, transport, air, sub, static, heavy, super, commander
+		// Auto-assigned roles: builder, air, static, super, commander
+		"role": ["builder", "mine"]
+
+		// Attributes - optinal states
+		// "melee" - always move close to target, disregard attack range
+		// "boost" - boost speed on retreat
+		// "no_jump" - disable jump on retreat
+		// "no_strafe" - disable gunship's strafe
+		// "stockpile" - load weapon before any task, auto-assigned
+		// "siege" - mostly use fight command instead of move
+		// "ret_hold" - hold fire on retreat
+		// "ret_fight" - fight on retreat
+		// "jump" - enable jump on regular move
+		// "dg_cost" - DGun by metal cost instead of by threat
+		// "anti_stat" - only static targets
+		// "no_dgun" - do not use DGun
+//		"attribute": ["boost", "no_strafe"],
+
+		// Fire state (open by default)
+		// "hold" - hold fire
+		// "return" - return fire
+		// "open" - fire at will
+//		"fire_state": "open",
+
+		// Overrides reloadTime in seconds
+//		"reload": 1.0,
+
+		// Limits number of units
+//		"limit": 10,
+
+		// Unit can be built only since specific time in seconds
+//		"since": 60,
+
+		// Minimum hp percent before retreat
+//		"retreat": 0.8,
+
+		// Ally threat multiplier
+//		"pwr_mod": 1.0,
+		// Enemy threat multiplier
+//		"thr_mod": 1.0,
+
+		// Ignore enemy
+//		"ignore": false
+	},
+	"cloakraid": {
+		"role": ["raider", "scout"],
+		"attribute": ["scout"],
+		"retreat": 0.1,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.75
+	},
+	"cloakheavyraid": {
+		"role": ["cloaked_raider", "raider"],
+		"attribute": ["ret_fight"],
+		"since": 180,
+		"limit": 3,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.1,
+		"retreat": 0.4
+	},
+	"cloakskirm": {
+		"role": ["skirmish"],
+		"attribute": ["ret_fight"],
+		"pwr_mod": 0.85,
+		"since": 180,
+		"limit": 20,
+		"retreat": 0.35  // mostly disposable
+	},
+	"cloakriot": {
+		"role": ["riot", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"since": 180,
+		"retreat": 0.55,
+		"pwr_mod": 1.4,
+		"thr_mod": 2.3
+	},
+	"cloakassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.35,  // assaults need to assault
+		"since": 240,
+		"pwr_mod": 0.7,
+		"thr_mod": 1.1
+	},
+	"cloakarty": {
+		"role": ["artillery"],
+		"since": 550,
+		"limit": 8,
+		"retreat": 0.9,
+		"thr_mod": 0.0
+	},
+	"cloaksnipe": {
+		"role": ["snipe_target"],
+		"attribute": ["support"],
+		"pwr_mod": 3.0,
+		"since": 520,
+		"thr_mod": 0.0,
+		"retreat": 0.69
+	},
+	"cloakbomb": {
+		"role": ["mine"],
+		"retreat": 0.01
+	},
+	"cloakjammer": {
+		"role": ["assault"],
+		"since": 480,
+		"retreat": 0.5,
+		"limit": 1
+	},
+	"cloakaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factorygunship
+	"gunshipcon": {
+		"role": ["builder", "air"],
+		"limit": 2,
+		"since": 240,
+		"retreat": 0.99
+	},
+	"gunshipbomb": {
+		"role": ["bomber", "air"],
+		"attribute": ["melee"],
+		"limit": 1,
+		"thr_mod": 1.0,
+		"retreat": 0.01
+	},
+	"gunshipemp": {
+		"role": ["anti_heavy", "air"],
+		"thr_mod": 0.1,
+		"pwr_mod": 0.1,
+		"since": 600,
+		"limit": 6,
+		"retreat": 0.9
+	},
+	"gunshipskirm": {
+		"role": ["air", "bullshit_raider"],
+		"retreat": 0.65,
+		"pwr_mod": 0.7,
+		"limit": 8,
+		"thr_mod": 0.66
+	},
+	"gunshipraid": {
+		"role": ["scout", "air"],
+		"retreat": 0.7,
+		"limit": 1,
+		"pwr_mod": 1.25,
+		"thr_mod": 1.1
+	},
+	"gunshipheavyskirm": {
+		"role": ["assault", "air"],
+		"since": 330,
+		"attribute": ["no_strafe"],
+		"retreat": 0.65,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.00
+	},
+	"gunshipassault": {
+		"role": ["anti_heavy", "air"],
+		"limit": 3,
+		"since": 330,
+		"retreat": 0.5,
+		"pwr_mod": 1.65,
+		"thr_mod": 1.00
+	},
+	"gunshipkrow": {
+		"role": ["anti_heavy", "air", "disarm_target"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"since": 720,
+		"pwr_mod": 0.3,
+		"thr_mod": 0.3,
+		"limit": 0
+	},
+	"gunshiptrans": {
+		"role": ["air"],
+		"limit": 0
+	},
+	"gunshipheavytrans": {
+		"role": ["air"],
+		"limit": 0,
+		"thr_mod": 0.0
+	},
+	"gunshipaa": {
+		"role": ["anti_air", "air"],
+		"limit": 6,
+		"retreat": 0.95,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryamph
+	"amphcon": {
+		"role": ["builder", "mine"]
+	},
+	"amphraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"limit": 10,
+		"retreat": 0.25  // pretty disposable
+	},
+	"amphimpulse": {
+		"role": ["riot"],
+		"limit": 1,
+		"retreat": 0.36,
+		"pwr_mod": 2.25,
+		"thr_mod": 2.25
+	},
+	"amphfloater": {
+		"role": ["assault", "snipe_target", "super"],
+		"limit": 14,
+		"since": 120,
+		"retreat": 0.25, // too slow to be retreating all the time
+		"pwr_mod": 1.3,
+		"thr_mod": 1.3
+	},
+	"amphriot": {
+		"role": ["riot"],
+		"attribute": ["melee", "ret_fight"],
+		"pwr_mod": 1.5,
+		"retreat": 0.35 // too slow to be retreating all the time
+	},
+	"amphassault": {
+		"role": ["heavy", "disarm_target"],
+		"retreat": 0.66,
+		"since": 520,
+		"pwr_mod": 1.4,
+		"thr_mod": 1.0
+	},
+	"amphtele": {
+		"role": ["transport"],
+		"limit": 0
+	},
+	"amphaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight", "support"],
+		"retreat": 0.3,
+		"limit": 5,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.5
+	},
+
+	// factoryspider
+	"spidercon": {
+		"role": ["builder", "mine"]
+	},
+	"spiderscout": {
+		"role": ["scout", "raider"],
+		"thr_mod": 0.5,
+		"limit": 20,
+		"retreat": 0.01
+	},
+	"spiderassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.15,
+		"retreat": 0.35
+	},
+	"spideremp": {
+		"role": ["raider", "riot"],
+		"pwr_mod": 3.0,
+		"limit": 1,
+		"retreat": 0.5
+	},
+	"spiderriot": {
+		"role": ["riot"],
+		"pwr_mod": 2.0,
+		"limit": 4,
+		"attribute": ["support"],
+		"retreat": 0.35
+	},
+	"spiderskirm": {
+		"role": ["skirmish", "snipe_target", "super"],
+		"pwr_mod": 2.0,
+		"thr_mod": 1.0,
+		"since": 180,
+		"retreat": 0.4
+	},
+	"spidercrabe": {
+		"role": ["heavy", "disarm_target", "turtle"],
+		"attribute": ["siege", "ret_fight", "support"],
+		"retreat": 0.5,
+		"thr_mod": 2.5,
+		"pwr_mod": 2.5,
+		"since": 300,
+		"thr_mod": 1.0
+	},
+	"spiderantiheavy": {
+		"role": ["anti_heavy", "mine"],
+		"retreat": 0.99,
+		"pwr_mod": 2.0,
+		"thr_mod": 0.1,
+		"since": 600,
+		"limit": 1
+	},
+	"spideraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryshield
+	"shieldcon": {
+		"role": ["builder", "shieldball", "mine"],
+		"retreat": 1.3
+	},
+	"shieldscout": {
+		"role": ["transport", "raider"],
+		"limit": 20,
+		"attribute": ["siege", "melee"],
+		"pwr_mod": 0.11,
+		"thr_mod": 0.1,
+		"retreat": 0.0
+	},
+	"shieldraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"retreat": 0.25,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.9
+	},
+	"shieldskirm": {
+		"role": ["skirmish"],
+		"limit": 15,
+		"since": 200,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"retreat": 0.3
+	},
+	"shieldassault": {
+		"role": ["assault", "support", "shieldball"],
+		"attribute": ["melee"],
+		"limit": 20,
+		"retreat": 0.3,
+		"since": 120,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.35
+	},
+	"shieldriot": {
+		"role": ["riot", "shieldball"],
+		"fire_state": "hold",
+		"since": 100,
+		"limit": 5,
+		"retreat": 0.3,
+		"pwr_mod": 1.7,
+		"thr_mod": 1.7
+	},
+	"shieldfelon": {
+		"role": ["heavy", "shieldball", "snipe_target"],
+		"since": 420,
+		"retreat": 0.35,
+		"pwr_mod": 1.1,
+		"thr_mod": 1.1
+	},
+	"shieldarty": {
+		"role": ["disarm_target"],
+		"since": 300,
+		"retreat": 0.3,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"shieldbomb": {
+		"role": ["mine"]
+	},
+	"shieldshield": {
+		"role": ["super", "heavy", "shieldball"],
+		"since": 540,
+		"attribute": ["support"],
+		"retreat": 0.36,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.25
+	},
+	"shieldaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryveh
+	"vehcon": {
+		"role": ["builder", "mine"]
+	},
+	"vehscout": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"thr_mod": 0.6,
+		"pwr_mod": 1.2,
+		"retreat": 0.01,
+		"limit": 4
+	},
+	"vehraid": {
+		"role": ["raider"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.3,
+		"pwr_mod": 1.1,
+		"thr_mod": 0.8
+	},
+	"vehsupport": {
+		"role": ["artillery", "missileskirm"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.4,
+		"retreat": 0.6  // cannot retreat
+	},
+	"vehriot": {
+		"role": ["riot"],
+		"retreat": 0.6,
+		"pwr_mod": 1.5,
+		"thr_mod": 1.5
+	},
+	"vehassault": {
+		"role": ["assault"],
+		"attribute": ["melee"],
+		"retreat": 0.4,  // slow to turn around
+		"since": 180,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9
+	},
+	"vehcapture": {
+		"role": ["support", "disarm_target", "snipe_target"],
+		"since": 180,
+		"pwr_mod": 1,
+		"thr_mod": 1,
+		"retreat": 0.8
+	},
+	"veharty": {
+		"role": ["transport", "super"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 15,
+		"since": 460,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0,
+		"retreat": 0.8
+	},
+	"vehheavyarty": {
+		"role": ["artillery", "heavy", "turtle"],
+		"since": 300,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.00
+	},
+	"vehaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.75,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryjump
+	"jumpcon": {
+		"role": ["builder", "mine"]
+	},
+	"jumpscout": {
+		"role": ["riot", "raider"],
+		"limit": 15,
+		"attribute": ["melee", "siege"],
+		"retreat": 0
+	},
+	"jumpraid": {
+		"role": ["raider", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.4,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.9
+	},
+	"jumpblackhole": {
+		"role": ["support"],
+		"since": 300,
+		"limit": 6,
+		"retreat": 0.36
+	},
+	"jumpskirm": {
+		"role": ["skirmish", "super", "snipe_target"],
+		"retreat": 0.4
+	},
+	"jumpassault": {
+		"role": ["assault", "anti_sub", "disarm_target"],
+		"attribute": ["melee", "siege", "ret_fight"],
+		"retreat": 0.4,
+		"pwr_mod": 1.3,
+		"thr_mod": 0.5
+	},
+	"jumpsumo": {
+		"role": ["heavy", "support", "disarm_target"],
+		"limit": 0,
+		"attribute": ["melee", "no_jump"]  // jump on attack
+	},
+	"jumparty": {
+		"role": ["heavy", "turtle", "snipe_target"],
+		"attribute": ["support"],
+		"since": 600,
+		"pwr_mod": 0.1,
+		"limit": 2,
+		"thr_mod": 0.00,
+		"retreat": 0.99
+	},
+	"jumpbomb": {
+		"role": ["anti_heavy", "builder"],
+		"attribute": ["melee", "mine"],
+		"fire_state": "open",
+		"since": 720,
+		"limit": 2,
+		"retreat": 0.01,
+		"pwr_mod": 3.0,
+		"thr_mod": 0.01
+	},
+	"jumpaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryhover
+	"hovercon": {
+		"role": ["builder", "mine"]
+	},
+	"hoverraid": {
+		"role": ["scout"],
+		"attribute": ["melee"],		
+		"pwr_mod": 0.9,
+		"thr_mod": 0.8,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9,
+		"limit": 4,
+		"retreat": 0.5
+	},
+	"hoverheavyraid": {
+		"role": ["raider", "bullshit_raider"],	
+		"retreat": 0.35,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.8
+	},
+	"hoverskirm": {
+		"role": ["skirmish", "support"],
+		"retreat": 0.55,
+		"limit": 12,
+		"reload": 4.0,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.6
+	},
+	"hoverassault": {
+		"role": ["assault", "raider"],
+		"attribute": ["melee", "ret_hold"],
+		"retreat": 0.4,
+		"limit": 12,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.45
+	},
+	"hoverdepthcharge": {
+		"role": ["anti_sub", "riot"],
+		"attribute": ["melee"],
+		"retreat": 0.6
+	},
+	"hoverriot": {
+		"role": ["riot", "snipe_target"],
+		"retreat": 0.4,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.25
+	},
+	"hoverarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"attribute": ["siege"],
+		"retreat": 0.99,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"hoveraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryplane
+	"planecon": {
+		"role": ["builder", "air"],
+		"since": 240,
+		"limit": 2,
+		"retreat": 0.99
+	},
+	"planefighter": {
+		"role": ["scout", "air"],
+		"attribute": ["boost"],
+		"pwr_mod": 1.5,
+		"limit": 1,
+		"thr_mod": 3.0,
+		"retreat": 0.8
+	},
+	"planeheavyfighter": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"limit": 8,
+		"retreat": 0.4,
+		"pwr_mod": 2.5,
+		"thr_mod": 3.0
+	},
+	"bomberprec": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"attribute": ["siege"],
+		"limit": 10,
+		"retreat": 0.8,
+		"pwr_mod": 0.10,
+		"thr_mod": 0.01
+	},
+	"bomberriot": {
+		"role": ["bomber", "air"],
+		"limit": 0,
+		"retreat": 0.6,
+		"pwr_mod": 0.01,
+		"thr_mod": 0.01
+	},
+	"bomberdisarm": {
+		"role": ["anti_heavy", "air"],
+		"attribute": ["siege", "bomber"],
+		"limit": 2,
+		"since": 1200,
+		"retreat": 0.95,
+		"pwr_mod": 100.00,
+		"thr_mod": 0.01
+	},
+	"bomberheavy": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"fire_state": "return",
+		"limit": 4,
+		"since": 420,
+		"retreat": 0.95,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.1
+	},
+	"bomberassault": {
+		"role": ["bomber", "air"],
+		"attribute": ["anti_stat", "no_dgun"],
+		"fire_state": "hold",
+		"limit": 1,
+		"since": 1800,
+		"retreat": 0.65,
+		"pwr_mod": 1.25,
+		"thr_mod": 0.01
+	},
+	"planescout": {
+		"role": ["scout", "air"],
+		"since": 360,
+		"limit": 2,
+		"retreat": 0.8
+	},
+
+	// factorytank
+	"tankcon": {
+		"role": ["builder"],
+		"pwr_mod": 0.40,
+		"thr_mod": 0.40,
+		"retreat": 0.9
+	},
+	"tankraid": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"limit": 2,
+		"thr_mod": 0.66,
+		"pwr_mod": 0.8,
+		"retreat": 0.45
+	},
+	"tankheavyraid": {
+		"role": ["raider", "bullshit_raider"],
+		"thr_mod": 0.6,
+		"pwr_mod": 0.65,
+		"retreat": 0.65
+	},
+	"tankriot": {
+		"role": ["riot", "heavy", "snipe_target"],
+		"thr_mod": 1.25,
+		"pwr_mod": 0.75,
+		"retreat": 0.55
+	},
+	"tankassault": {
+		"role": ["assault", "heavy", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7
+	},
+	"tankheavyassault": {
+		"role": ["heavy", "disarm_target", "super"],
+		"attribute": ["melee"],
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7,
+		"since": 480,
+		"retreat": 0.55
+	},
+	"tankarty": {
+		"role": ["artillery", "snipe_target", "heavy"],
+		"attribute": ["support"],
+		"since": 1000,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.0
+	},
+	"tankheavyarty": {
+		"role": ["transport"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 1,
+		"retreat": 0.99,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0
+	},
+	"tankaa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryship
+	"shipcon": {
+		"role": ["builder"]
+	},
+	"shipscout": {
+		"role": ["scout"]
+	},
+	"shiptorpraider": {
+		"role": ["raider"]
+	},
+	"subraider": {
+		"role": ["raider"]
+	},
+	"shipriot": {
+		"role": ["riot"]
+	},
+	"shipskirm": {
+		"role": ["skirmish"]
+	},
+	"shipassault": {
+		"role": ["assault"]
+	},
+	"shiparty": {
+		"role": ["artillery"]
+	},
+	"shipaa": {
+		"role": ["anti_air"]
+	},
+
+	// striderhub
+	"striderantiheavy": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"pwr_mod": 0.5,
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.35
+	},
+	"striderscorpion": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"fire_state": "return",
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"since": 1800,
+		"thr_mod": 0.5
+	},
+	"striderdante": {
+		"role": ["heavy", "disarm_target", "snipe_target"],
+		"attribute": ["melee"],
+		"limit": 2,
+		"retreat": 0.45,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.75
+	},
+	"striderarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"pwr_mod": 5.0,
+		"thr_mod": 0.0,
+		"retreat": 0.9
+	},
+	"striderfunnelweb": {
+		"role": ["heavy", "turtle", "shieldball"],
+		"attribute": ["support"],
+		"retreat": 1.4,
+		"pwr_mod": 1.0,
+		"limit": 1,
+		"since": 3000,
+		"thr_mod": 0.0
+	},
+	"striderbantha": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.5
+	},
+	"striderdetriment": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.50,  // deffo retreat, running into nab annihlator farm and sploding is silly :)
+		"pwr_mod": 0.34,
+		"thr_mod": 0.34
+	},
+	"subtacmissile": {
+		"role": ["artillery", "heavy"],
+		"attribute": ["stockpile"]
+	},
+	"shipcarrier": {
+		"role": ["artillery", "heavy"]
+	},
+	"shipheavyarty": {
+		"role": ["artillery", "heavy"]
+	},
+
+	// statics
+	"staticnuke": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 30.0,
+		"limit": 1,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"staticmissilesilo": {
+		"role": ["static", "support", "heavy"],
+		"thr_mod": 0.01
+	},
+	"raveparty": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"zenith": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 105.0,  // 105sec / 0.7sec/met = 150 meteorsControlled
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"mahlazer": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"staticheavyarty": {
+		"role": ["artillery", "turtle", "heavy"],
+		"limit": 5,
+		"thr_mod": 0.0,
+		"pwr_mod": 10.00
+	},
+	"turretheavy": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 1.00
+	},
+	"turretantiheavy": {
+		"role": ["static", "turtle", "static"],
+		"thr_mod": 0.55
+	},
+	"staticarty": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 0.55
+	},
+	"staticantinuke": {
+		"role": ["static", "heavy", "support"],
+		"since": 720,
+		"limit": 1
+	},
+	"turretheavylaser": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.0
+	},
+	"energysingu": {
+		"role": ["static", "turtle", "heavy"],
+		"attribute": ["support"],  // build at home
+		"since": 660
+	},
+	"energyfusion": {
+		"role": ["static", "mine", "heavy"],
+		"attribute": ["support"],  // build at home
+		"since": 280
+	},
+	"turretaalaser": {
+		"role": ["anti_air"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.0
+	},
+	"turretaaheavy": {
+		"role": ["anti_air", "heavy", "turtle"],
+		"limit": 1,
+		"thr_mod": 1.0
+	},
+	"turretlaser": {
+		"role": ["static", "riot", "builder"],
+		"thr_mod": 1.5
+	},
+	"turretmissile": {
+		"role": ["missileskirm", "riot", "builder"],
+		"thr_mod": 0.34
+	},
+	"turretriot": {
+		"role": ["static", "riot", "snipe_target"],
+		"thr_mod": 1.65
+	},
+	"turretaafar": {
+		"role": ["anti_air", "heavy", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaflak": {
+		"role": ["anti_air", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaclose": {
+		"role": ["anti_air"],
+		"thr_mod": 1.0
+	},
+	"turretgauss": {
+		"role": ["static", "turtle", "transport"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.6
+	},
+	"turretemp": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.5
+	},
+
+	// support factories won't be built in front
+	"factoryplane": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"factorygunship": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"striderhub": {
+		"role": ["static"],
+		"since": 900,
+		"attribute": ["support"]
+	},
+
+	// Enemy Eco!! //
+	"staticmex": {
+		"role": ["mine"]
+	},
+	"energywind": {
+		"role": ["mine"]
+	},
+	"staticradar": {
+		"role": ["mine"]
+	},
+	"staticcon": {
+		"role": ["mine"]
+	},
+	"energypylon": {
+		"role": ["mine"],
+		"since": 600
+	},
+	"staticheavyradar": {
+		"role": ["mine", "turtle"],
+		"limit": 1
+	},
+	"staticstorage": {
+		"role": ["mine", "turtle"],
+		"limit": 5
+	},
+	"energysolar": {
+		"role": ["mine"]
+	},
+	"staticshield": {
+		"role": ["static", "turtle"]
+	},
+
+	// Chickens!! //
+	"dronecarry": {
+		"role": ["transport"]
+	},
+	"chicken": {
+		"role": ["raider"]
+	},
+	"chicken_blimpy": {
+		"role": ["mine"]
+	},
+	"chicken_digger": {
+		"role": ["riot"]
+	},
+	"chicken_dodo": {
+		"role": ["mine"]
+	},
+	"chicken_dragon": {
+		"role": ["heavy"],
+		"thr_mod": 0.4
+	},
+	"chicken_drone": {
+		"role": ["raider"]
+	},
+	"chicken_drone_starter": {
+		"role": ["raider"]
+	},
+	"chicken_leaper": {
+		"role": ["raider"]
+	},
+	"chicken_listener": {
+		"role": ["static"]
+	},
+	"chicken_pigeon": {
+		"role": ["air"]
+	},
+	"chicken_roc": {
+		"role": ["air"]
+	},
+	"chicken_shield": {
+		"role": ["support"]
+	},
+	"chicken_spidermonkey": {
+		"role": ["anti_air"]
+	},
+	"chicken_tiamat": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenblobber": {
+		"role": ["artillery"]
+	},
+	"chickenbroodqueen": {
+		"role": ["heavy"],
+		"thr_mod": 0.05
+	},
+	"chickenflyerqueen": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenlandqueen": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenspire": {
+		"role": ["static"]
+	},
+	"chickena": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenc": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickend": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenf": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenr": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenwurm": {
+		"role": ["heavy"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/block_map.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/block_map.json
@@ -1,0 +1,139 @@
+// Mono-space font required
+{
+"building": {
+	"class_land": {
+		"fac_land": {
+			// "type": [<blocker_shape>, <structure_type>]
+			// Available blocker_shape: rectangle, circle.
+			// Available structure_type: factory, mex, engy_low, engy_mid, engy_high, pylon, def_low, def_mid, def_high, special, nano, terra, unknown
+			"type": ["rectangle", "factory"],
+
+			// Unit of measurement: 1 size/yard/radius = SQUARE_SIZE * 2 = 16 elmos, integer.
+			// Offset in South facing
+			"offset": [0, 6],  // default: [0, 0]
+
+			// Size of a blocker without yard
+//			"size": [7, 7],  // default: size of a unit
+
+			// Spacer, blocker_size = size + yard
+			"yard": [12, 12]  // default: [0, 0]
+
+			// "ignore": [<structure_type>, <structure_type>, ...]
+			// Ignore specified structures.
+			// Additional values: none, all
+//			"ignore": ["none"]  // default: ["none"]
+		},
+		"fac_air": {
+			"type": ["rectangle", "factory"],
+			"yard": [8, 8]
+		},
+		"fac_water": {
+			"type": ["rectangle", "factory"],
+			"offset": [0, 4],
+			"yard": [10, 12]
+		},
+		"fac_strider": {
+			"type": ["rectangle", "special"],
+			"offset": [0, 12],
+			"yard": [16, 16]
+		},
+		"solar": {
+			"type": ["circle", "engy_low"],
+			"ignore": ["mex", "engy_mid", "engy_high", "def_low", "pylon", "nano"],
+			"radius": 7
+		},
+		"wind": {
+			"type": ["circle", "engy_low"],
+			// Integer radius of a blocker or description string.
+			// Available string values: explosion, expl_ally
+//			"radius": "explosion",  // default: "explosion"
+			"radius": 4,
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"fusion": {
+			"type": ["circle", "engy_mid"],
+			"ignore": ["mex", "pylon", "def_low"]
+		},
+		"singu": {
+			"type": ["circle", "engy_high"],
+			"radius": "expl_ally",  // [radius ~ 1 player .. radius/2 ~ 4+ players]
+			"ignore": ["mex", "engy_low", "def_low", "pylon", "nano"]
+		},
+		"pylon": {
+			"type": ["circle", "pylon"],
+			"not_ignore": ["factory", "engy_low", "pylon", "terra"]  // default: ["all"]
+		},
+		"store": {
+			"type": ["rectangle", "mex"],
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"mex": {
+			"type": ["rectangle", "mex"],
+			"ignore": ["all"]
+		},
+		"def_low": {
+			"type": ["circle", "def_low"],
+			"radius": 10,  // 160 / (SQUARE_SIZE * 2)
+			"ignore": ["engy_mid", "engy_high", "pylon", "nano"]
+		},
+		"caretaker": {
+			"type": ["rectangle", "nano"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+		"small": {
+			"type": ["rectangle", "unknown"],
+			"not_ignore": ["factory", "def_low", "terra"]
+		},
+		"superweapon": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "pylon", "engy_high"]
+		},
+		"protector": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+//		"terraform": {
+//			"type": ["rectangle", "special"],
+//			"size": [7, 7]  // int2(3 + 4, 3 + 4)
+//		},
+		"strider": {
+			"type": ["rectangle", "special"],
+			"yard": [2, 2],
+			"ignore": ["all"]
+		},
+		"_default_": {
+			"type": ["rectangle", "unknown"],
+			"yard": [4, 4],
+			"ignore": ["pylon", "engy_high"]
+		}
+	},
+	// Water overrides land. Map considered as water if amount of land < 40%
+	"class_water" : {
+		"wind": {
+			"type": ["circle", "engy_low"],
+			"radius": 1,  // default: "explosion"
+			"ignore": ["mex", "engy_mid", "engy_high", "pylon", "nano"]
+		}
+	},
+	"instance": {
+		"fac_land": ["factorycloak", "factoryamph", "factoryhover", "factoryjump", "factoryshield", "factoryspider", "factorytank", "factoryveh"],
+		"fac_air": ["factoryplane", "factorygunship"],
+		"fac_water": ["factoryship"],
+		"fac_strider": ["striderhub"],
+		"solar": ["energysolar"],
+		"wind": ["energywind"],
+		"fusion": ["energyfusion"],
+		"singu": ["energysingu"],
+		"pylon": ["energypylon"],
+		"store": ["staticstorage"],
+		"mex": ["staticmex"],
+		"def_low": ["turretmissile", "turretlaser", "staticarty"],
+		"caretaker": ["staticcon", "staticrearm"],
+		"superweapon": ["raveparty", "staticnuke", "zenith", "turretaaheavy", "staticheavyarty", "staticantinuke", "staticheavyradar"],
+//		"protector": ["staticantinuke"],
+//		"terraform": ["terraunit"],
+		"strider": ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"small": ["staticradar"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/build_chain.json
@@ -1,0 +1,249 @@
+// Mono-space font required
+{
+"porcupine": {
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//        5              6                7             8                 9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10             11               12            13                14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		        16
+		"staticantinuke", "staticheavyradar"
+	],
+	// Actual number of defences per cluster bounded by income
+	"land":  [0, 0, 1, 3, 5, 1, 2, 14, 1, 9, 5, 6, 2, 3, 5, 0, 8, 9, 14, 1, 3, 6, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
+	"prevent": 1,  // number of preventive defences
+	"amount": {  // income bound factor
+		"offset": [-0.15, 0.4],
+		// Amount factor: 4x4 ~ 1.85, 20x20 ~ 1.45
+		"factor": [1.55, 1.30],
+		"map": [4, 20]
+	},
+
+
+	// Base defence and time to build it, in seconds
+	"base": [[0, 10], [1, 300], [0, 310], [1, 400], [6, 450], [0, 500], [16, 600], [5, 660], [1, 990], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [15, 1850]],
+
+	"superweapon": {
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "mahlazer", "staticantinuke"],  // FIXME: last aren't superweapon
+		"weight": [ 0.10,         0.20,        0.20,              0.10,     0.10,    0.10],
+
+		"condition": [16, 20000]  // [<Minimum income>, <maximum seconds to build>]
+	},
+
+	// Fallback defence
+	"default": "turretmissile"
+},
+
+// Actions on building finished event
+"build_chain": {
+	// WARNING: Avoid recursion
+	// <category>: factory, nano, store, pylon, energy, defence, bunker, big_gun, radar, sonar, mex, repair
+	"energy": {
+		// <UnitDef>: {<elements>}
+		"energysingu": {
+			// Available elements:
+			// "energy": [max energy income, <"mex"|true>]
+			// "pylon": <boolean>
+			// "porc": <boolean>
+			// "terra": <boolean>
+			// "hub": [
+			//     // chain1
+			//     [{<unit1>, <category>, <offset>, <condition>}, {<unit2>, <category>, <offset>, <condition>}, ...],
+			//     // chain2
+			//     [{...}, {...}, ...],
+			//     ...
+			// ]
+			// <unit>: UnitDef
+			// <offset>:
+			//     1) [x, z] in South facing, elmos
+			//     2) {<direction>: <delta>} - left, right, front, back
+			// <condition>: air, no_air, maybe
+
+			// Build pylon in direction of nearby mex cluster
+//			"pylon": true,
+
+			// Build chain of units
+			"hub": [
+				[  // chain1
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				],
+				[  // chain2
+					{"unit": "turretlaser", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 80}},
+					{"unit": "turretmissile", "category": "defence", "offset": [70, -70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				]
+			]
+		},
+		"energyfusion": {
+//			"pylon": true,
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, 80]}
+				]]
+		}
+	},
+	"factory": {
+		"factoryplane": {
+			"hub": [[{"unit": "staticrearm", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"factorygunship": {
+			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"striderhub": {
+			"pylon": true
+		}
+	},
+	"mex": {
+		"staticmex": {
+//			"terra": true,
+			"energy": [20, "mex"],
+			"porc": true
+		}
+	},
+	"big_gun": {
+		"staticheavyarty": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"raveparty": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"mahlazer": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"zenith": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticheavyradar": {
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]}
+				]]
+		},
+		"staticnuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"energypylon": {
+			"hub": [[
+					{"unit": "turretmissile", "category": "radar", "offset": {"back": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": {"left": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": {"back": -100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]}
+				]]
+		},
+		"turretaaheavy": {
+			"pylon": true,
+			"hub": [
+					[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		}
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/commander.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/commander.json
@@ -1,0 +1,383 @@
+// Mono-space font required
+{
+"commander": {
+	"prefix": "dyntrainer_",
+	"suffix": "_base",
+	"unit": {
+		"support": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["builder", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "builder", "scout", "skirmish", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["scout", "builder", "scout", "riot", "raider", "raider", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.9, ["builder", "raider", "scout", "raider", "raider", "scout", "raider", "raider", "scout", "builder"]],
+						[0.1, ["builder", "raider", "raider", "scout",  "skirmish", "builder", "skirmish", "scout"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "riot"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "scout", "scout", "raider", "raider", "builder", "builder"]],
+						[0.5, ["builder", "scout", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout","builder", "scout", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["riot", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[13, 42],  // shotgun
+					[31, 42],  // Cloak, Nano
+					[15, 41, 37],  // sniper, range, health
+					[34, 34, 34],  // companion drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 34],  // battle drones, companion drones
+					[34, 34, 34],  // companion drones
+					[34, 40, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 36, 36],  // health, regen
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 27, 29],  // nano, disruptor ammo, jammer
+					[32, 33, 30],  // area cloak, lazarus, radar
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 38, 38],  // range, high density
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39]  // damage
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 360,  // seconds
+				"threat": 30,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"recon": {
+			// Choice importance, 0 by default
+			"importance": 0.65,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["builder", "raider", "riot", "raider", "raider", "raider", "raider"]]
+						],
+					"factorygunship": [
+						[0.8, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.2, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.2, ["scout", "scout", "builder", "raider", "raider", "raider", "raider", "scout"]],
+						[0.8, ["builder", "scout",  "raider", "scout", "raider", "raider", "raider", "scout", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider"]],
+						[0.5, ["builder", "raider", "raider", "scout", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider", "raider",  "raider"]],
+						[0.5, ["builder", "scout", "scout", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["builder", "scout", "scout", "raider", "builder", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "scout", "builder", "scout", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 240,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[7, 37],  // Machinegun
+					[31, 36],  // Cloak, Regen
+					[19, 38, 39],  // disruptor bomb, high density, damage boost
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 37, 37],  // speed, health
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, builder
+					[42, 42, 42],  // builder
+					[42, 42, 42],  // builder
+					[30, 27, 29],  // radar, disruptor ammo, jammer
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 41, 39],  // range, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 600,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"assault": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["anti_heavy"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.10, ["scout", "builder", "skirmish", "builder", "riot", "builder", "scout", "scout", "scout", "skirmish", "skirmish", "skirmish"]],
+						[0.15, ["scout", "scout", "builder", "riot", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "skirmish", "builder", "riot"]],
+						[0.75, ["scout", "scout", "raider", "raider", "builder", "builder", "raider", "raider", "raider", "raider", "raider", "builder", "scout"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "raider", "raider", "raider", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "heavy"]],
+						[0.25, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "raider", "raider", "raider", "builder", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "scout", "scout", "scout", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout", "builder", "assault"]],
+						[0.5, ["scout", "scout", "builder", "raider", "scout", "raider", "builder", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[11],  // shotgun
+					[24, 37],  // shield, health
+					[11, 41, 41],  // Double Riot, range
+					[38, 41, 41],  // high density, range
+					[36, 41, 36],  // regen, range, regen
+					[41, 41, 41],  // range
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39, 25],  // damage, area shield
+					[26, 29, 30],  // napalm, jammer, radar
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 36, 36],  // speed, regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 38, 38],  // health, high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 140,  // seconds
+				"threat": 70,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"strike": {
+		   // Choice importance, 0 by default
+			"importance": 0.1,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "scout", "scout", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "scout", "builder", "riot"]],
+						[0.9, ["builder", "scout",  "scout",  "raider", "raider", "raider", "raider", "raider", "builder", "builder", "scout",  "raider", "raider", "raider", "raider", "raider", "builder"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "scout", "scout", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "raider", "raider", "skirmish", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.25, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "assault"]],
+						[0.5, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "scout", "scout", "raider", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 315,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[8, 37],  // beam laser
+					[31, 36],  // cloak, regen
+					[8, 40, 36],  // lightning, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[40, 40, 40],  // speed
+					[28, 29, 30],  // flux, jammer, radar
+					[36, 36, 37],  // regen, health
+					[37, 37, 37],  // health
+					[32, 41, 41],  // area cloak, range
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 42],  // companion drones, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 39, 39],  // nano, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 480,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		}
+	}
+}
+} 

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/economy.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/economy.json
@@ -1,0 +1,69 @@
+// Mono-space font required
+{
+"economy": {
+	// Plain list of energy UnitDef and its limit. AI sorts list by efficiency (inverse)
+	// which is = cost * sizeX * sizeZ / make^2
+	// With ZK v1.8.5.2:
+	//   energysingu = 15.486420
+	//   energygeo = 65.306122
+	//   energyfusion = 80.000000
+	//   energywind = 874.999939
+	//   energysolar = 1750.000000
+	// When e-stalling AI will build bottom-most energy that didn't reach its limit.
+	// On normal AI will select top-most energy that it can build under 40 seconds.
+	"energy": {
+		// If land area >= 40% of the map then "land" config used, "water" otherwise
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>]
+			// limit = random(<lower limit>..<upper limit>)
+			"energysingu": [6],
+			"energygeo": [0, 2],
+			"energyfusion": [6, 10],
+			"energywind": [8, 12],
+			"energysolar": [40]
+		},
+		"water": {
+			"energysingu": [1],
+			"energygeo": [0],
+			"energyfusion": [4],
+			"energywind": [20],
+			"energysolar": [8, 12]
+		},
+		// income factor for energy, time is in seconds
+		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]
+		"factor": [[0.15, 1], [7.0, 3600]],
+
+		"link_inc": 16.0,  // minimum metal-income for energy linking
+		"pylon": ["energypylon", "energysolar", "energywind"]
+	},
+
+	// Scales metal income
+	// ecoFactor = teamSize*eps_step+(1-eps_step)
+	"eps_step": 0.2,
+
+	// Mobile buildpower to metal income ratio
+	"buildpower": 1.25,
+	// Metal excess to income ratio, -1 to disable
+	"excess": -1.0,
+	// Mobile constructor to static constructor metal pull ratio
+	// [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
+//	"ms_pull": [[0.75, 0.0], [0.45, 0.10], [0.53, 0.25], [0.56, 0.40], [0.63, 0.44],[0.52, 0.48],[0.66, 0.52],[0.50, 0.56],[0.66, 0.60], [0.60, 0.65], [0.7, 0.66], [0.8, 0.66], [0.9, 0.75], [0.99, 0.90]],
+	"ms_pull": [[2.0, 0.0], [0.45, 0.20], [0.99, 0.90]],
+	// Max percent of mexes circuit team allowed to take.
+	// If its <1.0 then expansion obeys ms_pull rule, if >=1.0 then ms_pull doesn't affect expansion (mex, pylon, energy).
+	// [<cap_percent>, <is_ally_cap>]
+	"mex_max": [2.0, false],  // 200%
+	// Construction order delay in seconds, -1 to disable
+	"build_delay": [[-1.0, 0], [-1.0, 0]],
+
+	// New factory switch interval, in seconds (each new factory resets timer, switch event is also based on eco + caretakers)
+	// switch = random(<min_interval>..<max_interval>)
+	"switch": [800, 900],
+
+	"terra": "terraunit",
+	"airpad": "staticrearm",
+
+	// Unknown UnitDef replacer
+	"default": "turretmissile"
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/factory.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/factory.json
@@ -1,0 +1,380 @@
+// Mono-space font required
+{
+// Factory selection parameters
+"select": {
+	"air_map": 80,
+	"offset": [-20, 20],
+	// Speed factor: 8x8 ~ 0%, 24x24 ~ 40%
+	"speed": [0, 40],
+	"map": [8, 24],
+	"no_air": 3
+},
+
+// Utility param: warning on unit's total probability not equal to 100%
+"warn_probability": true,
+
+// Define factories
+"factory": {
+	"factorycloak": {
+		// Adjusts the priority of factory choice (factories with map_percent < 20 are ignored)
+		// map_percent is [20..100]
+		// On start:
+		//   if factory has available builder in current frame: priority ~= map_percent * importance0 + random(-20..+20)
+		//   if factory's builder unavailable in current frame: priority ~= map_percent * importance0 / 10 + random(-20..+20)
+		// During game: priority ~= map_percent * importance1 + random(-20..+20)
+		// importanceN = 1.0 by default if not set
+		"importance": [0.78, 0.2],
+
+		// 'require_energy' adds energy requirement for tierN (N>0): fallback to lowest tier on low energy
+		"require_energy": true,
+
+		// If income*ecoFactor < income_tier[N] then 'tierN' probability will be used
+		"income_tier": [20, 30, 40],
+
+		//             conjurer,   glaive,      scythe,           rocko,        warrior,     zeus,           hammer,      sniper,       tick,        eraser,        gremlin
+		"unit":      ["cloakcon", "cloakraid", "cloakheavyraid", "cloakskirm", "cloakriot", "cloakassault", "cloakarty", "cloaksnipe", "cloakbomb", "cloakjammer", "cloakaa"],
+
+		"land": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.03,             0.30,         0.03,        0.00,           0.00,        0.00,         0.00,        0.00,          0.00],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.20,       0.10,        0.06,             0.51,         0.10,        0.00,           0.00,        0.03,         0.00,        0.00,          0.00],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.25,       0.01,        0.20,             0.20,         0.03,        0.00,           0.00,        0.20,         0.00,        0.11,          0.00]
+
+			// 25-32m Expansions meet - Economy can afford to begin producing in bulk so unit compositions alter.
+	//		"tier3": [ 0.10,       0.40,        0.05,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 33m -40m Solid Fronts - Now we stop raiding and start pushing.
+	//		"tier4": [ 0.10,       0.35,        0.10,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 41m - 56m Mid Game - we must have 2 facs by now, stop making balanced compositions and start being abusive.
+	//		"tier5": [ 0.10,       0.05,        0.25,             0.10,         0.00,        0.20,           0.10,        0.00,         0.00,        0.10,          0.00],
+
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+	//		"tier6": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00],
+
+			// 72m - inf+ Late late Game - This fac sucks!
+	//		"tier7": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00]
+		},
+		"air": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.26,             0.00,         0.00,        0.00,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.10,       0.25,        0.11,             0.38,         0.00,        0.06,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.20,       0.10,        0.10,             0.33,         0.00,        0.12,           0.00,        0.00,         0.00,        0.05,          0.10]
+		},
+		"caretaker": 6
+	},
+
+	"factorygunship": {
+		"importance": [15.0, 1.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 85],
+		//             wasp,         blastwing,     gnat,         banshee,       rapier,         brawler,             blackdawn,        krow,          valkyrie,       vindicator,          trident
+		"unit":      ["gunshipcon", "gunshipbomb", "gunshipemp", "gunshipraid", "gunshipskirm", "gunshipheavyskirm", "gunshipassault", "gunshipkrow", "gunshiptrans", "gunshipheavytrans", "gunshipaa"],
+		"land": {
+			// 0-8m Opening - Blastwing and banshee Harass
+			"tier0": [ 0.00,         0.00,          0.00,         0.00,          0.98,           0.00,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 9-16m Early Game - Banshee with a chance of Blackdawn
+			"tier1": [ 0.00,         0.20,          0.00,         0.02,          0.45,           0.31,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 17-24m Expanding - Time to start a-makin Brawlers
+			"tier2": [ 0.00,         0.02,          0.00,         0.00,          0.04,           0.90,                0.04,             0.00,          0.00,           0.00,                0.00],
+			// 25-32m Expansions meet - Time to keep a-makin Brawlers
+			"tier3": [ 0.00,         0.05,          0.00,         0.00,          0.04,           0.83,                0.08,             0.00,          0.00,           0.00,                0.00],
+			// 33m -40m Solid Fronts - Brawlers with a chance of Krow
+			"tier4": [ 0.00,         0.04,          0.00,         0.00,          0.05,           0.80,                0.10,             0.01,          0.00,           0.00,                0.00],
+			// 41m - 56m Mid Game - Brawlers with a bigger chance of Krow
+			"tier5": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.87,                0.06,             0.02,          0.00,           0.00,                0.00],
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+			"tier6": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.84,                0.07,             0.04,          0.00,           0.00,                0.00],
+			// 72m - inf+ Late late Game - Spam Krows!
+			"tier7": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.90,                0.00,             0.05,          0.00,           0.00,                0.00]
+		},
+		"caretaker": 6
+	},
+
+	"factoryamph": {
+		"importance": [0.85, 1.0],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             conch,     duck,       archer,        buoy,          scallop,    grizzly,       djinn,      angler
+		"unit":      ["amphcon", "amphraid", "amphimpulse", "amphfloater", "amphriot", "amphassault", "amphtele", "amphaa"],
+		"land": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.53,       0.25,          0.20,          0.02,       0.00,          0.00,       0.00],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.16,          0.47,          0.22,       0.00,          0.00,       0.00],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.10,       0.09,          0.51,          0.15,       0.05,          0.00,       0.00],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.47,          0.12,       0.13,          0.00,       0.00],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.16,      0.11,       0.02,          0.52,          0.04,       0.15,          0.00,       0.00],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.20,      0.10,       0.02,          0.49,          0.02,       0.17,          0.00,       0.00],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.48,          0.02,       0.18,          0.00,       0.00],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.46,          0.02,       0.22,          0.00,       0.00]
+		},
+		"air": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.58,       0.25,          0.10,          0.02,       0.00,          0.00,       0.05],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.11,          0.47,          0.22,       0.00,          0.00,       0.05],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.11,       0.04,          0.53,          0.12,       0.05,          0.00,       0.05],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.42,          0.12,       0.13,          0.00,       0.05],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.15,      0.10,       0.02,          0.49,          0.04,       0.15,          0.00,       0.05],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.16,      0.13,       0.02,          0.45,          0.02,       0.17,          0.00,       0.05],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.43,          0.02,       0.18,          0.00,       0.05],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.41,          0.02,       0.22,          0.00,       0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryspider": {
+		"importance": [0.71, 0.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             weaver,      flea,          hermit,          venom,       redback,      recluse,       crabe,         infiltrator,       tarantula
+		"unit":      ["spidercon", "spiderscout", "spiderassault", "spideremp", "spiderriot", "spiderskirm", "spidercrabe", "spiderantiheavy", "spideraa"],
+		"land": {
+			// 0-12m Opening - Opening turbo Flea spam & Riots
+			"tier0": [ 0.00,        0.73,          0.00,            0.22,        0.05,         0.00,          0.00,          0.00,              0.00],
+			// 13-18m Early Game - Reducing Flea spam, still mostly Riots
+			"tier1": [ 0.00,        0.59,          0.00,            0.05,        0.05,         0.31,          0.00,          0.00,              0.00],
+			// 17-24m Expanding - Slant production towards Hermit & Redback
+			"tier2": [ 0.06,        0.48,          0.04,            0.05,        0.00,         0.35,          0.02,          0.00,              0.00],
+			// 25-32m Expansions meet - Slant production towards Hermit & Recluse
+			"tier3": [ 0.08,        0.45,          0.06,            0.03,        0.00,         0.33,          0.05,          0.00,              0.00],
+			// 33m -40m Solid Fronts - 	Greater Emphasis on Hermit & Crabbe
+			"tier4": [ 0.08,        0.40,          0.09,            0.03,        0.00,         0.32,          0.08,          0.00,              0.00],
+			// 41m - 56m Mid Game - We need more Crabbes
+			"tier5": [ 0.08,        0.42,          0.07,            0.02,        0.00,         0.31,          0.10,          0.00,              0.00],
+			// 57m - 72m Late Game -  MORE CRABBES
+			"tier6": [ 0.09,        0.40,          0.11,            0.00,        0.00,         0.29,          0.11,          0.00,              0.00],
+			// 72m - inf+ Late late Game - TURBO CRABBES
+			"tier7": [ 0.10,        0.35,          0.20,            0.00,        0.00,         0.22,          0.13,          0.00,              0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryveh": {
+		"importance": [0.95, 0.2],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             mason,    dart,       scorcher,  slasher,      leveler,   ravager,      dominatrix,   wolverine, impaler,        crasher
+		"unit":      ["vehcon", "vehscout", "vehraid", "vehsupport", "vehriot", "vehassault", "vehcapture", "veharty", "vehheavyarty", "vehaa"],
+		"land": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.12,       0.00,      0.00,         0.20,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.20,      0.60,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.59,         0.01,         0.00,      0.04,           0.00],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.10,       0.00,      0.00,         0.10,      0.56,         0.02,         0.00,      0.07,           0.00],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.10,       0.00,      0.00,         0.06,      0.57,         0.05,         0.00,      0.07,           0.00]
+		},
+		"air": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.10,       0.00,      0.00,         0.22,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.15,      0.65,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.05,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.05],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.56,         0.02,         0.00,      0.03,           0.05],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.56,         0.01,         0.00,      0.04,           0.03],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.15,       0.00,      0.00,         0.10,      0.46,         0.02,         0.00,      0.07,           0.05],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.05,       0.00,      0.00,         0.16,      0.47,         0.05,         0.00,      0.07,           0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryhover": {
+		"importance": [1.00, 1.1],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             quill,      dagger,      scalpel,      halberd,        claymore,           mace,        penetrator,  flail,        bolas
+		"unit":      ["hovercon", "hoverraid", "hoverskirm", "hoverassault", "hoverdepthcharge", "hoverriot", "hoverarty", "hoveraa", "hoverheavyraid"],
+		"land": {
+			// 0-8m Opening - Raiders and Riots
+			"tier0": [ 0.00,       0.55,        0.10,         0.00,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 9-16m Early Game - Mostly Mace, some support
+			"tier1": [ 0.00,       0.10,        0.44,         0.11,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 17-24m Expanding - MAXIMUM OP Scalpel time
+			"tier2": [ 0.05,       0.10,        0.43,         0.20,           0.00,               0.14,        0.08,        0.00,        0.00],
+			// 25-32m Expansions meet - Mix in some Halberds
+			"tier3": [ 0.15,       0.10,        0.26,         0.20,           0.01,               0.16,        0.12,        0.00,        0.00],
+			// 33m -40m Solid Fronts - 	More Halberd and Pene
+			"tier4": [ 0.17,       0.13,        0.19,         0.31,           0.01,               0.05,        0.14,        0.00,        0.00],
+			// 41m - 56m Mid Game - Even more Halberd and Pene
+			"tier5": [ 0.17,       0.11,        0.17,         0.30,           0.01,               0.05,        0.19,        0.00,        0.00],
+			// 57m - 72m Late Game - More Pene
+			"tier6": [ 0.20,       0.04,        0.10,         0.34,           0.01,               0.10,        0.21,        0.00,        0.00],
+			// 72m - inf+ Late late Game - MAXIMUM PENE
+			"tier7": [ 0.25,       0.02,        0.07,         0.21,           0.00,               0.10,        0.35,        0.00,        0.00]
+		},
+		"water": {
+			// 33m -40m
+			"tier4": [ 0.00,       0.49,        0.10,         0.20,           0.10,               0.10,        0.01,        0.00],
+			// 41m - inf+4
+			"tier5": [ 0.00,       0.24,        0.05,         0.41,           0.20,               0.05,        0.05,        0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryplane": {
+		"importance": [12.0, 12.1],
+		"require_energy": false,
+
+		"income_tier": [30, 60],
+		//             crane,      swift,          hawk,                raven,        phoenix,      thunderbird,    wyvern,        vulture
+		"unit":      ["planecon", "planefighter", "planeheavyfighter", "bomberprec", "bomberriot", "bomberdisarm", "bomberheavy", "planescout"],
+		"air": {
+			// 0-10m Early Game
+			"tier0": [ 0.00,       0.00,           0.75,                0.15,         0.00,         0.00,           0.05,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.00,       0.00,           0.51,                0.00,         0.02,         0.01,           0.24,          0.22]
+		},
+		"land": {
+			// 0-10m Early Game
+			"tier0": [ 0.10,       0.00,           0.00,                0.60,         0.05,         0.00,           0.20,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.10,       0.00,           0.00,                0.05,         0.00,         0.00,           0.40,          0.45]
+		},
+		"caretaker": 6
+	},
+
+	"factorytank": {
+		"importance": [0.9, 1.5],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             welder,    kodachi,    panther,         banisher,   reaper,        goliath,            pillager,   tremor,          copperhead
+		"unit":      ["tankcon", "tankraid", "tankheavyraid", "tankriot", "tankassault", "tankheavyassault", "tankarty", "tankheavyarty", "tankaa"],
+		"land": {
+			// 0-8m Opening - Koda and Banisher
+			"tier0": [ 0.10,      0.60,       0.10,            0.20,       0.00,          0.00,               0.00,       0.00,            0.00],
+			// 9-16m Early Game - Mostly Banisher
+			"tier1": [ 0.10,      0.15,       0.10,            0.23,       0.42,          0.00,               0.00,       0.00,            0.00],
+			// 17-24m Expanding - Begin mixing in Reapers!
+			"tier2": [ 0.30,      0.13,       0.07,            0.16,       0.34,          0.00,               0.00,       0.00,            0.00],
+			// 25-32m Expansions meet - More Reapers!
+			"tier3": [ 0.46,      0.15,       0.03,            0.04,       0.32,          0.00,               0.00,       0.00,            0.00],
+			// 33m -40m Solid Fronts - 	MAXIMUM REAPERS
+			"tier4": [ 0.45,      0.14,       0.00,            0.02,       0.37,          0.02,               0.00,       0.00,            0.00],
+			// 41m - 56m Mid Game - More arty & Golly
+			"tier5": [ 0.46,      0.16,       0.00,            0.02,       0.32,          0.04,               0.00,       0.00,            0.00],
+			// 57m - 72m Late Game - Even more arty & Golly
+			"tier6": [ 0.40,      0.13,       0.00,            0.02,       0.34,          0.11,               0.00,       0.00,            0.00],
+			// 72m - inf+ Late late Game - MAXIMUM GOLLY
+			"tier7": [ 0.42,      0.08,       0.00,            0.02,       0.32,          0.16,               0.00,       0.00,            0.00]
+		},
+
+		"caretaker": 15
+	},
+
+	"factoryjump": {
+		"importance": [0.73, 1.1],
+		"require_energy": false,
+
+		"income_tier": [20, 40, 60, 80],
+		//             freaker,   puppy,       pyro,       placeholder,     moderator,   jack,          sumo,       firewalker, skuttle,    archangel
+		"unit":      ["jumpcon", "jumpscout", "jumpraid", "jumpblackhole", "jumpskirm", "jumpassault", "jumpsumo", "jumparty", "jumpbomb", "jumpaa"],
+		"land": {
+			"tier0": [ 0.05,      0.24,        0.50,       0.00,            0.15,        0.06,          0.00,       0.00,       0.00,       0.00],
+			"tier1": [ 0.10,      0.20,        0.20,       0.10,            0.16,        0.24,          0.00,       0.00,       0.00,       0.00],
+			"tier2": [ 0.20,      0.20,        0.00,       0.15,            0.04,        0.31,          0.00,       0.10,       0.00,       0.00],
+			"tier3": [ 0.25,      0.15,        0.00,       0.15,            0.00,        0.33,          0.00,       0.12,       0.00,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryshield": {
+		"importance": [0.88, 0.6],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 48, 66],
+		//             convict,     dirtbag,       bandit,       rogue,         thug,            outlaw,       felon,         racketeer,    roach,        aspis,          vandal
+		"unit":      ["shieldcon", "shieldscout", "shieldraid", "shieldskirm", "shieldassault", "shieldriot", "shieldfelon", "shieldarty", "shieldbomb", "shieldshield", "shieldaa"],
+		"land": {
+			"tier0": [ 0.05,        0.05,          0.70,         0.00,          0.20,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier1": [ 0.08,        0.01,          0.10,         0.24,          0.57,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier2": [ 0.12,        0.03,          0.00,         0.20,          0.54,            0.00,         0.05,          0.00,         0.00,         0.06,           0.00],
+			"tier3": [ 0.15,        0.07,          0.00,         0.00,          0.62,            0.00,         0.08,          0.00,         0.00,         0.08,           0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryship": {
+		"importance": [5.5, 5.5],
+		"require_energy": false,
+
+		"income_tier": [30],
+		//             mariner    cutter,      hunter,           seawolf,     corsair,    mistral,     siren,         ronin,      zephyr
+		"unit":      ["shipcon", "shipscout", "shiptorpraider", "subraider", "shipriot", "shipskirm", "shipassault", "shiparty", "shipaa"],
+		"water": {
+			"tier0": [ 0.05,      0.15,        0.35,             0.10,        0.10,       0.10,        0.15,          0.00,       0.00],
+			"tier1": [ 0.05,      0.10,        0.20,             0.10,        0.05,       0.10,        0.25,          0.15,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"striderhub": {
+		"importance": [0, 1.5],
+		"require_energy": false,
+
+		"income_tier": [60, 80, 100],
+		//             ultimatum,          scorpion,          dante,          catapult,      funnelweb,          bantha,          detriment,          scylla,          reef,          battleship
+		"unit":      ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"land": {
+			"tier0": [ 0.01,               0.10,              0.81,           0.00,          0.05,               0.03,            0.00,               0.00,            0.00,          0.00],
+			"tier1": [ 0.03,               0.14,              0.22,           0.24,          0.20,               0.16,            0.01,               0.00,            0.00,          0.00],
+			"tier2": [ 0.05,               0.10,              0.16,           0.35,          0.10,               0.21,            0.03,               0.00,            0.00,          0.00],
+			"tier3": [ 0.05,               0.10,              0.01,           0.26,          0.10,               0.35,            0.13,               0.00,            0.00,          0.00]
+		},
+		"water": {
+			"tier1": [ 0.50,               0.00,              0.00,           0.00,          0.00,               0.00,            0.00,               0.00,            0.25,          0.25],
+			"tier2": [ 0.10,               0.00,              0.00,           0.00,          0.00,               0.00,            0.10,               0.00,            0.40,          0.40]
+		},
+
+		"caretaker": 100
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/response.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/response.json
@@ -1,0 +1,136 @@
+// Mono-space font required
+{
+// Build special units when enemy_metal*ratio > response_metal*eps; eps=teamSize*eps_step+(1-eps_step)
+// AA condition for 3v3: (enemy_air_metal*0.67 > (aa_metal+aa_cost)*1.12) and (aa_metal+aa_cost < army_metal*0.5)
+//
+// Probability of UnitDef for AA role depends on income tier: (tierN[UnitDef]+_weight_)*enemy_air_metal/aa_metal*importance
+// armjeth probability for tier 1: (0.00+10.00)*enemy_air_metal*600.0
+"response": {
+	"_weight_": 70.0,  // base weight of response probability, default=0.5
+
+	"assault": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "super", "missileskirm", "turtle"],
+		"ratio":      [ 0.75,   2.0,      0.00,      0.20,        0.00,    0.75,    1.5,            3.0],
+		"importance": [ 15.00,  45.00,    25.00,     75.00,       0.00,    45.00,   125.00,         50.0],
+		"max_percent": 1.00
+	},
+	"skirmish": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "anti_heavy"],
+		"ratio":      [ 1.50,   0.75,     1.00,      0.00,        0.00,    0.00],
+		"importance": [ 35.00,  25.00,    25.00,     75.00,       0.00,    0.00],
+		"max_percent": 1.00
+	},
+	"raider": {
+		"vs":         ["anti_air", "scout", "raider", "anti_heavy", "mine", "skirmish", "artillery"],
+		"ratio":      [ 0.00,       1.00,    1.0,      0.10,         0.35,   0.40,       0.8],
+		"importance": [ 15.00,      75.00,   75.00,    15.00,        60.00,  45.00,      10.00],
+		"max_percent": 1.00,
+		"eps_step": 0.75
+	},
+	"riot": {
+		"vs":         ["raider", "scout", "commander", "bullshit_raider"],
+		"ratio":      [ 0.8,      0.8,     0.33,        1.5],
+		"importance": [ 100.00,   100.00,  75.00,       125.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"missileskirm": {
+		"vs":         ["raider", "scout", "riot"],
+		"ratio":      [ 0.25,     0.5,     0.25],
+		"importance": [ 35.00,    50.00,   35.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"transport": {
+		"vs":         ["super", "support", "shieldball"],
+		"ratio":      [ 0.75,    0.75,      0.75],
+		"importance": [ 50.00,   50.00,     50.00],
+		"max_percent": 0.30,
+		"eps_step": 0.015
+	},
+	"scout": {
+		"vs":         ["mine", "artillery", "anti_air", "scout", "static", "heavy", "anti_heavy", "cloaked_raider"],
+		"ratio":      [ 0.35,   0.05,        0.10,       1.00,    0.00,     0.00,    0.05,         0.5],
+		"importance": [ 60.00,  60.0,        60.0,       35.00,   0.00,     0.00,    10.00,        100.00],
+		"max_percent": 0.09,
+		"eps_step": 0.025
+	},
+	"artillery": {
+		"vs":         ["static", "artillery", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.66,     0.00,        0.66,    0.25,         3.0],
+		"importance": [ 20.00,    0.00,        40.00,   40.00,        40.0],
+		"max_percent": 0.66,
+		"eps_step": 0.02
+	},
+	"anti_air": {
+		"vs":         ["air"],
+		"ratio":      [ 0.8],
+		"importance": [ 75.0],
+		"max_percent": 0.4,
+		"eps_step": 0.75
+	},
+	"anti_sub": {
+		"vs":         ["sub"],
+		"ratio":      [ 0.0],
+		"importance": [ 0.0],
+		"max_percent": 0.00,
+		"eps_step": 0.0
+	},
+	"anti_heavy": {
+		"vs":         ["heavy", "artillery", "support", "anti_heavy", "commander", "super", "turtle"],
+		"ratio":      [ 0.45,    0.00,        0.00,      0.00,         0.4,         0.50,    3.00],
+		"importance": [ 85.00,   0.00,        0.00,      0.00,         50.00,       85.0,    50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"disarm_target": {
+		"vs":         ["disarm_target"],
+		"ratio":      [ 0.50],
+		"importance": [ 100.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"snipe_target": {
+		"vs":         ["snipe_target", "commander"],
+		"ratio":      [ 1.00,           0.20],
+		"importance": [ 100.00,         50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"cloaked_raider": {
+		"vs":         ["snipe_target", "commander", "transport"],
+		"ratio":      [ 0.50,           0.20,        2.00],
+		"importance": [ 35.00,          35.00,       125.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"heavy": {
+		"vs":         ["heavy", "static", "support", "skirmish", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.75,    0.5,      0.00,      0.75,       0.75,    0.75,         3.00],
+		"importance": [ 75.00,   15.00,    0.00,      15.00,      75.00,   75.00,        75.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"bomber": {
+		"vs":         ["shieldball", "anti_heavy", "artillery", "super"],
+		"ratio":      [ 0.50,         0.50,         0.50,        0.50],
+		"importance": [ 0.50,         50.00,        50.00,       50.00],
+		"max_percent": 1.0,
+		"eps_step": 0.00
+	},
+	"super": {
+		"vs":         ["heavy", "static", "support", "skirmish", "artillery", "super", "turtle"],
+		"ratio":      [ 0.3,     0.55,     0.00,      0.00,       0.00,        0.00,    0.5],
+		"importance": [ 45.00,   25.00,    0.00,      0.00,       0.00,        0.00,    45.00],
+		"max_percent": 0.2,
+		"eps_step": 0.00
+	},
+	"support": {
+		"vs":         ["assault", "bullshit_raider"],
+		"ratio":      [ 1.00,      0.4],
+		"importance": [ 35.00,     75.00],
+		"max_percent": 0.25,
+		"eps_step": 0.00
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/behaviour.json
@@ -1,0 +1,1120 @@
+// Mono-space font required
+{
+"quota": {
+	"scout": 1,  // max scout units out of raiders
+	"raid": [7.0, 42.0],  // [<min>, <avg>] power of raider squad
+	"attack": 20.0,  // min power of attack group
+	"thr_mod": {
+		"attack": [0.45, 0.45],  // [<min>, <max>] enemy threat modifier for target selection of attack task
+		"defence": [0.80, 0.80],  // [<min>, <max>] enemy threat modifier for group size calculation of defence task
+		"mobile": 1.075,  // initial modifier for power of attack group based on mobile enemy threat
+		"static": 4.25,  // initial modifier for power of attack group based on static enemy threat
+		"comm": 0.75
+	},
+	"aa_threat": 80.0,  // anti-air threat threshold, air factories will stop production when AA threat exceeds
+	"slack_mod": {
+		"all": 0.5,  // threat map 64-elmos slack multiplier for all units
+		"static": 1.5,  // additional 64-elmo-cells for static units
+		"speed": [0.75, 4.0]  // [<64elmo_cells_speed_mod>, <max_64elmo_cells>]
+	}
+},
+
+// If unit's health drops below specified percent it will retreat
+"retreat": {
+	"builder": [0.70, 1.0],  // [<default>, <UnitDef modifier>] for all builders
+	"fighter": [0.45, 1.0],  // [<default>, <UnitDef modifier>] for all not-builder units
+	"shield": [0.25, 0.275]  // [<empty>, <full>] shield power
+},
+
+"defence": {
+	"infl_rad": 7,  // influenece cell radius for defendAlly map
+	"base_rad": [1000.0, 2000.0],  // defend if enemy within clamp(distance(lane_pos, base_pos), 1000, 2000) radius
+	"comm_rad": [1000.0, 500.0]  // 0 distance from base ~ 1000, base_rad ~ 500.0
+},
+
+
+"behaviour": {
+	// factorycloak
+	"cloakcon": {
+		// "role": [<main>, <enemy>, <enemy>, ...]
+		// <main> is the role to make desicions of when to build it and what task to assign
+		// <enemy> is to decide how to counter enemy unit, if missing then equals to <main>
+		// Roles: builder, scout, raider, riot, assault, skirmish, artillery, anti_air, anti_sub, anti_heavy, bomber, support, mine, transport, air, sub, static, heavy, super, commander
+		// Auto-assigned roles: builder, air, static, super, commander
+		"role": ["builder", "mine"]
+
+		// Attributes - optinal states
+		// "melee" - always move close to target, disregard attack range
+		// "boost" - boost speed on retreat
+		// "no_jump" - disable jump on retreat
+		// "no_strafe" - disable gunship's strafe
+		// "stockpile" - load weapon before any task, auto-assigned
+		// "siege" - mostly use fight command instead of move
+		// "ret_hold" - hold fire on retreat
+		// "ret_fight" - fight on retreat
+		// "jump" - enable jump on regular move
+		// "dg_cost" - DGun by metal cost instead of by threat
+		// "anti_stat" - only static targets
+		// "no_dgun" - do not use DGun
+//		"attribute": ["boost", "no_strafe"],
+
+		// Fire state (open by default)
+		// "hold" - hold fire
+		// "return" - return fire
+		// "open" - fire at will
+//		"fire_state": "open",
+
+		// Overrides reloadTime in seconds
+//		"reload": 1.0,
+
+		// Limits number of units
+//		"limit": 10,
+
+		// Unit can be built only since specific time in seconds
+//		"since": 60,
+
+		// Minimum hp percent before retreat
+//		"retreat": 0.8,
+
+		// Ally threat multiplier
+//		"pwr_mod": 1.0,
+		// Enemy threat multiplier
+//		"thr_mod": 1.0,
+
+		// Ignore enemy
+//		"ignore": false
+	},
+	"cloakraid": {
+		"role": ["raider", "scout"],
+		"attribute": ["scout"],
+		"retreat": 0.1,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.75
+	},
+	"cloakheavyraid": {
+		"role": ["cloaked_raider", "raider"],
+		"attribute": ["ret_fight"],
+		"since": 180,
+		"limit": 3,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.1,
+		"retreat": 0.4
+	},
+	"cloakskirm": {
+		"role": ["skirmish"],
+		"attribute": ["ret_fight"],
+		"pwr_mod": 0.85,
+		"since": 180,
+		"limit": 20,
+		"retreat": 0.35  // mostly disposable
+	},
+	"cloakriot": {
+		"role": ["riot", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"since": 180,
+		"retreat": 0.55,
+		"pwr_mod": 1.4,
+		"thr_mod": 2.3
+	},
+	"cloakassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.35,  // assaults need to assault
+		"since": 240,
+		"pwr_mod": 0.7,
+		"thr_mod": 1.1
+	},
+	"cloakarty": {
+		"role": ["artillery"],
+		"since": 550,
+		"limit": 8,
+		"retreat": 0.9,
+		"thr_mod": 0.0
+	},
+	"cloaksnipe": {
+		"role": ["snipe_target"],
+		"attribute": ["support"],
+		"pwr_mod": 3.0,
+		"since": 520,
+		"thr_mod": 0.0,
+		"retreat": 0.69
+	},
+	"cloakbomb": {
+		"role": ["mine"],
+		"retreat": 0.01
+	},
+	"cloakjammer": {
+		"role": ["assault"],
+		"since": 480,
+		"retreat": 0.5,
+		"limit": 1
+	},
+	"cloakaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factorygunship
+	"gunshipcon": {
+		"role": ["builder", "air"],
+		"limit": 2,
+		"since": 240,
+		"retreat": 0.99
+	},
+	"gunshipbomb": {
+		"role": ["bomber", "air"],
+		"attribute": ["melee"],
+		"limit": 1,
+		"thr_mod": 1.0,
+		"retreat": 0.01
+	},
+	"gunshipemp": {
+		"role": ["anti_heavy", "air"],
+		"thr_mod": 0.1,
+		"pwr_mod": 0.1,
+		"since": 600,
+		"limit": 6,
+		"retreat": 0.9
+	},
+	"gunshipskirm": {
+		"role": ["air", "bullshit_raider"],
+		"retreat": 0.65,
+		"pwr_mod": 0.7,
+		"limit": 8,
+		"thr_mod": 0.66
+	},
+	"gunshipraid": {
+		"role": ["scout", "air"],
+		"retreat": 0.7,
+		"limit": 1,
+		"pwr_mod": 1.25,
+		"thr_mod": 1.1
+	},
+	"gunshipheavyskirm": {
+		"role": ["assault", "air"],
+		"since": 330,
+		"attribute": ["no_strafe"],
+		"retreat": 0.65,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.00
+	},
+	"gunshipassault": {
+		"role": ["anti_heavy", "air"],
+		"limit": 3,
+		"since": 330,
+		"retreat": 0.5,
+		"pwr_mod": 1.65,
+		"thr_mod": 1.00
+	},
+	"gunshipkrow": {
+		"role": ["anti_heavy", "air", "disarm_target"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"since": 720,
+		"pwr_mod": 0.3,
+		"thr_mod": 0.3,
+		"limit": 0
+	},
+	"gunshiptrans": {
+		"role": ["air"],
+		"limit": 0
+	},
+	"gunshipheavytrans": {
+		"role": ["air"],
+		"limit": 0,
+		"thr_mod": 0.0
+	},
+	"gunshipaa": {
+		"role": ["anti_air", "air"],
+		"limit": 6,
+		"retreat": 0.95,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryamph
+	"amphcon": {
+		"role": ["builder", "mine"]
+	},
+	"amphraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"limit": 10,
+		"retreat": 0.25  // pretty disposable
+	},
+	"amphimpulse": {
+		"role": ["riot"],
+		"limit": 1,
+		"retreat": 0.36,
+		"pwr_mod": 2.25,
+		"thr_mod": 2.25
+	},
+	"amphfloater": {
+		"role": ["assault", "snipe_target", "super"],
+		"limit": 14,
+		"since": 120,
+		"retreat": 0.25, // too slow to be retreating all the time
+		"pwr_mod": 1.3,
+		"thr_mod": 1.3
+	},
+	"amphriot": {
+		"role": ["riot"],
+		"attribute": ["melee", "ret_fight"],
+		"pwr_mod": 1.5,
+		"retreat": 0.35 // too slow to be retreating all the time
+	},
+	"amphassault": {
+		"role": ["heavy", "disarm_target"],
+		"retreat": 0.66,
+		"since": 520,
+		"pwr_mod": 1.4,
+		"thr_mod": 1.0
+	},
+	"amphtele": {
+		"role": ["transport"],
+		"limit": 0
+	},
+	"amphaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight", "support"],
+		"retreat": 0.3,
+		"limit": 5,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.5
+	},
+
+	// factoryspider
+	"spidercon": {
+		"role": ["builder", "mine"]
+	},
+	"spiderscout": {
+		"role": ["scout", "raider"],
+		"thr_mod": 0.5,
+		"limit": 20,
+		"retreat": 0.01
+	},
+	"spiderassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.15,
+		"retreat": 0.35
+	},
+	"spideremp": {
+		"role": ["raider", "riot"],
+		"pwr_mod": 3.0,
+		"limit": 1,
+		"retreat": 0.5
+	},
+	"spiderriot": {
+		"role": ["riot"],
+		"pwr_mod": 2.0,
+		"limit": 4,
+		"attribute": ["support"],
+		"retreat": 0.35
+	},
+	"spiderskirm": {
+		"role": ["skirmish", "snipe_target", "super"],
+		"pwr_mod": 2.0,
+		"thr_mod": 1.0,
+		"since": 180,
+		"retreat": 0.4
+	},
+	"spidercrabe": {
+		"role": ["heavy", "disarm_target", "turtle"],
+		"attribute": ["siege", "ret_fight", "support"],
+		"retreat": 0.5,
+		"thr_mod": 2.5,
+		"pwr_mod": 2.5,
+		"since": 300,
+		"thr_mod": 1.0
+	},
+	"spiderantiheavy": {
+		"role": ["anti_heavy", "mine"],
+		"retreat": 0.99,
+		"pwr_mod": 2.0,
+		"thr_mod": 0.1,
+		"since": 600,
+		"limit": 1
+	},
+	"spideraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryshield
+	"shieldcon": {
+		"role": ["builder", "shieldball", "mine"],
+		"retreat": 1.3
+	},
+	"shieldscout": {
+		"role": ["transport", "raider"],
+		"limit": 20,
+		"attribute": ["siege", "melee"],
+		"pwr_mod": 0.11,
+		"thr_mod": 0.1,
+		"retreat": 0.0
+	},
+	"shieldraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"retreat": 0.25,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.9
+	},
+	"shieldskirm": {
+		"role": ["skirmish"],
+		"limit": 15,
+		"since": 200,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"retreat": 0.3
+	},
+	"shieldassault": {
+		"role": ["assault", "support", "shieldball"],
+		"attribute": ["melee"],
+		"limit": 20,
+		"retreat": 0.3,
+		"since": 120,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.35
+	},
+	"shieldriot": {
+		"role": ["riot", "shieldball"],
+		"fire_state": "hold",
+		"since": 100,
+		"limit": 5,
+		"retreat": 0.3,
+		"pwr_mod": 1.7,
+		"thr_mod": 1.7
+	},
+	"shieldfelon": {
+		"role": ["heavy", "shieldball", "snipe_target"],
+		"since": 420,
+		"retreat": 0.35,
+		"pwr_mod": 1.1,
+		"thr_mod": 1.1
+	},
+	"shieldarty": {
+		"role": ["disarm_target"],
+		"since": 300,
+		"retreat": 0.3,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"shieldbomb": {
+		"role": ["mine"]
+	},
+	"shieldshield": {
+		"role": ["super", "heavy", "shieldball"],
+		"since": 540,
+		"attribute": ["support"],
+		"retreat": 0.36,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.25
+	},
+	"shieldaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryveh
+	"vehcon": {
+		"role": ["builder", "mine"]
+	},
+	"vehscout": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"thr_mod": 0.6,
+		"pwr_mod": 1.2,
+		"retreat": 0.01,
+		"limit": 4
+	},
+	"vehraid": {
+		"role": ["raider"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.3,
+		"pwr_mod": 1.1,
+		"thr_mod": 0.8
+	},
+	"vehsupport": {
+		"role": ["artillery", "missileskirm"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.4,
+		"retreat": 0.6  // cannot retreat
+	},
+	"vehriot": {
+		"role": ["riot"],
+		"retreat": 0.6,
+		"pwr_mod": 1.5,
+		"thr_mod": 1.5
+	},
+	"vehassault": {
+		"role": ["assault"],
+		"attribute": ["melee"],
+		"retreat": 0.4,  // slow to turn around
+		"since": 180,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9
+	},
+	"vehcapture": {
+		"role": ["support", "disarm_target", "snipe_target"],
+		"since": 180,
+		"pwr_mod": 1,
+		"thr_mod": 1,
+		"retreat": 0.8
+	},
+	"veharty": {
+		"role": ["transport", "super"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 15,
+		"since": 460,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0,
+		"retreat": 0.8
+	},
+	"vehheavyarty": {
+		"role": ["artillery", "heavy", "turtle"],
+		"since": 300,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.00
+	},
+	"vehaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.75,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryjump
+	"jumpcon": {
+		"role": ["builder", "mine"]
+	},
+	"jumpscout": {
+		"role": ["riot", "raider"],
+		"limit": 15,
+		"attribute": ["melee", "siege"],
+		"retreat": 0
+	},
+	"jumpraid": {
+		"role": ["raider", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.4,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.9
+	},
+	"jumpblackhole": {
+		"role": ["support"],
+		"since": 300,
+		"limit": 6,
+		"retreat": 0.36
+	},
+	"jumpskirm": {
+		"role": ["skirmish", "super", "snipe_target"],
+		"retreat": 0.4
+	},
+	"jumpassault": {
+		"role": ["assault", "anti_sub", "disarm_target"],
+		"attribute": ["melee", "siege", "ret_fight"],
+		"retreat": 0.4,
+		"pwr_mod": 1.3,
+		"thr_mod": 0.5
+	},
+	"jumpsumo": {
+		"role": ["heavy", "support", "disarm_target"],
+		"limit": 0,
+		"attribute": ["melee", "no_jump"]  // jump on attack
+	},
+	"jumparty": {
+		"role": ["heavy", "turtle", "snipe_target"],
+		"attribute": ["support"],
+		"since": 600,
+		"pwr_mod": 0.1,
+		"limit": 2,
+		"thr_mod": 0.00,
+		"retreat": 0.99
+	},
+	"jumpbomb": {
+		"role": ["anti_heavy", "builder"],
+		"attribute": ["melee", "mine"],
+		"fire_state": "open",
+		"since": 720,
+		"limit": 2,
+		"retreat": 0.01,
+		"pwr_mod": 3.0,
+		"thr_mod": 0.01
+	},
+	"jumpaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryhover
+	"hovercon": {
+		"role": ["builder", "mine"]
+	},
+	"hoverraid": {
+		"role": ["scout"],
+		"attribute": ["melee"],		
+		"pwr_mod": 0.9,
+		"thr_mod": 0.8,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9,
+		"limit": 4,
+		"retreat": 0.5
+	},
+	"hoverheavyraid": {
+		"role": ["raider", "bullshit_raider"],	
+		"retreat": 0.35,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.8
+	},
+	"hoverskirm": {
+		"role": ["skirmish", "support"],
+		"retreat": 0.55,
+		"limit": 12,
+		"reload": 4.0,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.6
+	},
+	"hoverassault": {
+		"role": ["assault", "raider"],
+		"attribute": ["melee", "ret_hold"],
+		"retreat": 0.4,
+		"limit": 12,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.45
+	},
+	"hoverdepthcharge": {
+		"role": ["anti_sub", "riot"],
+		"attribute": ["melee"],
+		"retreat": 0.6
+	},
+	"hoverriot": {
+		"role": ["riot", "snipe_target"],
+		"retreat": 0.4,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.25
+	},
+	"hoverarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"attribute": ["siege"],
+		"retreat": 0.99,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"hoveraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryplane
+	"planecon": {
+		"role": ["builder", "air"],
+		"since": 240,
+		"limit": 2,
+		"retreat": 0.99
+	},
+	"planefighter": {
+		"role": ["scout", "air"],
+		"attribute": ["boost"],
+		"pwr_mod": 1.5,
+		"limit": 1,
+		"thr_mod": 3.0,
+		"retreat": 0.8
+	},
+	"planeheavyfighter": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"limit": 8,
+		"retreat": 0.4,
+		"pwr_mod": 2.5,
+		"thr_mod": 3.0
+	},
+	"bomberprec": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"attribute": ["siege"],
+		"limit": 10,
+		"retreat": 0.8,
+		"pwr_mod": 0.10,
+		"thr_mod": 0.01
+	},
+	"bomberriot": {
+		"role": ["bomber", "air"],
+		"limit": 0,
+		"retreat": 0.6,
+		"pwr_mod": 0.01,
+		"thr_mod": 0.01
+	},
+	"bomberdisarm": {
+		"role": ["anti_heavy", "air"],
+		"attribute": ["siege", "bomber"],
+		"limit": 2,
+		"since": 1200,
+		"retreat": 0.95,
+		"pwr_mod": 100.00,
+		"thr_mod": 0.01
+	},
+	"bomberheavy": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"fire_state": "return",
+		"limit": 4,
+		"since": 420,
+		"retreat": 0.95,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.1
+	},
+	"bomberassault": {
+		"role": ["bomber", "air"],
+		"attribute": ["anti_stat", "no_dgun"],
+		"fire_state": "hold",
+		"limit": 1,
+		"since": 1800,
+		"retreat": 0.65,
+		"pwr_mod": 1.25,
+		"thr_mod": 0.01
+	},
+	"planescout": {
+		"role": ["scout", "air"],
+		"since": 360,
+		"limit": 2,
+		"retreat": 0.8
+	},
+
+	// factorytank
+	"tankcon": {
+		"role": ["builder"],
+		"pwr_mod": 0.40,
+		"thr_mod": 0.40,
+		"retreat": 0.9
+	},
+	"tankraid": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"limit": 2,
+		"thr_mod": 0.66,
+		"pwr_mod": 0.8,
+		"retreat": 0.45
+	},
+	"tankheavyraid": {
+		"role": ["raider", "bullshit_raider"],
+		"thr_mod": 0.6,
+		"pwr_mod": 0.65,
+		"retreat": 0.65
+	},
+	"tankriot": {
+		"role": ["riot", "heavy", "snipe_target"],
+		"thr_mod": 1.25,
+		"pwr_mod": 0.75,
+		"retreat": 0.55
+	},
+	"tankassault": {
+		"role": ["assault", "heavy", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7
+	},
+	"tankheavyassault": {
+		"role": ["heavy", "disarm_target", "super"],
+		"attribute": ["melee"],
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7,
+		"since": 480,
+		"retreat": 0.55
+	},
+	"tankarty": {
+		"role": ["artillery", "snipe_target", "heavy"],
+		"attribute": ["support"],
+		"since": 1000,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.0
+	},
+	"tankheavyarty": {
+		"role": ["transport"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 1,
+		"retreat": 0.99,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0
+	},
+	"tankaa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryship
+	"shipcon": {
+		"role": ["builder"]
+	},
+	"shipscout": {
+		"role": ["scout"]
+	},
+	"shiptorpraider": {
+		"role": ["raider"]
+	},
+	"subraider": {
+		"role": ["raider"]
+	},
+	"shipriot": {
+		"role": ["riot"]
+	},
+	"shipskirm": {
+		"role": ["skirmish"]
+	},
+	"shipassault": {
+		"role": ["assault"]
+	},
+	"shiparty": {
+		"role": ["artillery"]
+	},
+	"shipaa": {
+		"role": ["anti_air"]
+	},
+
+	// striderhub
+	"striderantiheavy": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"pwr_mod": 0.5,
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.35
+	},
+	"striderscorpion": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"fire_state": "return",
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"since": 1800,
+		"thr_mod": 0.5
+	},
+	"striderdante": {
+		"role": ["heavy", "disarm_target", "snipe_target"],
+		"attribute": ["melee"],
+		"limit": 2,
+		"retreat": 0.45,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.75
+	},
+	"striderarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"pwr_mod": 5.0,
+		"thr_mod": 0.0,
+		"retreat": 0.9
+	},
+	"striderfunnelweb": {
+		"role": ["heavy", "turtle", "shieldball"],
+		"attribute": ["support"],
+		"retreat": 1.4,
+		"pwr_mod": 1.0,
+		"limit": 1,
+		"since": 3000,
+		"thr_mod": 0.0
+	},
+	"striderbantha": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.5
+	},
+	"striderdetriment": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.50,  // deffo retreat, running into nab annihlator farm and sploding is silly :)
+		"pwr_mod": 0.34,
+		"thr_mod": 0.34
+	},
+	"subtacmissile": {
+		"role": ["artillery", "heavy"],
+		"attribute": ["stockpile"]
+	},
+	"shipcarrier": {
+		"role": ["artillery", "heavy"]
+	},
+	"shipheavyarty": {
+		"role": ["artillery", "heavy"]
+	},
+
+	// statics
+	"staticnuke": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 30.0,
+		"limit": 1,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"staticmissilesilo": {
+		"role": ["static", "support", "heavy"],
+		"thr_mod": 0.01
+	},
+	"raveparty": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"zenith": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 105.0,  // 105sec / 0.7sec/met = 150 meteorsControlled
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"mahlazer": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"staticheavyarty": {
+		"role": ["artillery", "turtle", "heavy"],
+		"limit": 5,
+		"thr_mod": 0.0,
+		"pwr_mod": 10.00
+	},
+	"turretheavy": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 1.00
+	},
+	"turretantiheavy": {
+		"role": ["static", "turtle", "static"],
+		"thr_mod": 0.55
+	},
+	"staticarty": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 0.55
+	},
+	"staticantinuke": {
+		"role": ["static", "heavy", "support"],
+		"since": 720,
+		"limit": 1
+	},
+	"turretheavylaser": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.0
+	},
+	"energysingu": {
+		"role": ["static", "turtle", "heavy"],
+		"since": 660
+	},
+	"energyfusion": {
+		"role": ["static", "mine", "heavy"],
+		"since": 280
+	},
+	"turretaalaser": {
+		"role": ["anti_air"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.0
+	},
+	"turretaaheavy": {
+		"role": ["anti_air", "heavy", "turtle"],
+		"limit": 1,
+		"thr_mod": 1.0
+	},
+	"turretlaser": {
+		"role": ["static", "riot", "builder"],
+		"thr_mod": 1.5
+	},
+	"turretmissile": {
+		"role": ["missileskirm", "riot", "builder"],
+		"thr_mod": 0.34
+	},
+	"turretriot": {
+		"role": ["static", "riot", "snipe_target"],
+		"thr_mod": 1.65
+	},
+	"turretaafar": {
+		"role": ["anti_air", "heavy", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaflak": {
+		"role": ["anti_air", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaclose": {
+		"role": ["anti_air"],
+		"thr_mod": 1.0
+	},
+	"turretgauss": {
+		"role": ["static", "turtle", "transport"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.6
+	},
+	"turretemp": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.5
+	},
+
+	// support factories won't be built in front
+	"factoryplane": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"factorygunship": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"striderhub": {
+		"role": ["static"],
+		"since": 900,
+		"attribute": ["support"]
+	},
+
+	// Enemy Eco!! //
+	"staticmex": {
+		"role": ["mine"]
+	},
+	"energywind": {
+		"role": ["mine"]
+	},
+	"staticradar": {
+		"role": ["mine"]
+	},
+	"staticcon": {
+		"role": ["mine"]
+	},
+	"energypylon": {
+		"role": ["mine"],
+		"since": 600
+	},
+	"staticheavyradar": {
+		"role": ["mine", "turtle"],
+		"limit": 1
+	},
+	"staticstorage": {
+		"role": ["mine", "turtle"],
+		"limit": 5
+	},
+	"energysolar": {
+		"role": ["mine"]
+	},
+	"staticshield": {
+		"role": ["static", "turtle"]
+	},
+
+	// Chickens!! //
+	"dronecarry": {
+		"role": ["transport"]
+	},
+	"chicken": {
+		"role": ["raider"]
+	},
+	"chicken_blimpy": {
+		"role": ["mine"]
+	},
+	"chicken_digger": {
+		"role": ["riot"]
+	},
+	"chicken_dodo": {
+		"role": ["mine"]
+	},
+	"chicken_dragon": {
+		"role": ["heavy"],
+		"thr_mod": 0.4
+	},
+	"chicken_drone": {
+		"role": ["raider"]
+	},
+	"chicken_drone_starter": {
+		"role": ["raider"]
+	},
+	"chicken_leaper": {
+		"role": ["raider"]
+	},
+	"chicken_listener": {
+		"role": ["static"]
+	},
+	"chicken_pigeon": {
+		"role": ["air"]
+	},
+	"chicken_roc": {
+		"role": ["air"]
+	},
+	"chicken_shield": {
+		"role": ["support"]
+	},
+	"chicken_spidermonkey": {
+		"role": ["anti_air"]
+	},
+	"chicken_tiamat": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenblobber": {
+		"role": ["artillery"]
+	},
+	"chickenbroodqueen": {
+		"role": ["heavy"],
+		"thr_mod": 0.05
+	},
+	"chickenflyerqueen": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenlandqueen": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenspire": {
+		"role": ["static"]
+	},
+	"chickena": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenc": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickend": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenf": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenr": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenwurm": {
+		"role": ["heavy"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/block_map.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/block_map.json
@@ -1,0 +1,138 @@
+// Mono-space font required
+{
+"building": {
+	"class_land": {
+		"fac_land": {
+			// "type": [<blocker_shape>, <structure_type>]
+			// Available blocker_shape: rectangle, circle.
+			// Available structure_type: factory, mex, engy_low, engy_mid, engy_high, pylon, def_low, def_mid, def_high, special, nano, terra, unknown
+			"type": ["rectangle", "factory"],
+
+			// Unit of measurement: 1 size/yard/radius = SQUARE_SIZE * 2 = 16 elmos, integer.
+			// Offset in South facing
+			"offset": [0, 6],  // default: [0, 0]
+
+			// Size of a blocker without yard
+//			"size": [7, 7],  // default: size of a unit
+
+			// Spacer, blocker_size = size + yard
+			"yard": [12, 12]  // default: [0, 0]
+
+			// "ignore": [<structure_type>, <structure_type>, ...]
+			// Ignore specified structures.
+			// Additional values: none, all
+//			"ignore": ["none"]  // default: ["none"]
+		},
+		"fac_air": {
+			"type": ["rectangle", "factory"],
+			"yard": [8, 8]
+		},
+		"fac_water": {
+			"type": ["rectangle", "factory"],
+			"offset": [0, 4],
+			"yard": [10, 12]
+		},
+		"fac_strider": {
+			"type": ["rectangle", "special"],
+			"offset": [0, 12],
+			"yard": [16, 16]
+		},
+		"solar": {
+			"type": ["circle", "engy_low"],
+			"ignore": ["mex", "engy_mid", "engy_high", "def_low", "pylon", "nano"],
+			"radius": 7
+		},
+		"wind": {
+			"type": ["circle", "engy_low"],
+			// Integer radius of a blocker or description string.
+			// Available string values: explosion, expl_ally
+//			"radius": "explosion",  // default: "explosion"
+			"radius": 4,
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"fusion": {
+			"type": ["circle", "engy_mid"],
+			"ignore": ["mex", "pylon", "def_low"]
+		},
+		"singu": {
+			"type": ["rectangle", "engy_high"],
+			"ignore": ["mex", "engy_low", "def_low", "pylon", "nano"]
+		},
+		"pylon": {
+			"type": ["circle", "pylon"],
+			"not_ignore": ["factory", "engy_low", "pylon", "terra"]  // default: ["all"]
+		},
+		"store": {
+			"type": ["rectangle", "mex"],
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"mex": {
+			"type": ["rectangle", "mex"],
+			"ignore": ["all"]
+		},
+		"def_low": {
+			"type": ["circle", "def_low"],
+			"radius": 10,  // 160 / (SQUARE_SIZE * 2)
+			"ignore": ["engy_mid", "engy_high", "pylon", "nano"]
+		},
+		"caretaker": {
+			"type": ["rectangle", "nano"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+		"small": {
+			"type": ["rectangle", "unknown"],
+			"not_ignore": ["factory", "def_low", "terra"]
+		},
+		"superweapon": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "pylon", "engy_high"]
+		},
+		"protector": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+//		"terraform": {
+//			"type": ["rectangle", "special"],
+//			"size": [7, 7]  // int2(3 + 4, 3 + 4)
+//		},
+		"strider": {
+			"type": ["rectangle", "special"],
+			"yard": [2, 2],
+			"ignore": ["all"]
+		},
+		"_default_": {
+			"type": ["rectangle", "unknown"],
+			"yard": [4, 4],
+			"ignore": ["pylon", "engy_high"]
+		}
+	},
+	// Water overrides land. Map considered as water if amount of land < 40%
+	"class_water" : {
+		"wind": {
+			"type": ["circle", "engy_low"],
+			"radius": 1,  // default: "explosion"
+			"ignore": ["mex", "engy_mid", "engy_high", "pylon", "nano"]
+		}
+	},
+	"instance": {
+		"fac_land": ["factorycloak", "factoryamph", "factoryhover", "factoryjump", "factoryshield", "factoryspider", "factorytank", "factoryveh"],
+		"fac_air": ["factoryplane", "factorygunship"],
+		"fac_water": ["factoryship"],
+		"fac_strider": ["striderhub"],
+		"solar": ["energysolar"],
+		"wind": ["energywind"],
+		"fusion": ["energyfusion"],
+		"singu": ["energysingu"],
+		"pylon": ["energypylon"],
+		"store": ["staticstorage"],
+		"mex": ["staticmex"],
+		"def_low": ["turretmissile", "turretlaser", "staticarty"],
+		"caretaker": ["staticcon", "staticrearm"],
+		"superweapon": ["raveparty", "staticnuke", "zenith", "turretaaheavy", "staticheavyarty", "staticantinuke", "staticheavyradar"],
+//		"protector": ["staticantinuke"],
+//		"terraform": ["terraunit"],
+		"strider": ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"small": ["staticradar"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/build_chain.json
@@ -1,0 +1,249 @@
+// Mono-space font required
+{
+"porcupine": {
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//        5              6                7             8                 9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10             11               12            13                14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		        16
+		"staticantinuke", "staticheavyradar"
+	],
+	// Actual number of defences per cluster bounded by income
+	"land":  [0, 0, 1, 3, 5, 1, 2, 14, 1, 9, 5, 6, 2, 3, 5, 0, 8, 9, 14, 1, 3, 6, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
+	"prevent": 1,  // number of preventive defences
+	"amount": {  // income bound factor
+		"offset": [-0.15, 0.4],
+		// Amount factor: 4x4 ~ 1.85, 20x20 ~ 1.45
+		"factor": [1.55, 1.30],
+		"map": [4, 20]
+	},
+
+
+	// Base defence and time to build it, in seconds
+	"base": [[0, 10], [1, 300], [0, 310], [1, 400], [6, 450], [0, 500], [16, 600], [5, 660], [1, 990], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [15, 1850]],
+
+	"superweapon": {
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "mahlazer", "staticantinuke"],  // FIXME: last aren't superweapon
+		"weight": [ 0.10,         0.20,        0.20,              0.10,     0.10,    0.10],
+
+		"condition": [16, 20000]  // [<Minimum income>, <maximum seconds to build>]
+	},
+
+	// Fallback defence
+	"default": "turretmissile"
+},
+
+// Actions on building finished event
+"build_chain": {
+	// WARNING: Avoid recursion
+	// <category>: factory, nano, store, pylon, energy, defence, bunker, big_gun, radar, sonar, mex, repair
+	"energy": {
+		// <UnitDef>: {<elements>}
+		"energysingu": {
+			// Available elements:
+			// "energy": [max energy income, <"mex"|true>]
+			// "pylon": <boolean>
+			// "porc": <boolean>
+			// "terra": <boolean>
+			// "hub": [
+			//     // chain1
+			//     [{<unit1>, <category>, <offset>, <condition>}, {<unit2>, <category>, <offset>, <condition>}, ...],
+			//     // chain2
+			//     [{...}, {...}, ...],
+			//     ...
+			// ]
+			// <unit>: UnitDef
+			// <offset>:
+			//     1) [x, z] in South facing, elmos
+			//     2) {<direction>: <delta>} - left, right, front, back
+			// <condition>: air, no_air, maybe
+
+			// Build pylon in direction of nearby mex cluster
+//			"pylon": true,
+
+			// Build chain of units
+			"hub": [
+				[  // chain1
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				],
+				[  // chain2
+					{"unit": "turretlaser", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 80}},
+					{"unit": "turretmissile", "category": "defence", "offset": [70, -70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				]
+			]
+		},
+		"energyfusion": {
+//			"pylon": true,
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, 80]}
+				]]
+		}
+	},
+	"factory": {
+		"factoryplane": {
+			"hub": [[{"unit": "staticrearm", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"factorygunship": {
+			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"striderhub": {
+			"pylon": true
+		}
+	},
+	"mex": {
+		"staticmex": {
+//			"terra": true,
+			"energy": [20, "mex"],
+			"porc": true
+		}
+	},
+	"big_gun": {
+		"staticheavyarty": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"raveparty": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"mahlazer": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"zenith": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticheavyradar": {
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]}
+				]]
+		},
+		"staticnuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"energypylon": {
+			"hub": [[
+					{"unit": "turretmissile", "category": "radar", "offset": {"back": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": {"left": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": {"back": -100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]}
+				]]
+		},
+		"turretaaheavy": {
+			"pylon": true,
+			"hub": [
+					[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		}
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/commander.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/commander.json
@@ -1,0 +1,383 @@
+// Mono-space font required
+{
+"commander": {
+	"prefix": "dyntrainer_",
+	"suffix": "_base",
+	"unit": {
+		"support": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["builder", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "builder", "scout", "skirmish", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["scout", "builder", "scout", "riot", "raider", "raider", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.9, ["builder", "raider", "scout", "raider", "raider", "scout", "raider", "raider", "scout", "builder"]],
+						[0.1, ["builder", "raider", "raider", "scout",  "skirmish", "builder", "skirmish", "scout"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "riot"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "scout", "scout", "raider", "raider", "builder", "builder"]],
+						[0.5, ["builder", "scout", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout","builder", "scout", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["riot", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[13, 42],  // shotgun
+					[31, 42],  // Cloak, Nano
+					[15, 41, 37],  // sniper, range, health
+					[34, 34, 34],  // companion drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 34],  // battle drones, companion drones
+					[34, 34, 34],  // companion drones
+					[34, 40, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 36, 36],  // health, regen
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 27, 29],  // nano, disruptor ammo, jammer
+					[32, 33, 30],  // area cloak, lazarus, radar
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 38, 38],  // range, high density
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39]  // damage
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 360,  // seconds
+				"threat": 30,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"recon": {
+			// Choice importance, 0 by default
+			"importance": 0.65,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["builder", "raider", "riot", "raider", "raider", "raider", "raider"]]
+						],
+					"factorygunship": [
+						[0.8, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.2, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.2, ["scout", "scout", "builder", "raider", "raider", "raider", "raider", "scout"]],
+						[0.8, ["builder", "scout",  "raider", "scout", "raider", "raider", "raider", "scout", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider"]],
+						[0.5, ["builder", "raider", "raider", "scout", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider", "raider",  "raider"]],
+						[0.5, ["builder", "scout", "scout", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["builder", "scout", "scout", "raider", "builder", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "scout", "builder", "scout", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 240,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[7, 37],  // Machinegun
+					[31, 36],  // Cloak, Regen
+					[19, 38, 39],  // disruptor bomb, high density, damage boost
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 37, 37],  // speed, health
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, builder
+					[42, 42, 42],  // builder
+					[42, 42, 42],  // builder
+					[30, 27, 29],  // radar, disruptor ammo, jammer
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 41, 39],  // range, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 600,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"assault": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["anti_heavy"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.10, ["scout", "builder", "skirmish", "builder", "riot", "builder", "scout", "scout", "scout", "skirmish", "skirmish", "skirmish"]],
+						[0.15, ["scout", "scout", "builder", "riot", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "skirmish", "builder", "riot"]],
+						[0.75, ["scout", "scout", "raider", "raider", "builder", "builder", "raider", "raider", "raider", "raider", "raider", "builder", "scout"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "raider", "raider", "raider", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "heavy"]],
+						[0.25, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "raider", "raider", "raider", "builder", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "scout", "scout", "scout", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout", "builder", "assault"]],
+						[0.5, ["scout", "scout", "builder", "raider", "scout", "raider", "builder", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[11],  // shotgun
+					[24, 37],  // shield, health
+					[11, 41, 41],  // Double Riot, range
+					[38, 41, 41],  // high density, range
+					[36, 41, 36],  // regen, range, regen
+					[41, 41, 41],  // range
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39, 25],  // damage, area shield
+					[26, 29, 30],  // napalm, jammer, radar
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 36, 36],  // speed, regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 38, 38],  // health, high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 140,  // seconds
+				"threat": 70,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"strike": {
+		   // Choice importance, 0 by default
+			"importance": 0.1,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "scout", "scout", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "scout", "builder", "riot"]],
+						[0.9, ["builder", "scout",  "scout",  "raider", "raider", "raider", "raider", "raider", "builder", "builder", "scout",  "raider", "raider", "raider", "raider", "raider", "builder"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "scout", "scout", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "raider", "raider", "skirmish", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.25, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "assault"]],
+						[0.5, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "scout", "scout", "raider", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 315,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[8, 37],  // beam laser
+					[31, 36],  // cloak, regen
+					[8, 40, 36],  // lightning, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[40, 40, 40],  // speed
+					[28, 29, 30],  // flux, jammer, radar
+					[36, 36, 37],  // regen, health
+					[37, 37, 37],  // health
+					[32, 41, 41],  // area cloak, range
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 42],  // companion drones, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 39, 39],  // nano, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 480,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		}
+	}
+}
+} 

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/economy.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/economy.json
@@ -1,0 +1,69 @@
+// Mono-space font required
+{
+"economy": {
+	// Plain list of energy UnitDef and its limit. AI sorts list by efficiency (inverse)
+	// which is = cost * sizeX * sizeZ / make^2
+	// With ZK v1.8.5.2:
+	//   energysingu = 15.486420
+	//   energygeo = 65.306122
+	//   energyfusion = 80.000000
+	//   energywind = 874.999939
+	//   energysolar = 1750.000000
+	// When e-stalling AI will build bottom-most energy that didn't reach its limit.
+	// On normal AI will select top-most energy that it can build under 40 seconds.
+	"energy": {
+		// If land area >= 40% of the map then "land" config used, "water" otherwise
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>]
+			// limit = random(<lower limit>..<upper limit>)
+			"energysingu": [6],
+			"energygeo": [0, 2],
+			"energyfusion": [6, 10],
+			"energywind": [8, 12],
+			"energysolar": [40]
+		},
+		"water": {
+			"energysingu": [1],
+			"energygeo": [0],
+			"energyfusion": [4],
+			"energywind": [20],
+			"energysolar": [8, 12]
+		},
+		// income factor for energy, time is in seconds
+		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]
+		"factor": [[0.15, 1], [7.0, 3600]],
+
+		"link_inc": 16.0,  // minimum metal-income for energy linking
+		"pylon": ["energypylon", "energysolar", "energywind"]
+	},
+
+	// Scales metal income
+	// ecoFactor = teamSize*eps_step+(1-eps_step)
+	"eps_step": 0.2,
+
+	// Mobile buildpower to metal income ratio
+	"buildpower": 1,
+	// Metal excess to income ratio, -1 to disable
+	"excess": -1.0,
+	// Mobile constructor to static constructor metal pull ratio
+	// [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
+//	"ms_pull": [[0.75, 0.0], [0.45, 0.10], [0.53, 0.25], [0.56, 0.40], [0.63, 0.44],[0.52, 0.48],[0.66, 0.52],[0.50, 0.56],[0.66, 0.60], [0.60, 0.65], [0.7, 0.66], [0.8, 0.66], [0.9, 0.75], [0.99, 0.90]],
+	"ms_pull": [[2.0, 0.0], [0.45, 0.20], [0.99, 0.90]],
+	// Max percent of mexes circuit team allowed to take.
+	// If its <1.0 then expansion obeys ms_pull rule, if >=1.0 then ms_pull doesn't affect expansion (mex, pylon, energy).
+	// [<cap_percent>, <is_ally_cap>]
+	"mex_max": [0.3, true],  // 30%
+	// Construction order delay in seconds, -1 to disable
+	"build_delay": [[40, 600], [30, 2400]],
+
+	// New factory switch interval, in seconds (each new factory resets timer, switch event is also based on eco + caretakers)
+	// switch = random(<min_interval>..<max_interval>)
+	"switch": [800, 900],
+
+	"terra": "terraunit",
+	"airpad": "staticrearm",
+
+	// Unknown UnitDef replacer
+	"default": "turretmissile"
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/factory.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/factory.json
@@ -1,0 +1,380 @@
+// Mono-space font required
+{
+// Factory selection parameters
+"select": {
+	"air_map": 80,
+	"offset": [-20, 20],
+	// Speed factor: 8x8 ~ 0%, 24x24 ~ 40%
+	"speed": [0, 40],
+	"map": [8, 24],
+	"no_air": 3
+},
+
+// Utility param: warning on unit's total probability not equal to 100%
+"warn_probability": true,
+
+// Define factories
+"factory": {
+	"factorycloak": {
+		// Adjusts the priority of factory choice (factories with map_percent < 20 are ignored)
+		// map_percent is [20..100]
+		// On start:
+		//   if factory has available builder in current frame: priority ~= map_percent * importance0 + random(-20..+20)
+		//   if factory's builder unavailable in current frame: priority ~= map_percent * importance0 / 10 + random(-20..+20)
+		// During game: priority ~= map_percent * importance1 + random(-20..+20)
+		// importanceN = 1.0 by default if not set
+		"importance": [0.78, 0.2],
+
+		// 'require_energy' adds energy requirement for tierN (N>0): fallback to lowest tier on low energy
+		"require_energy": true,
+
+		// If income*ecoFactor < income_tier[N] then 'tierN' probability will be used
+		"income_tier": [20, 30, 40],
+
+		//             conjurer,   glaive,      scythe,           rocko,        warrior,     zeus,           hammer,      sniper,       tick,        eraser,        gremlin
+		"unit":      ["cloakcon", "cloakraid", "cloakheavyraid", "cloakskirm", "cloakriot", "cloakassault", "cloakarty", "cloaksnipe", "cloakbomb", "cloakjammer", "cloakaa"],
+
+		"land": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.03,             0.30,         0.03,        0.00,           0.00,        0.00,         0.00,        0.00,          0.00],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.20,       0.10,        0.06,             0.51,         0.10,        0.00,           0.00,        0.03,         0.00,        0.00,          0.00],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.25,       0.01,        0.20,             0.20,         0.03,        0.00,           0.00,        0.20,         0.00,        0.11,          0.00]
+
+			// 25-32m Expansions meet - Economy can afford to begin producing in bulk so unit compositions alter.
+	//		"tier3": [ 0.10,       0.40,        0.05,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 33m -40m Solid Fronts - Now we stop raiding and start pushing.
+	//		"tier4": [ 0.10,       0.35,        0.10,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 41m - 56m Mid Game - we must have 2 facs by now, stop making balanced compositions and start being abusive.
+	//		"tier5": [ 0.10,       0.05,        0.25,             0.10,         0.00,        0.20,           0.10,        0.00,         0.00,        0.10,          0.00],
+
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+	//		"tier6": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00],
+
+			// 72m - inf+ Late late Game - This fac sucks!
+	//		"tier7": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00]
+		},
+		"air": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.26,             0.00,         0.00,        0.00,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.10,       0.25,        0.11,             0.38,         0.00,        0.06,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.20,       0.10,        0.10,             0.33,         0.00,        0.12,           0.00,        0.00,         0.00,        0.05,          0.10]
+		},
+		"caretaker": 6
+	},
+
+	"factorygunship": {
+		"importance": [15.0, 1.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 85],
+		//             wasp,         blastwing,     gnat,         banshee,       rapier,         brawler,             blackdawn,        krow,          valkyrie,       vindicator,          trident
+		"unit":      ["gunshipcon", "gunshipbomb", "gunshipemp", "gunshipraid", "gunshipskirm", "gunshipheavyskirm", "gunshipassault", "gunshipkrow", "gunshiptrans", "gunshipheavytrans", "gunshipaa"],
+		"land": {
+			// 0-8m Opening - Blastwing and banshee Harass
+			"tier0": [ 0.00,         0.00,          0.00,         0.00,          0.98,           0.00,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 9-16m Early Game - Banshee with a chance of Blackdawn
+			"tier1": [ 0.00,         0.20,          0.00,         0.02,          0.45,           0.31,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 17-24m Expanding - Time to start a-makin Brawlers
+			"tier2": [ 0.00,         0.02,          0.00,         0.00,          0.04,           0.90,                0.04,             0.00,          0.00,           0.00,                0.00],
+			// 25-32m Expansions meet - Time to keep a-makin Brawlers
+			"tier3": [ 0.00,         0.05,          0.00,         0.00,          0.04,           0.83,                0.08,             0.00,          0.00,           0.00,                0.00],
+			// 33m -40m Solid Fronts - Brawlers with a chance of Krow
+			"tier4": [ 0.00,         0.04,          0.00,         0.00,          0.05,           0.80,                0.10,             0.01,          0.00,           0.00,                0.00],
+			// 41m - 56m Mid Game - Brawlers with a bigger chance of Krow
+			"tier5": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.87,                0.06,             0.02,          0.00,           0.00,                0.00],
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+			"tier6": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.84,                0.07,             0.04,          0.00,           0.00,                0.00],
+			// 72m - inf+ Late late Game - Spam Krows!
+			"tier7": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.90,                0.00,             0.05,          0.00,           0.00,                0.00]
+		},
+		"caretaker": 6
+	},
+
+	"factoryamph": {
+		"importance": [0.85, 1.0],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             conch,     duck,       archer,        buoy,          scallop,    grizzly,       djinn,      angler
+		"unit":      ["amphcon", "amphraid", "amphimpulse", "amphfloater", "amphriot", "amphassault", "amphtele", "amphaa"],
+		"land": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.53,       0.25,          0.20,          0.02,       0.00,          0.00,       0.00],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.16,          0.47,          0.22,       0.00,          0.00,       0.00],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.10,       0.09,          0.51,          0.15,       0.05,          0.00,       0.00],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.47,          0.12,       0.13,          0.00,       0.00],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.16,      0.11,       0.02,          0.52,          0.04,       0.15,          0.00,       0.00],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.20,      0.10,       0.02,          0.49,          0.02,       0.17,          0.00,       0.00],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.48,          0.02,       0.18,          0.00,       0.00],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.46,          0.02,       0.22,          0.00,       0.00]
+		},
+		"air": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.58,       0.25,          0.10,          0.02,       0.00,          0.00,       0.05],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.11,          0.47,          0.22,       0.00,          0.00,       0.05],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.11,       0.04,          0.53,          0.12,       0.05,          0.00,       0.05],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.42,          0.12,       0.13,          0.00,       0.05],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.15,      0.10,       0.02,          0.49,          0.04,       0.15,          0.00,       0.05],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.16,      0.13,       0.02,          0.45,          0.02,       0.17,          0.00,       0.05],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.43,          0.02,       0.18,          0.00,       0.05],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.41,          0.02,       0.22,          0.00,       0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryspider": {
+		"importance": [0.71, 0.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             weaver,      flea,          hermit,          venom,       redback,      recluse,       crabe,         infiltrator,       tarantula
+		"unit":      ["spidercon", "spiderscout", "spiderassault", "spideremp", "spiderriot", "spiderskirm", "spidercrabe", "spiderantiheavy", "spideraa"],
+		"land": {
+			// 0-12m Opening - Opening turbo Flea spam & Riots
+			"tier0": [ 0.00,        0.73,          0.00,            0.22,        0.05,         0.00,          0.00,          0.00,              0.00],
+			// 13-18m Early Game - Reducing Flea spam, still mostly Riots
+			"tier1": [ 0.00,        0.59,          0.00,            0.05,        0.05,         0.31,          0.00,          0.00,              0.00],
+			// 17-24m Expanding - Slant production towards Hermit & Redback
+			"tier2": [ 0.06,        0.48,          0.04,            0.05,        0.00,         0.35,          0.02,          0.00,              0.00],
+			// 25-32m Expansions meet - Slant production towards Hermit & Recluse
+			"tier3": [ 0.08,        0.45,          0.06,            0.03,        0.00,         0.33,          0.05,          0.00,              0.00],
+			// 33m -40m Solid Fronts - 	Greater Emphasis on Hermit & Crabbe
+			"tier4": [ 0.08,        0.40,          0.09,            0.03,        0.00,         0.32,          0.08,          0.00,              0.00],
+			// 41m - 56m Mid Game - We need more Crabbes
+			"tier5": [ 0.08,        0.42,          0.07,            0.02,        0.00,         0.31,          0.10,          0.00,              0.00],
+			// 57m - 72m Late Game -  MORE CRABBES
+			"tier6": [ 0.09,        0.40,          0.11,            0.00,        0.00,         0.29,          0.11,          0.00,              0.00],
+			// 72m - inf+ Late late Game - TURBO CRABBES
+			"tier7": [ 0.10,        0.35,          0.20,            0.00,        0.00,         0.22,          0.13,          0.00,              0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryveh": {
+		"importance": [0.95, 0.2],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             mason,    dart,       scorcher,  slasher,      leveler,   ravager,      dominatrix,   wolverine, impaler,        crasher
+		"unit":      ["vehcon", "vehscout", "vehraid", "vehsupport", "vehriot", "vehassault", "vehcapture", "veharty", "vehheavyarty", "vehaa"],
+		"land": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.12,       0.00,      0.00,         0.20,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.20,      0.60,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.59,         0.01,         0.00,      0.04,           0.00],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.10,       0.00,      0.00,         0.10,      0.56,         0.02,         0.00,      0.07,           0.00],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.10,       0.00,      0.00,         0.06,      0.57,         0.05,         0.00,      0.07,           0.00]
+		},
+		"air": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.10,       0.00,      0.00,         0.22,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.15,      0.65,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.05,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.05],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.56,         0.02,         0.00,      0.03,           0.05],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.56,         0.01,         0.00,      0.04,           0.03],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.15,       0.00,      0.00,         0.10,      0.46,         0.02,         0.00,      0.07,           0.05],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.05,       0.00,      0.00,         0.16,      0.47,         0.05,         0.00,      0.07,           0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryhover": {
+		"importance": [1.00, 1.1],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             quill,      dagger,      scalpel,      halberd,        claymore,           mace,        penetrator,  flail,        bolas
+		"unit":      ["hovercon", "hoverraid", "hoverskirm", "hoverassault", "hoverdepthcharge", "hoverriot", "hoverarty", "hoveraa", "hoverheavyraid"],
+		"land": {
+			// 0-8m Opening - Raiders and Riots
+			"tier0": [ 0.00,       0.55,        0.10,         0.00,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 9-16m Early Game - Mostly Mace, some support
+			"tier1": [ 0.00,       0.10,        0.44,         0.11,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 17-24m Expanding - MAXIMUM OP Scalpel time
+			"tier2": [ 0.05,       0.10,        0.43,         0.20,           0.00,               0.14,        0.08,        0.00,        0.00],
+			// 25-32m Expansions meet - Mix in some Halberds
+			"tier3": [ 0.15,       0.10,        0.26,         0.20,           0.01,               0.16,        0.12,        0.00,        0.00],
+			// 33m -40m Solid Fronts - 	More Halberd and Pene
+			"tier4": [ 0.17,       0.13,        0.19,         0.31,           0.01,               0.05,        0.14,        0.00,        0.00],
+			// 41m - 56m Mid Game - Even more Halberd and Pene
+			"tier5": [ 0.17,       0.11,        0.17,         0.30,           0.01,               0.05,        0.19,        0.00,        0.00],
+			// 57m - 72m Late Game - More Pene
+			"tier6": [ 0.20,       0.04,        0.10,         0.34,           0.01,               0.10,        0.21,        0.00,        0.00],
+			// 72m - inf+ Late late Game - MAXIMUM PENE
+			"tier7": [ 0.25,       0.02,        0.07,         0.21,           0.00,               0.10,        0.35,        0.00,        0.00]
+		},
+		"water": {
+			// 33m -40m
+			"tier4": [ 0.00,       0.49,        0.10,         0.20,           0.10,               0.10,        0.01,        0.00],
+			// 41m - inf+4
+			"tier5": [ 0.00,       0.24,        0.05,         0.41,           0.20,               0.05,        0.05,        0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryplane": {
+		"importance": [12.0, 12.1],
+		"require_energy": false,
+
+		"income_tier": [30, 60],
+		//             crane,      swift,          hawk,                raven,        phoenix,      thunderbird,    wyvern,        vulture
+		"unit":      ["planecon", "planefighter", "planeheavyfighter", "bomberprec", "bomberriot", "bomberdisarm", "bomberheavy", "planescout"],
+		"air": {
+			// 0-10m Early Game
+			"tier0": [ 0.00,       0.00,           0.75,                0.15,         0.00,         0.00,           0.05,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.00,       0.00,           0.51,                0.00,         0.02,         0.01,           0.24,          0.22]
+		},
+		"land": {
+			// 0-10m Early Game
+			"tier0": [ 0.10,       0.00,           0.00,                0.60,         0.05,         0.00,           0.20,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.10,       0.00,           0.00,                0.05,         0.00,         0.00,           0.40,          0.45]
+		},
+		"caretaker": 6
+	},
+
+	"factorytank": {
+		"importance": [0.9, 1.5],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             welder,    kodachi,    panther,         banisher,   reaper,        goliath,            pillager,   tremor,          copperhead
+		"unit":      ["tankcon", "tankraid", "tankheavyraid", "tankriot", "tankassault", "tankheavyassault", "tankarty", "tankheavyarty", "tankaa"],
+		"land": {
+			// 0-8m Opening - Koda and Banisher
+			"tier0": [ 0.10,      0.60,       0.10,            0.20,       0.00,          0.00,               0.00,       0.00,            0.00],
+			// 9-16m Early Game - Mostly Banisher
+			"tier1": [ 0.10,      0.15,       0.10,            0.23,       0.42,          0.00,               0.00,       0.00,            0.00],
+			// 17-24m Expanding - Begin mixing in Reapers!
+			"tier2": [ 0.30,      0.13,       0.07,            0.16,       0.34,          0.00,               0.00,       0.00,            0.00],
+			// 25-32m Expansions meet - More Reapers!
+			"tier3": [ 0.46,      0.15,       0.03,            0.04,       0.32,          0.00,               0.00,       0.00,            0.00],
+			// 33m -40m Solid Fronts - 	MAXIMUM REAPERS
+			"tier4": [ 0.45,      0.14,       0.00,            0.02,       0.37,          0.02,               0.00,       0.00,            0.00],
+			// 41m - 56m Mid Game - More arty & Golly
+			"tier5": [ 0.46,      0.16,       0.00,            0.02,       0.32,          0.04,               0.00,       0.00,            0.00],
+			// 57m - 72m Late Game - Even more arty & Golly
+			"tier6": [ 0.40,      0.13,       0.00,            0.02,       0.34,          0.11,               0.00,       0.00,            0.00],
+			// 72m - inf+ Late late Game - MAXIMUM GOLLY
+			"tier7": [ 0.42,      0.08,       0.00,            0.02,       0.32,          0.16,               0.00,       0.00,            0.00]
+		},
+
+		"caretaker": 15
+	},
+
+	"factoryjump": {
+		"importance": [0.73, 1.1],
+		"require_energy": false,
+
+		"income_tier": [20, 40, 60, 80],
+		//             freaker,   puppy,       pyro,       placeholder,     moderator,   jack,          sumo,       firewalker, skuttle,    archangel
+		"unit":      ["jumpcon", "jumpscout", "jumpraid", "jumpblackhole", "jumpskirm", "jumpassault", "jumpsumo", "jumparty", "jumpbomb", "jumpaa"],
+		"land": {
+			"tier0": [ 0.05,      0.24,        0.50,       0.00,            0.15,        0.06,          0.00,       0.00,       0.00,       0.00],
+			"tier1": [ 0.10,      0.20,        0.20,       0.10,            0.16,        0.24,          0.00,       0.00,       0.00,       0.00],
+			"tier2": [ 0.20,      0.20,        0.00,       0.15,            0.04,        0.31,          0.00,       0.10,       0.00,       0.00],
+			"tier3": [ 0.25,      0.15,        0.00,       0.15,            0.00,        0.33,          0.00,       0.12,       0.00,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryshield": {
+		"importance": [0.88, 0.6],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 48, 66],
+		//             convict,     dirtbag,       bandit,       rogue,         thug,            outlaw,       felon,         racketeer,    roach,        aspis,          vandal
+		"unit":      ["shieldcon", "shieldscout", "shieldraid", "shieldskirm", "shieldassault", "shieldriot", "shieldfelon", "shieldarty", "shieldbomb", "shieldshield", "shieldaa"],
+		"land": {
+			"tier0": [ 0.05,        0.05,          0.70,         0.00,          0.20,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier1": [ 0.08,        0.01,          0.10,         0.24,          0.57,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier2": [ 0.12,        0.03,          0.00,         0.20,          0.54,            0.00,         0.05,          0.00,         0.00,         0.06,           0.00],
+			"tier3": [ 0.15,        0.07,          0.00,         0.00,          0.62,            0.00,         0.08,          0.00,         0.00,         0.08,           0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryship": {
+		"importance": [5.5, 5.5],
+		"require_energy": false,
+
+		"income_tier": [30],
+		//             mariner    cutter,      hunter,           seawolf,     corsair,    mistral,     siren,         ronin,      zephyr
+		"unit":      ["shipcon", "shipscout", "shiptorpraider", "subraider", "shipriot", "shipskirm", "shipassault", "shiparty", "shipaa"],
+		"water": {
+			"tier0": [ 0.05,      0.15,        0.35,             0.10,        0.10,       0.10,        0.15,          0.00,       0.00],
+			"tier1": [ 0.05,      0.10,        0.20,             0.10,        0.05,       0.10,        0.25,          0.15,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"striderhub": {
+		"importance": [0, 1.5],
+		"require_energy": false,
+
+		"income_tier": [60, 80, 100],
+		//             ultimatum,          scorpion,          dante,          catapult,      funnelweb,          bantha,          detriment,          scylla,          reef,          battleship
+		"unit":      ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"land": {
+			"tier0": [ 0.01,               0.10,              0.81,           0.00,          0.05,               0.03,            0.00,               0.00,            0.00,          0.00],
+			"tier1": [ 0.03,               0.14,              0.22,           0.24,          0.20,               0.16,            0.01,               0.00,            0.00,          0.00],
+			"tier2": [ 0.05,               0.10,              0.16,           0.35,          0.10,               0.21,            0.03,               0.00,            0.00,          0.00],
+			"tier3": [ 0.05,               0.10,              0.01,           0.26,          0.10,               0.35,            0.13,               0.00,            0.00,          0.00]
+		},
+		"water": {
+			"tier1": [ 0.50,               0.00,              0.00,           0.00,          0.00,               0.00,            0.00,               0.00,            0.25,          0.25],
+			"tier2": [ 0.10,               0.00,              0.00,           0.00,          0.00,               0.00,            0.10,               0.00,            0.40,          0.40]
+		},
+
+		"caretaker": 100
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/response.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/response.json
@@ -1,0 +1,136 @@
+// Mono-space font required
+{
+// Build special units when enemy_metal*ratio > response_metal*eps; eps=teamSize*eps_step+(1-eps_step)
+// AA condition for 3v3: (enemy_air_metal*0.67 > (aa_metal+aa_cost)*1.12) and (aa_metal+aa_cost < army_metal*0.5)
+//
+// Probability of UnitDef for AA role depends on income tier: (tierN[UnitDef]+_weight_)*enemy_air_metal/aa_metal*importance
+// armjeth probability for tier 1: (0.00+10.00)*enemy_air_metal*600.0
+"response": {
+	"_weight_": 70.0,  // base weight of response probability, default=0.5
+
+	"assault": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "super", "missileskirm", "turtle"],
+		"ratio":      [ 0.75,   2.0,      0.00,      0.20,        0.00,    0.75,    1.5,            3.0],
+		"importance": [ 15.00,  45.00,    25.00,     75.00,       0.00,    45.00,   125.00,         50.0],
+		"max_percent": 1.00
+	},
+	"skirmish": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "anti_heavy"],
+		"ratio":      [ 1.50,   0.75,     1.00,      0.00,        0.00,    0.00],
+		"importance": [ 35.00,  25.00,    25.00,     75.00,       0.00,    0.00],
+		"max_percent": 1.00
+	},
+	"raider": {
+		"vs":         ["anti_air", "scout", "raider", "anti_heavy", "mine", "skirmish", "artillery"],
+		"ratio":      [ 0.00,       1.00,    1.0,      0.10,         0.35,   0.40,       0.8],
+		"importance": [ 15.00,      75.00,   75.00,    15.00,        60.00,  45.00,      10.00],
+		"max_percent": 1.00,
+		"eps_step": 0.75
+	},
+	"riot": {
+		"vs":         ["raider", "scout", "commander", "bullshit_raider"],
+		"ratio":      [ 0.8,      0.8,     0.33,        1.5],
+		"importance": [ 100.00,   100.00,  75.00,       125.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"missileskirm": {
+		"vs":         ["raider", "scout", "riot"],
+		"ratio":      [ 0.25,     0.5,     0.25],
+		"importance": [ 35.00,    50.00,   35.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"transport": {
+		"vs":         ["super", "support", "shieldball"],
+		"ratio":      [ 0.75,    0.75,      0.75],
+		"importance": [ 50.00,   50.00,     50.00],
+		"max_percent": 0.30,
+		"eps_step": 0.015
+	},
+	"scout": {
+		"vs":         ["mine", "artillery", "anti_air", "scout", "static", "heavy", "anti_heavy", "cloaked_raider"],
+		"ratio":      [ 0.35,   0.05,        0.10,       1.00,    0.00,     0.00,    0.05,         0.5],
+		"importance": [ 60.00,  60.0,        60.0,       35.00,   0.00,     0.00,    10.00,        100.00],
+		"max_percent": 0.09,
+		"eps_step": 0.025
+	},
+	"artillery": {
+		"vs":         ["static", "artillery", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.66,     0.00,        0.66,    0.25,         3.0],
+		"importance": [ 20.00,    0.00,        40.00,   40.00,        40.0],
+		"max_percent": 0.66,
+		"eps_step": 0.02
+	},
+	"anti_air": {
+		"vs":         ["air"],
+		"ratio":      [ 0.8],
+		"importance": [ 75.0],
+		"max_percent": 0.4,
+		"eps_step": 0.75
+	},
+	"anti_sub": {
+		"vs":         ["sub"],
+		"ratio":      [ 0.0],
+		"importance": [ 0.0],
+		"max_percent": 0.00,
+		"eps_step": 0.0
+	},
+	"anti_heavy": {
+		"vs":         ["heavy", "artillery", "support", "anti_heavy", "commander", "super", "turtle"],
+		"ratio":      [ 0.45,    0.00,        0.00,      0.00,         0.4,         0.50,    3.00],
+		"importance": [ 85.00,   0.00,        0.00,      0.00,         50.00,       85.0,    50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"disarm_target": {
+		"vs":         ["disarm_target"],
+		"ratio":      [ 0.50],
+		"importance": [ 100.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"snipe_target": {
+		"vs":         ["snipe_target", "commander"],
+		"ratio":      [ 1.00,           0.20],
+		"importance": [ 100.00,         50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"cloaked_raider": {
+		"vs":         ["snipe_target", "commander", "transport"],
+		"ratio":      [ 0.50,           0.20,        2.00],
+		"importance": [ 35.00,          35.00,       125.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"heavy": {
+		"vs":         ["heavy", "static", "support", "skirmish", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.75,    0.5,      0.00,      0.75,       0.75,    0.75,         3.00],
+		"importance": [ 75.00,   15.00,    0.00,      15.00,      75.00,   75.00,        75.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"bomber": {
+		"vs":         ["shieldball", "anti_heavy", "artillery", "super"],
+		"ratio":      [ 0.50,         0.50,         0.50,        0.50],
+		"importance": [ 0.50,         50.00,        50.00,       50.00],
+		"max_percent": 1.0,
+		"eps_step": 0.00
+	},
+	"super": {
+		"vs":         ["heavy", "static", "support", "skirmish", "artillery", "super", "turtle"],
+		"ratio":      [ 0.3,     0.55,     0.00,      0.00,       0.00,        0.00,    0.5],
+		"importance": [ 45.00,   25.00,    0.00,      0.00,       0.00,        0.00,    45.00],
+		"max_percent": 0.2,
+		"eps_step": 0.00
+	},
+	"support": {
+		"vs":         ["assault", "bullshit_raider"],
+		"ratio":      [ 1.00,      0.4],
+		"importance": [ 35.00,     75.00],
+		"max_percent": 0.25,
+		"eps_step": 0.00
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/behaviour.json
@@ -1,0 +1,1122 @@
+// Mono-space font required
+{
+"quota": {
+	"scout": 1,  // max scout units out of raiders
+	"raid": [7.0, 42.0],  // [<min>, <avg>] power of raider squad
+	"attack": 20.0,  // min power of attack group
+	"thr_mod": {
+		"attack": [0.45, 0.45],  // [<min>, <max>] enemy threat modifier for target selection of attack task
+		"defence": [0.80, 0.80],  // [<min>, <max>] enemy threat modifier for group size calculation of defence task
+		"mobile": 1.075,  // initial modifier for power of attack group based on mobile enemy threat
+		"static": 4.25,  // initial modifier for power of attack group based on static enemy threat
+		"comm": 0.75
+	},
+	"aa_threat": 80.0,  // anti-air threat threshold, air factories will stop production when AA threat exceeds
+	"slack_mod": {
+		"all": 0.5,  // threat map 64-elmos slack multiplier for all units
+		"static": 1.5,  // additional 64-elmo-cells for static units
+		"speed": [0.75, 4.0]  // [<64elmo_cells_speed_mod>, <max_64elmo_cells>]
+	}
+},
+
+// If unit's health drops below specified percent it will retreat
+"retreat": {
+	"builder": [0.70, 1.0],  // [<default>, <UnitDef modifier>] for all builders
+	"fighter": [0.45, 1.0],  // [<default>, <UnitDef modifier>] for all not-builder units
+	"shield": [0.25, 0.275]  // [<empty>, <full>] shield power
+},
+
+"defence": {
+	"infl_rad": 7,  // influenece cell radius for defendAlly map
+	"base_rad": [1000.0, 2000.0],  // defend if enemy within clamp(distance(lane_pos, base_pos), 1000, 2000) radius
+	"comm_rad": [1000.0, 500.0]  // 0 distance from base ~ 1000, base_rad ~ 500.0
+},
+
+
+"behaviour": {
+	// factorycloak
+	"cloakcon": {
+		// "role": [<main>, <enemy>, <enemy>, ...]
+		// <main> is the role to make desicions of when to build it and what task to assign
+		// <enemy> is to decide how to counter enemy unit, if missing then equals to <main>
+		// Roles: builder, scout, raider, riot, assault, skirmish, artillery, anti_air, anti_sub, anti_heavy, bomber, support, mine, transport, air, sub, static, heavy, super, commander
+		// Auto-assigned roles: builder, air, static, super, commander
+		"role": ["builder", "mine"]
+
+		// Attributes - optinal states
+		// "melee" - always move close to target, disregard attack range
+		// "boost" - boost speed on retreat
+		// "no_jump" - disable jump on retreat
+		// "no_strafe" - disable gunship's strafe
+		// "stockpile" - load weapon before any task, auto-assigned
+		// "siege" - mostly use fight command instead of move
+		// "ret_hold" - hold fire on retreat
+		// "ret_fight" - fight on retreat
+		// "jump" - enable jump on regular move
+		// "dg_cost" - DGun by metal cost instead of by threat
+		// "anti_stat" - only static targets
+		// "no_dgun" - do not use DGun
+//		"attribute": ["boost", "no_strafe"],
+
+		// Fire state (open by default)
+		// "hold" - hold fire
+		// "return" - return fire
+		// "open" - fire at will
+//		"fire_state": "open",
+
+		// Overrides reloadTime in seconds
+//		"reload": 1.0,
+
+		// Limits number of units
+//		"limit": 10,
+
+		// Unit can be built only since specific time in seconds
+//		"since": 60,
+
+		// Minimum hp percent before retreat
+//		"retreat": 0.8,
+
+		// Ally threat multiplier
+//		"pwr_mod": 1.0,
+		// Enemy threat multiplier
+//		"thr_mod": 1.0,
+
+		// Ignore enemy
+//		"ignore": false
+	},
+	"cloakraid": {
+		"role": ["raider", "scout"],
+		"attribute": ["scout"],
+		"retreat": 0.1,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.75
+	},
+	"cloakheavyraid": {
+		"role": ["cloaked_raider", "raider"],
+		"attribute": ["ret_fight"],
+		"since": 180,
+		"limit": 3,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.1,
+		"retreat": 0.4
+	},
+	"cloakskirm": {
+		"role": ["skirmish"],
+		"attribute": ["ret_fight"],
+		"pwr_mod": 0.85,
+		"since": 180,
+		"limit": 20,
+		"retreat": 0.35  // mostly disposable
+	},
+	"cloakriot": {
+		"role": ["riot", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"since": 180,
+		"retreat": 0.55,
+		"pwr_mod": 1.4,
+		"thr_mod": 2.3
+	},
+	"cloakassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.35,  // assaults need to assault
+		"since": 240,
+		"pwr_mod": 0.7,
+		"thr_mod": 1.1
+	},
+	"cloakarty": {
+		"role": ["artillery"],
+		"since": 550,
+		"limit": 8,
+		"retreat": 0.9,
+		"thr_mod": 0.0
+	},
+	"cloaksnipe": {
+		"role": ["snipe_target"],
+		"attribute": ["support"],
+		"pwr_mod": 3.0,
+		"since": 520,
+		"thr_mod": 0.0,
+		"retreat": 0.69
+	},
+	"cloakbomb": {
+		"role": ["mine"],
+		"retreat": 0.01
+	},
+	"cloakjammer": {
+		"role": ["assault"],
+		"since": 480,
+		"retreat": 0.5,
+		"limit": 1
+	},
+	"cloakaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factorygunship
+	"gunshipcon": {
+		"role": ["builder", "air"],
+		"limit": 2,
+		"since": 240,
+		"retreat": 0.99
+	},
+	"gunshipbomb": {
+		"role": ["bomber", "air"],
+		"attribute": ["melee"],
+		"limit": 1,
+		"thr_mod": 1.0,
+		"retreat": 0.01
+	},
+	"gunshipemp": {
+		"role": ["anti_heavy", "air"],
+		"thr_mod": 0.1,
+		"pwr_mod": 0.1,
+		"since": 600,
+		"limit": 6,
+		"retreat": 0.9
+	},
+	"gunshipskirm": {
+		"role": ["air", "bullshit_raider"],
+		"retreat": 0.65,
+		"pwr_mod": 0.7,
+		"limit": 8,
+		"thr_mod": 0.66
+	},
+	"gunshipraid": {
+		"role": ["scout", "air"],
+		"retreat": 0.7,
+		"limit": 1,
+		"pwr_mod": 1.25,
+		"thr_mod": 1.1
+	},
+	"gunshipheavyskirm": {
+		"role": ["assault", "air"],
+		"since": 330,
+		"attribute": ["no_strafe"],
+		"retreat": 0.65,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.00
+	},
+	"gunshipassault": {
+		"role": ["anti_heavy", "air"],
+		"limit": 3,
+		"since": 330,
+		"retreat": 0.5,
+		"pwr_mod": 1.65,
+		"thr_mod": 1.00
+	},
+	"gunshipkrow": {
+		"role": ["anti_heavy", "air", "disarm_target"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"since": 720,
+		"pwr_mod": 0.3,
+		"thr_mod": 0.3,
+		"limit": 0
+	},
+	"gunshiptrans": {
+		"role": ["air"],
+		"limit": 0
+	},
+	"gunshipheavytrans": {
+		"role": ["air"],
+		"limit": 0,
+		"thr_mod": 0.0
+	},
+	"gunshipaa": {
+		"role": ["anti_air", "air"],
+		"limit": 6,
+		"retreat": 0.95,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryamph
+	"amphcon": {
+		"role": ["builder", "mine"]
+	},
+	"amphraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"limit": 10,
+		"retreat": 0.25  // pretty disposable
+	},
+	"amphimpulse": {
+		"role": ["riot"],
+		"limit": 1,
+		"retreat": 0.36,
+		"pwr_mod": 2.25,
+		"thr_mod": 2.25
+	},
+	"amphfloater": {
+		"role": ["assault", "snipe_target", "super"],
+		"limit": 14,
+		"since": 120,
+		"retreat": 0.25, // too slow to be retreating all the time
+		"pwr_mod": 1.3,
+		"thr_mod": 1.3
+	},
+	"amphriot": {
+		"role": ["riot"],
+		"attribute": ["melee", "ret_fight"],
+		"pwr_mod": 1.5,
+		"retreat": 0.35 // too slow to be retreating all the time
+	},
+	"amphassault": {
+		"role": ["heavy", "disarm_target"],
+		"retreat": 0.66,
+		"since": 520,
+		"pwr_mod": 1.4,
+		"thr_mod": 1.0
+	},
+	"amphtele": {
+		"role": ["transport"],
+		"limit": 0
+	},
+	"amphaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight", "support"],
+		"retreat": 0.3,
+		"limit": 5,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.5
+	},
+
+	// factoryspider
+	"spidercon": {
+		"role": ["builder", "mine"]
+	},
+	"spiderscout": {
+		"role": ["scout", "raider"],
+		"thr_mod": 0.5,
+		"limit": 20,
+		"retreat": 0.01
+	},
+	"spiderassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.15,
+		"retreat": 0.35
+	},
+	"spideremp": {
+		"role": ["raider", "riot"],
+		"pwr_mod": 3.0,
+		"limit": 1,
+		"retreat": 0.5
+	},
+	"spiderriot": {
+		"role": ["riot"],
+		"pwr_mod": 2.0,
+		"limit": 4,
+		"attribute": ["support"],
+		"retreat": 0.35
+	},
+	"spiderskirm": {
+		"role": ["skirmish", "snipe_target", "super"],
+		"pwr_mod": 2.0,
+		"thr_mod": 1.0,
+		"since": 180,
+		"retreat": 0.4
+	},
+	"spidercrabe": {
+		"role": ["heavy", "disarm_target", "turtle"],
+		"attribute": ["siege", "ret_fight", "support"],
+		"retreat": 0.5,
+		"thr_mod": 2.5,
+		"pwr_mod": 2.5,
+		"since": 300,
+		"thr_mod": 1.0
+	},
+	"spiderantiheavy": {
+		"role": ["anti_heavy", "mine"],
+		"retreat": 0.99,
+		"pwr_mod": 2.0,
+		"thr_mod": 0.1,
+		"since": 600,
+		"limit": 1
+	},
+	"spideraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryshield
+	"shieldcon": {
+		"role": ["builder", "shieldball", "mine"],
+		"retreat": 1.3
+	},
+	"shieldscout": {
+		"role": ["transport", "raider"],
+		"limit": 20,
+		"attribute": ["siege", "melee"],
+		"pwr_mod": 0.11,
+		"thr_mod": 0.1,
+		"retreat": 0.0
+	},
+	"shieldraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"retreat": 0.25,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.9
+	},
+	"shieldskirm": {
+		"role": ["skirmish"],
+		"limit": 15,
+		"since": 200,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"retreat": 0.3
+	},
+	"shieldassault": {
+		"role": ["assault", "support", "shieldball"],
+		"attribute": ["melee"],
+		"limit": 20,
+		"retreat": 0.3,
+		"since": 120,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.35
+	},
+	"shieldriot": {
+		"role": ["riot", "shieldball"],
+		"fire_state": "hold",
+		"since": 100,
+		"limit": 5,
+		"retreat": 0.3,
+		"pwr_mod": 1.7,
+		"thr_mod": 1.7
+	},
+	"shieldfelon": {
+		"role": ["heavy", "shieldball", "snipe_target"],
+		"since": 420,
+		"retreat": 0.35,
+		"pwr_mod": 1.1,
+		"thr_mod": 1.1
+	},
+	"shieldarty": {
+		"role": ["disarm_target"],
+		"since": 300,
+		"retreat": 0.3,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"shieldbomb": {
+		"role": ["mine"]
+	},
+	"shieldshield": {
+		"role": ["super", "heavy", "shieldball"],
+		"since": 540,
+		"attribute": ["support"],
+		"retreat": 0.36,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.25
+	},
+	"shieldaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryveh
+	"vehcon": {
+		"role": ["builder", "mine"]
+	},
+	"vehscout": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"thr_mod": 0.6,
+		"pwr_mod": 1.2,
+		"retreat": 0.01,
+		"limit": 4
+	},
+	"vehraid": {
+		"role": ["raider"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.3,
+		"pwr_mod": 1.1,
+		"thr_mod": 0.8
+	},
+	"vehsupport": {
+		"role": ["artillery", "missileskirm"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.4,
+		"retreat": 0.6  // cannot retreat
+	},
+	"vehriot": {
+		"role": ["riot"],
+		"retreat": 0.6,
+		"pwr_mod": 1.5,
+		"thr_mod": 1.5
+	},
+	"vehassault": {
+		"role": ["assault"],
+		"attribute": ["melee"],
+		"retreat": 0.4,  // slow to turn around
+		"since": 180,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9
+	},
+	"vehcapture": {
+		"role": ["support", "disarm_target", "snipe_target"],
+		"since": 180,
+		"pwr_mod": 1,
+		"thr_mod": 1,
+		"retreat": 0.8
+	},
+	"veharty": {
+		"role": ["transport", "super"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 15,
+		"since": 460,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0,
+		"retreat": 0.8
+	},
+	"vehheavyarty": {
+		"role": ["artillery", "heavy", "turtle"],
+		"since": 300,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.00
+	},
+	"vehaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.75,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryjump
+	"jumpcon": {
+		"role": ["builder", "mine"]
+	},
+	"jumpscout": {
+		"role": ["riot", "raider"],
+		"limit": 15,
+		"attribute": ["melee", "siege"],
+		"retreat": 0
+	},
+	"jumpraid": {
+		"role": ["raider", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.4,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.9
+	},
+	"jumpblackhole": {
+		"role": ["support"],
+		"since": 300,
+		"limit": 6,
+		"retreat": 0.36
+	},
+	"jumpskirm": {
+		"role": ["skirmish", "super", "snipe_target"],
+		"retreat": 0.4
+	},
+	"jumpassault": {
+		"role": ["assault", "anti_sub", "disarm_target"],
+		"attribute": ["melee", "siege", "ret_fight"],
+		"retreat": 0.4,
+		"pwr_mod": 1.3,
+		"thr_mod": 0.5
+	},
+	"jumpsumo": {
+		"role": ["heavy", "support", "disarm_target"],
+		"limit": 0,
+		"attribute": ["melee", "no_jump"]  // jump on attack
+	},
+	"jumparty": {
+		"role": ["heavy", "turtle", "snipe_target"],
+		"attribute": ["support"],
+		"since": 600,
+		"pwr_mod": 0.1,
+		"limit": 2,
+		"thr_mod": 0.00,
+		"retreat": 0.99
+	},
+	"jumpbomb": {
+		"role": ["anti_heavy", "builder"],
+		"attribute": ["melee", "mine"],
+		"fire_state": "open",
+		"since": 720,
+		"limit": 2,
+		"retreat": 0.01,
+		"pwr_mod": 3.0,
+		"thr_mod": 0.01
+	},
+	"jumpaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryhover
+	"hovercon": {
+		"role": ["builder", "mine"]
+	},
+	"hoverraid": {
+		"role": ["scout"],
+		"attribute": ["melee"],		
+		"pwr_mod": 0.9,
+		"thr_mod": 0.8,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9,
+		"limit": 4,
+		"retreat": 0.5
+	},
+	"hoverheavyraid": {
+		"role": ["raider", "bullshit_raider"],	
+		"retreat": 0.35,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.8
+	},
+	"hoverskirm": {
+		"role": ["skirmish", "support"],
+		"retreat": 0.55,
+		"limit": 12,
+		"reload": 4.0,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.6
+	},
+	"hoverassault": {
+		"role": ["assault", "raider"],
+		"attribute": ["melee", "ret_hold"],
+		"retreat": 0.4,
+		"limit": 12,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.45
+	},
+	"hoverdepthcharge": {
+		"role": ["anti_sub", "riot"],
+		"attribute": ["melee"],
+		"retreat": 0.6
+	},
+	"hoverriot": {
+		"role": ["riot", "snipe_target"],
+		"retreat": 0.4,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.25
+	},
+	"hoverarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"attribute": ["siege"],
+		"retreat": 0.99,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"hoveraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryplane
+	"planecon": {
+		"role": ["builder", "air"],
+		"since": 240,
+		"limit": 2,
+		"retreat": 0.99
+	},
+	"planefighter": {
+		"role": ["scout", "air"],
+		"attribute": ["boost"],
+		"pwr_mod": 1.5,
+		"limit": 1,
+		"thr_mod": 3.0,
+		"retreat": 0.8
+	},
+	"planeheavyfighter": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"limit": 8,
+		"retreat": 0.4,
+		"pwr_mod": 2.5,
+		"thr_mod": 3.0
+	},
+	"bomberprec": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"attribute": ["siege"],
+		"limit": 10,
+		"retreat": 0.8,
+		"pwr_mod": 0.10,
+		"thr_mod": 0.01
+	},
+	"bomberriot": {
+		"role": ["bomber", "air"],
+		"limit": 0,
+		"retreat": 0.6,
+		"pwr_mod": 0.01,
+		"thr_mod": 0.01
+	},
+	"bomberdisarm": {
+		"role": ["anti_heavy", "air"],
+		"attribute": ["siege", "bomber"],
+		"limit": 2,
+		"since": 1200,
+		"retreat": 0.95,
+		"pwr_mod": 100.00,
+		"thr_mod": 0.01
+	},
+	"bomberheavy": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"fire_state": "return",
+		"limit": 4,
+		"since": 420,
+		"retreat": 0.95,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.1
+	},
+	"bomberassault": {
+		"role": ["bomber", "air"],
+		"attribute": ["anti_stat", "no_dgun"],
+		"fire_state": "hold",
+		"limit": 1,
+		"since": 1800,
+		"retreat": 0.65,
+		"pwr_mod": 1.25,
+		"thr_mod": 0.01
+	},
+	"planescout": {
+		"role": ["scout", "air"],
+		"since": 360,
+		"limit": 2,
+		"retreat": 0.8
+	},
+
+	// factorytank
+	"tankcon": {
+		"role": ["builder"],
+		"pwr_mod": 0.40,
+		"thr_mod": 0.40,
+		"retreat": 0.9
+	},
+	"tankraid": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"limit": 2,
+		"thr_mod": 0.66,
+		"pwr_mod": 0.8,
+		"retreat": 0.45
+	},
+	"tankheavyraid": {
+		"role": ["raider", "bullshit_raider"],
+		"thr_mod": 0.6,
+		"pwr_mod": 0.65,
+		"retreat": 0.65
+	},
+	"tankriot": {
+		"role": ["riot", "heavy", "snipe_target"],
+		"thr_mod": 1.25,
+		"pwr_mod": 0.75,
+		"retreat": 0.55
+	},
+	"tankassault": {
+		"role": ["assault", "heavy", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7
+	},
+	"tankheavyassault": {
+		"role": ["heavy", "disarm_target", "super"],
+		"attribute": ["melee"],
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7,
+		"since": 480,
+		"retreat": 0.55
+	},
+	"tankarty": {
+		"role": ["artillery", "snipe_target", "heavy"],
+		"attribute": ["support"],
+		"since": 1000,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.0
+	},
+	"tankheavyarty": {
+		"role": ["transport"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 1,
+		"retreat": 0.99,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0
+	},
+	"tankaa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryship
+	"shipcon": {
+		"role": ["builder"]
+	},
+	"shipscout": {
+		"role": ["scout"]
+	},
+	"shiptorpraider": {
+		"role": ["raider"]
+	},
+	"subraider": {
+		"role": ["raider"]
+	},
+	"shipriot": {
+		"role": ["riot"]
+	},
+	"shipskirm": {
+		"role": ["skirmish"]
+	},
+	"shipassault": {
+		"role": ["assault"]
+	},
+	"shiparty": {
+		"role": ["artillery"]
+	},
+	"shipaa": {
+		"role": ["anti_air"]
+	},
+
+	// striderhub
+	"striderantiheavy": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"pwr_mod": 0.5,
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.35
+	},
+	"striderscorpion": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"fire_state": "return",
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"since": 1800,
+		"thr_mod": 0.5
+	},
+	"striderdante": {
+		"role": ["heavy", "disarm_target", "snipe_target"],
+		"attribute": ["melee"],
+		"limit": 2,
+		"retreat": 0.45,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.75
+	},
+	"striderarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"pwr_mod": 5.0,
+		"thr_mod": 0.0,
+		"retreat": 0.9
+	},
+	"striderfunnelweb": {
+		"role": ["heavy", "turtle", "shieldball"],
+		"attribute": ["support"],
+		"retreat": 1.4,
+		"pwr_mod": 1.0,
+		"limit": 1,
+		"since": 3000,
+		"thr_mod": 0.0
+	},
+	"striderbantha": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.5
+	},
+	"striderdetriment": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.50,  // deffo retreat, running into nab annihlator farm and sploding is silly :)
+		"pwr_mod": 0.34,
+		"thr_mod": 0.34
+	},
+	"subtacmissile": {
+		"role": ["artillery", "heavy"],
+		"attribute": ["stockpile"]
+	},
+	"shipcarrier": {
+		"role": ["artillery", "heavy"]
+	},
+	"shipheavyarty": {
+		"role": ["artillery", "heavy"]
+	},
+
+	// statics
+	"staticnuke": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 30.0,
+		"limit": 1,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"staticmissilesilo": {
+		"role": ["static", "support", "heavy"],
+		"thr_mod": 0.01
+	},
+	"raveparty": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"zenith": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 105.0,  // 105sec / 0.7sec/met = 150 meteorsControlled
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"mahlazer": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"staticheavyarty": {
+		"role": ["artillery", "turtle", "heavy"],
+		"limit": 5,
+		"thr_mod": 0.0,
+		"pwr_mod": 10.00
+	},
+	"turretheavy": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 1.00
+	},
+	"turretantiheavy": {
+		"role": ["static", "turtle", "static"],
+		"thr_mod": 0.55
+	},
+	"staticarty": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 0.55
+	},
+	"staticantinuke": {
+		"role": ["static", "heavy", "support"],
+		"since": 720,
+		"limit": 1
+	},
+	"turretheavylaser": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.0
+	},
+	"energysingu": {
+		"role": ["static", "turtle", "heavy"],
+		"attribute": ["support"],  // build at home
+		"since": 660
+	},
+	"energyfusion": {
+		"role": ["static", "mine", "heavy"],
+		"attribute": ["support"],  // build at home
+		"since": 280
+	},
+	"turretaalaser": {
+		"role": ["anti_air"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.0
+	},
+	"turretaaheavy": {
+		"role": ["anti_air", "heavy", "turtle"],
+		"limit": 1,
+		"thr_mod": 1.0
+	},
+	"turretlaser": {
+		"role": ["static", "riot", "builder"],
+		"thr_mod": 1.5
+	},
+	"turretmissile": {
+		"role": ["missileskirm", "riot", "builder"],
+		"thr_mod": 0.34
+	},
+	"turretriot": {
+		"role": ["static", "riot", "snipe_target"],
+		"thr_mod": 1.65
+	},
+	"turretaafar": {
+		"role": ["anti_air", "heavy", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaflak": {
+		"role": ["anti_air", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaclose": {
+		"role": ["anti_air"],
+		"thr_mod": 1.0
+	},
+	"turretgauss": {
+		"role": ["static", "turtle", "transport"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.6
+	},
+	"turretemp": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.5
+	},
+
+	// support factories won't be built in front
+	"factoryplane": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"factorygunship": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"striderhub": {
+		"role": ["static"],
+		"since": 900,
+		"attribute": ["support"]
+	},
+
+	// Enemy Eco!! //
+	"staticmex": {
+		"role": ["mine"]
+	},
+	"energywind": {
+		"role": ["mine"]
+	},
+	"staticradar": {
+		"role": ["mine"]
+	},
+	"staticcon": {
+		"role": ["mine"]
+	},
+	"energypylon": {
+		"role": ["mine"],
+		"since": 600
+	},
+	"staticheavyradar": {
+		"role": ["mine", "turtle"],
+		"limit": 1
+	},
+	"staticstorage": {
+		"role": ["mine", "turtle"],
+		"limit": 5
+	},
+	"energysolar": {
+		"role": ["mine"]
+	},
+	"staticshield": {
+		"role": ["static", "turtle"]
+	},
+
+	// Chickens!! //
+	"dronecarry": {
+		"role": ["transport"]
+	},
+	"chicken": {
+		"role": ["raider"]
+	},
+	"chicken_blimpy": {
+		"role": ["mine"]
+	},
+	"chicken_digger": {
+		"role": ["riot"]
+	},
+	"chicken_dodo": {
+		"role": ["mine"]
+	},
+	"chicken_dragon": {
+		"role": ["heavy"],
+		"thr_mod": 0.4
+	},
+	"chicken_drone": {
+		"role": ["raider"]
+	},
+	"chicken_drone_starter": {
+		"role": ["raider"]
+	},
+	"chicken_leaper": {
+		"role": ["raider"]
+	},
+	"chicken_listener": {
+		"role": ["static"]
+	},
+	"chicken_pigeon": {
+		"role": ["air"]
+	},
+	"chicken_roc": {
+		"role": ["air"]
+	},
+	"chicken_shield": {
+		"role": ["support"]
+	},
+	"chicken_spidermonkey": {
+		"role": ["anti_air"]
+	},
+	"chicken_tiamat": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenblobber": {
+		"role": ["artillery"]
+	},
+	"chickenbroodqueen": {
+		"role": ["heavy"],
+		"thr_mod": 0.05
+	},
+	"chickenflyerqueen": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenlandqueen": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenspire": {
+		"role": ["static"]
+	},
+	"chickena": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenc": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickend": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenf": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenr": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenwurm": {
+		"role": ["heavy"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/block_map.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/block_map.json
@@ -1,0 +1,139 @@
+// Mono-space font required
+{
+"building": {
+	"class_land": {
+		"fac_land": {
+			// "type": [<blocker_shape>, <structure_type>]
+			// Available blocker_shape: rectangle, circle.
+			// Available structure_type: factory, mex, engy_low, engy_mid, engy_high, pylon, def_low, def_mid, def_high, special, nano, terra, unknown
+			"type": ["rectangle", "factory"],
+
+			// Unit of measurement: 1 size/yard/radius = SQUARE_SIZE * 2 = 16 elmos, integer.
+			// Offset in South facing
+			"offset": [0, 6],  // default: [0, 0]
+
+			// Size of a blocker without yard
+//			"size": [7, 7],  // default: size of a unit
+
+			// Spacer, blocker_size = size + yard
+			"yard": [12, 12]  // default: [0, 0]
+
+			// "ignore": [<structure_type>, <structure_type>, ...]
+			// Ignore specified structures.
+			// Additional values: none, all
+//			"ignore": ["none"]  // default: ["none"]
+		},
+		"fac_air": {
+			"type": ["rectangle", "factory"],
+			"yard": [8, 8]
+		},
+		"fac_water": {
+			"type": ["rectangle", "factory"],
+			"offset": [0, 4],
+			"yard": [10, 12]
+		},
+		"fac_strider": {
+			"type": ["rectangle", "special"],
+			"offset": [0, 12],
+			"yard": [16, 16]
+		},
+		"solar": {
+			"type": ["circle", "engy_low"],
+			"ignore": ["mex", "engy_mid", "engy_high", "def_low", "pylon", "nano"],
+			"radius": 7
+		},
+		"wind": {
+			"type": ["circle", "engy_low"],
+			// Integer radius of a blocker or description string.
+			// Available string values: explosion, expl_ally
+//			"radius": "explosion",  // default: "explosion"
+			"radius": 4,
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"fusion": {
+			"type": ["circle", "engy_mid"],
+			"ignore": ["mex", "pylon", "def_low"]
+		},
+		"singu": {
+			"type": ["circle", "engy_high"],
+			"radius": "expl_ally",  // [radius ~ 1 player .. radius/2 ~ 4+ players]
+			"ignore": ["mex", "engy_low", "def_low", "pylon", "nano"]
+		},
+		"pylon": {
+			"type": ["circle", "pylon"],
+			"not_ignore": ["factory", "engy_low", "pylon", "terra"]  // default: ["all"]
+		},
+		"store": {
+			"type": ["rectangle", "mex"],
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"mex": {
+			"type": ["rectangle", "mex"],
+			"ignore": ["all"]
+		},
+		"def_low": {
+			"type": ["circle", "def_low"],
+			"radius": 10,  // 160 / (SQUARE_SIZE * 2)
+			"ignore": ["engy_mid", "engy_high", "pylon", "nano"]
+		},
+		"caretaker": {
+			"type": ["rectangle", "nano"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+		"small": {
+			"type": ["rectangle", "unknown"],
+			"not_ignore": ["factory", "def_low", "terra"]
+		},
+		"superweapon": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "pylon", "engy_high"]
+		},
+		"protector": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+//		"terraform": {
+//			"type": ["rectangle", "special"],
+//			"size": [7, 7]  // int2(3 + 4, 3 + 4)
+//		},
+		"strider": {
+			"type": ["rectangle", "special"],
+			"yard": [2, 2],
+			"ignore": ["all"]
+		},
+		"_default_": {
+			"type": ["rectangle", "unknown"],
+			"yard": [4, 4],
+			"ignore": ["pylon", "engy_high"]
+		}
+	},
+	// Water overrides land. Map considered as water if amount of land < 40%
+	"class_water" : {
+		"wind": {
+			"type": ["circle", "engy_low"],
+			"radius": 1,  // default: "explosion"
+			"ignore": ["mex", "engy_mid", "engy_high", "pylon", "nano"]
+		}
+	},
+	"instance": {
+		"fac_land": ["factorycloak", "factoryamph", "factoryhover", "factoryjump", "factoryshield", "factoryspider", "factorytank", "factoryveh"],
+		"fac_air": ["factoryplane", "factorygunship"],
+		"fac_water": ["factoryship"],
+		"fac_strider": ["striderhub"],
+		"solar": ["energysolar"],
+		"wind": ["energywind"],
+		"fusion": ["energyfusion"],
+		"singu": ["energysingu"],
+		"pylon": ["energypylon"],
+		"store": ["staticstorage"],
+		"mex": ["staticmex"],
+		"def_low": ["turretmissile", "turretlaser", "staticarty"],
+		"caretaker": ["staticcon", "staticrearm"],
+		"superweapon": ["raveparty", "staticnuke", "zenith", "turretaaheavy", "staticheavyarty", "staticantinuke", "staticheavyradar"],
+//		"protector": ["staticantinuke"],
+//		"terraform": ["terraunit"],
+		"strider": ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"small": ["staticradar"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/build_chain.json
@@ -1,0 +1,249 @@
+// Mono-space font required
+{
+"porcupine": {
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//        5              6                7             8                 9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10             11               12            13                14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		        16
+		"staticantinuke", "staticheavyradar"
+	],
+	// Actual number of defences per cluster bounded by income
+	"land":  [0, 0, 1, 3, 5, 1, 2, 14, 1, 9, 5, 6, 2, 3, 5, 0, 8, 9, 14, 1, 3, 6, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
+	"prevent": 1,  // number of preventive defences
+	"amount": {  // income bound factor
+		"offset": [-0.15, 0.4],
+		// Amount factor: 4x4 ~ 1.85, 20x20 ~ 1.45
+		"factor": [1.55, 1.30],
+		"map": [4, 20]
+	},
+
+
+	// Base defence and time to build it, in seconds
+	"base": [[0, 10], [1, 300], [0, 310], [1, 400], [6, 450], [0, 500], [16, 600], [5, 660], [1, 990], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [15, 1850]],
+
+	"superweapon": {
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "mahlazer", "staticantinuke"],  // FIXME: last aren't superweapon
+		"weight": [ 0.10,         0.20,        0.20,              0.10,     0.10,    0.10],
+
+		"condition": [16, 20000]  // [<Minimum income>, <maximum seconds to build>]
+	},
+
+	// Fallback defence
+	"default": "turretmissile"
+},
+
+// Actions on building finished event
+"build_chain": {
+	// WARNING: Avoid recursion
+	// <category>: factory, nano, store, pylon, energy, defence, bunker, big_gun, radar, sonar, mex, repair
+	"energy": {
+		// <UnitDef>: {<elements>}
+		"energysingu": {
+			// Available elements:
+			// "energy": [max energy income, <"mex"|true>]
+			// "pylon": <boolean>
+			// "porc": <boolean>
+			// "terra": <boolean>
+			// "hub": [
+			//     // chain1
+			//     [{<unit1>, <category>, <offset>, <condition>}, {<unit2>, <category>, <offset>, <condition>}, ...],
+			//     // chain2
+			//     [{...}, {...}, ...],
+			//     ...
+			// ]
+			// <unit>: UnitDef
+			// <offset>:
+			//     1) [x, z] in South facing, elmos
+			//     2) {<direction>: <delta>} - left, right, front, back
+			// <condition>: air, no_air, maybe
+
+			// Build pylon in direction of nearby mex cluster
+//			"pylon": true,
+
+			// Build chain of units
+			"hub": [
+				[  // chain1
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				],
+				[  // chain2
+					{"unit": "turretlaser", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 80}},
+					{"unit": "turretmissile", "category": "defence", "offset": [70, -70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				]
+			]
+		},
+		"energyfusion": {
+//			"pylon": true,
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, 80]}
+				]]
+		}
+	},
+	"factory": {
+		"factoryplane": {
+			"hub": [[{"unit": "staticrearm", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"factorygunship": {
+			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"striderhub": {
+			"pylon": true
+		}
+	},
+	"mex": {
+		"staticmex": {
+//			"terra": true,
+			"energy": [20, "mex"],
+			"porc": true
+		}
+	},
+	"big_gun": {
+		"staticheavyarty": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"raveparty": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"mahlazer": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"zenith": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticheavyradar": {
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]}
+				]]
+		},
+		"staticnuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"energypylon": {
+			"hub": [[
+					{"unit": "turretmissile", "category": "radar", "offset": {"back": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": {"left": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": {"back": -100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]}
+				]]
+		},
+		"turretaaheavy": {
+			"pylon": true,
+			"hub": [
+					[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		}
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/commander.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/commander.json
@@ -1,0 +1,383 @@
+// Mono-space font required
+{
+"commander": {
+	"prefix": "dyntrainer_",
+	"suffix": "_base",
+	"unit": {
+		"support": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["builder", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "builder", "scout", "skirmish", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["scout", "builder", "scout", "riot", "raider", "raider", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.9, ["builder", "raider", "scout", "raider", "raider", "scout", "raider", "raider", "scout", "builder"]],
+						[0.1, ["builder", "raider", "raider", "scout",  "skirmish", "builder", "skirmish", "scout"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "riot"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "scout", "scout", "raider", "raider", "builder", "builder"]],
+						[0.5, ["builder", "scout", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout","builder", "scout", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["riot", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[13, 42],  // shotgun
+					[31, 42],  // Cloak, Nano
+					[15, 41, 37],  // sniper, range, health
+					[34, 34, 34],  // companion drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 34],  // battle drones, companion drones
+					[34, 34, 34],  // companion drones
+					[34, 40, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 36, 36],  // health, regen
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 27, 29],  // nano, disruptor ammo, jammer
+					[32, 33, 30],  // area cloak, lazarus, radar
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 38, 38],  // range, high density
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39]  // damage
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 360,  // seconds
+				"threat": 30,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"recon": {
+			// Choice importance, 0 by default
+			"importance": 0.65,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["builder", "raider", "riot", "raider", "raider", "raider", "raider"]]
+						],
+					"factorygunship": [
+						[0.8, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.2, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.2, ["scout", "scout", "builder", "raider", "raider", "raider", "raider", "scout"]],
+						[0.8, ["builder", "scout",  "raider", "scout", "raider", "raider", "raider", "scout", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider"]],
+						[0.5, ["builder", "raider", "raider", "scout", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider", "raider",  "raider"]],
+						[0.5, ["builder", "scout", "scout", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["builder", "scout", "scout", "raider", "builder", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "scout", "builder", "scout", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 240,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[7, 37],  // Machinegun
+					[31, 36],  // Cloak, Regen
+					[19, 38, 39],  // disruptor bomb, high density, damage boost
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 37, 37],  // speed, health
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, builder
+					[42, 42, 42],  // builder
+					[42, 42, 42],  // builder
+					[30, 27, 29],  // radar, disruptor ammo, jammer
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 41, 39],  // range, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 600,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"assault": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["anti_heavy"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.10, ["scout", "builder", "skirmish", "builder", "riot", "builder", "scout", "scout", "scout", "skirmish", "skirmish", "skirmish"]],
+						[0.15, ["scout", "scout", "builder", "riot", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "skirmish", "builder", "riot"]],
+						[0.75, ["scout", "scout", "raider", "raider", "builder", "builder", "raider", "raider", "raider", "raider", "raider", "builder", "scout"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "raider", "raider", "raider", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "heavy"]],
+						[0.25, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "raider", "raider", "raider", "builder", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "scout", "scout", "scout", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout", "builder", "assault"]],
+						[0.5, ["scout", "scout", "builder", "raider", "scout", "raider", "builder", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[11],  // shotgun
+					[24, 37],  // shield, health
+					[11, 41, 41],  // Double Riot, range
+					[38, 41, 41],  // high density, range
+					[36, 41, 36],  // regen, range, regen
+					[41, 41, 41],  // range
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39, 25],  // damage, area shield
+					[26, 29, 30],  // napalm, jammer, radar
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 36, 36],  // speed, regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 38, 38],  // health, high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 140,  // seconds
+				"threat": 70,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"strike": {
+		   // Choice importance, 0 by default
+			"importance": 0.1,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "scout", "scout", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "scout", "builder", "riot"]],
+						[0.9, ["builder", "scout",  "scout",  "raider", "raider", "raider", "raider", "raider", "builder", "builder", "scout",  "raider", "raider", "raider", "raider", "raider", "builder"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "scout", "scout", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "raider", "raider", "skirmish", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.25, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "assault"]],
+						[0.5, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "scout", "scout", "raider", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 315,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[8, 37],  // beam laser
+					[31, 36],  // cloak, regen
+					[8, 40, 36],  // lightning, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[40, 40, 40],  // speed
+					[28, 29, 30],  // flux, jammer, radar
+					[36, 36, 37],  // regen, health
+					[37, 37, 37],  // health
+					[32, 41, 41],  // area cloak, range
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 42],  // companion drones, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 39, 39],  // nano, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 480,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		}
+	}
+}
+} 

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/economy.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/economy.json
@@ -1,0 +1,69 @@
+// Mono-space font required
+{
+"economy": {
+	// Plain list of energy UnitDef and its limit. AI sorts list by efficiency (inverse)
+	// which is = cost * sizeX * sizeZ / make^2
+	// With ZK v1.8.5.2:
+	//   energysingu = 15.486420
+	//   energygeo = 65.306122
+	//   energyfusion = 80.000000
+	//   energywind = 874.999939
+	//   energysolar = 1750.000000
+	// When e-stalling AI will build bottom-most energy that didn't reach its limit.
+	// On normal AI will select top-most energy that it can build under 40 seconds.
+	"energy": {
+		// If land area >= 40% of the map then "land" config used, "water" otherwise
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>]
+			// limit = random(<lower limit>..<upper limit>)
+			"energysingu": [6],
+			"energygeo": [0, 2],
+			"energyfusion": [6, 10],
+			"energywind": [8, 12],
+			"energysolar": [40]
+		},
+		"water": {
+			"energysingu": [1],
+			"energygeo": [0],
+			"energyfusion": [4],
+			"energywind": [20],
+			"energysolar": [8, 12]
+		},
+		// income factor for energy, time is in seconds
+		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]
+		"factor": [[0.15, 1], [7.0, 3600]],
+
+		"link_inc": 16.0,  // minimum metal-income for energy linking
+		"pylon": ["energypylon", "energysolar", "energywind"]
+	},
+
+	// Scales metal income
+	// ecoFactor = teamSize*eps_step+(1-eps_step)
+	"eps_step": 0.2,
+
+	// Mobile buildpower to metal income ratio
+	"buildpower": 1.2,
+	// Metal excess to income ratio, -1 to disable
+	"excess": -1.0,
+	// Mobile constructor to static constructor metal pull ratio
+	// [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
+//	"ms_pull": [[0.75, 0.0], [0.45, 0.10], [0.53, 0.25], [0.56, 0.40], [0.63, 0.44],[0.52, 0.48],[0.66, 0.52],[0.50, 0.56],[0.66, 0.60], [0.60, 0.65], [0.7, 0.66], [0.8, 0.66], [0.9, 0.75], [0.99, 0.90]],
+	"ms_pull": [[2.0, 0.0], [0.45, 0.20], [0.99, 0.90]],
+	// Max percent of mexes circuit team allowed to take.
+	// If its <1.0 then expansion obeys ms_pull rule, if >=1.0 then ms_pull doesn't affect expansion (mex, pylon, energy).
+	// [<cap_percent>, <is_ally_cap>]
+	"mex_max": [1.0, false],  // 100%
+	// Construction order delay in seconds, -1 to disable
+	"build_delay": [[5, 300], [3, 900]],
+
+	// New factory switch interval, in seconds (each new factory resets timer, switch event is also based on eco + caretakers)
+	// switch = random(<min_interval>..<max_interval>)
+	"switch": [800, 900],
+
+	"terra": "terraunit",
+	"airpad": "staticrearm",
+
+	// Unknown UnitDef replacer
+	"default": "turretmissile"
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/factory.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/factory.json
@@ -1,0 +1,380 @@
+// Mono-space font required
+{
+// Factory selection parameters
+"select": {
+	"air_map": 80,
+	"offset": [-20, 20],
+	// Speed factor: 8x8 ~ 0%, 24x24 ~ 40%
+	"speed": [0, 40],
+	"map": [8, 24],
+	"no_air": 3
+},
+
+// Utility param: warning on unit's total probability not equal to 100%
+"warn_probability": true,
+
+// Define factories
+"factory": {
+	"factorycloak": {
+		// Adjusts the priority of factory choice (factories with map_percent < 20 are ignored)
+		// map_percent is [20..100]
+		// On start:
+		//   if factory has available builder in current frame: priority ~= map_percent * importance0 + random(-20..+20)
+		//   if factory's builder unavailable in current frame: priority ~= map_percent * importance0 / 10 + random(-20..+20)
+		// During game: priority ~= map_percent * importance1 + random(-20..+20)
+		// importanceN = 1.0 by default if not set
+		"importance": [0.78, 0.2],
+
+		// 'require_energy' adds energy requirement for tierN (N>0): fallback to lowest tier on low energy
+		"require_energy": true,
+
+		// If income*ecoFactor < income_tier[N] then 'tierN' probability will be used
+		"income_tier": [20, 30, 40],
+
+		//             conjurer,   glaive,      scythe,           rocko,        warrior,     zeus,           hammer,      sniper,       tick,        eraser,        gremlin
+		"unit":      ["cloakcon", "cloakraid", "cloakheavyraid", "cloakskirm", "cloakriot", "cloakassault", "cloakarty", "cloaksnipe", "cloakbomb", "cloakjammer", "cloakaa"],
+
+		"land": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.03,             0.30,         0.03,        0.00,           0.00,        0.00,         0.00,        0.00,          0.00],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.20,       0.10,        0.06,             0.51,         0.10,        0.00,           0.00,        0.03,         0.00,        0.00,          0.00],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.25,       0.01,        0.20,             0.20,         0.03,        0.00,           0.00,        0.20,         0.00,        0.11,          0.00]
+
+			// 25-32m Expansions meet - Economy can afford to begin producing in bulk so unit compositions alter.
+	//		"tier3": [ 0.10,       0.40,        0.05,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 33m -40m Solid Fronts - Now we stop raiding and start pushing.
+	//		"tier4": [ 0.10,       0.35,        0.10,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 41m - 56m Mid Game - we must have 2 facs by now, stop making balanced compositions and start being abusive.
+	//		"tier5": [ 0.10,       0.05,        0.25,             0.10,         0.00,        0.20,           0.10,        0.00,         0.00,        0.10,          0.00],
+
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+	//		"tier6": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00],
+
+			// 72m - inf+ Late late Game - This fac sucks!
+	//		"tier7": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00]
+		},
+		"air": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.26,             0.00,         0.00,        0.00,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.10,       0.25,        0.11,             0.38,         0.00,        0.06,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.20,       0.10,        0.10,             0.33,         0.00,        0.12,           0.00,        0.00,         0.00,        0.05,          0.10]
+		},
+		"caretaker": 6
+	},
+
+	"factorygunship": {
+		"importance": [15.0, 1.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 85],
+		//             wasp,         blastwing,     gnat,         banshee,       rapier,         brawler,             blackdawn,        krow,          valkyrie,       vindicator,          trident
+		"unit":      ["gunshipcon", "gunshipbomb", "gunshipemp", "gunshipraid", "gunshipskirm", "gunshipheavyskirm", "gunshipassault", "gunshipkrow", "gunshiptrans", "gunshipheavytrans", "gunshipaa"],
+		"land": {
+			// 0-8m Opening - Blastwing and banshee Harass
+			"tier0": [ 0.00,         0.00,          0.00,         0.00,          0.98,           0.00,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 9-16m Early Game - Banshee with a chance of Blackdawn
+			"tier1": [ 0.00,         0.20,          0.00,         0.02,          0.45,           0.31,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 17-24m Expanding - Time to start a-makin Brawlers
+			"tier2": [ 0.00,         0.02,          0.00,         0.00,          0.04,           0.90,                0.04,             0.00,          0.00,           0.00,                0.00],
+			// 25-32m Expansions meet - Time to keep a-makin Brawlers
+			"tier3": [ 0.00,         0.05,          0.00,         0.00,          0.04,           0.83,                0.08,             0.00,          0.00,           0.00,                0.00],
+			// 33m -40m Solid Fronts - Brawlers with a chance of Krow
+			"tier4": [ 0.00,         0.04,          0.00,         0.00,          0.05,           0.80,                0.10,             0.01,          0.00,           0.00,                0.00],
+			// 41m - 56m Mid Game - Brawlers with a bigger chance of Krow
+			"tier5": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.87,                0.06,             0.02,          0.00,           0.00,                0.00],
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+			"tier6": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.84,                0.07,             0.04,          0.00,           0.00,                0.00],
+			// 72m - inf+ Late late Game - Spam Krows!
+			"tier7": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.90,                0.00,             0.05,          0.00,           0.00,                0.00]
+		},
+		"caretaker": 6
+	},
+
+	"factoryamph": {
+		"importance": [0.85, 1.0],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             conch,     duck,       archer,        buoy,          scallop,    grizzly,       djinn,      angler
+		"unit":      ["amphcon", "amphraid", "amphimpulse", "amphfloater", "amphriot", "amphassault", "amphtele", "amphaa"],
+		"land": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.53,       0.25,          0.20,          0.02,       0.00,          0.00,       0.00],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.16,          0.47,          0.22,       0.00,          0.00,       0.00],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.10,       0.09,          0.51,          0.15,       0.05,          0.00,       0.00],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.47,          0.12,       0.13,          0.00,       0.00],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.16,      0.11,       0.02,          0.52,          0.04,       0.15,          0.00,       0.00],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.20,      0.10,       0.02,          0.49,          0.02,       0.17,          0.00,       0.00],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.48,          0.02,       0.18,          0.00,       0.00],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.46,          0.02,       0.22,          0.00,       0.00]
+		},
+		"air": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.58,       0.25,          0.10,          0.02,       0.00,          0.00,       0.05],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.11,          0.47,          0.22,       0.00,          0.00,       0.05],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.11,       0.04,          0.53,          0.12,       0.05,          0.00,       0.05],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.42,          0.12,       0.13,          0.00,       0.05],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.15,      0.10,       0.02,          0.49,          0.04,       0.15,          0.00,       0.05],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.16,      0.13,       0.02,          0.45,          0.02,       0.17,          0.00,       0.05],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.43,          0.02,       0.18,          0.00,       0.05],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.41,          0.02,       0.22,          0.00,       0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryspider": {
+		"importance": [0.71, 0.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             weaver,      flea,          hermit,          venom,       redback,      recluse,       crabe,         infiltrator,       tarantula
+		"unit":      ["spidercon", "spiderscout", "spiderassault", "spideremp", "spiderriot", "spiderskirm", "spidercrabe", "spiderantiheavy", "spideraa"],
+		"land": {
+			// 0-12m Opening - Opening turbo Flea spam & Riots
+			"tier0": [ 0.00,        0.73,          0.00,            0.22,        0.05,         0.00,          0.00,          0.00,              0.00],
+			// 13-18m Early Game - Reducing Flea spam, still mostly Riots
+			"tier1": [ 0.00,        0.59,          0.00,            0.05,        0.05,         0.31,          0.00,          0.00,              0.00],
+			// 17-24m Expanding - Slant production towards Hermit & Redback
+			"tier2": [ 0.06,        0.48,          0.04,            0.05,        0.00,         0.35,          0.02,          0.00,              0.00],
+			// 25-32m Expansions meet - Slant production towards Hermit & Recluse
+			"tier3": [ 0.08,        0.45,          0.06,            0.03,        0.00,         0.33,          0.05,          0.00,              0.00],
+			// 33m -40m Solid Fronts - 	Greater Emphasis on Hermit & Crabbe
+			"tier4": [ 0.08,        0.40,          0.09,            0.03,        0.00,         0.32,          0.08,          0.00,              0.00],
+			// 41m - 56m Mid Game - We need more Crabbes
+			"tier5": [ 0.08,        0.42,          0.07,            0.02,        0.00,         0.31,          0.10,          0.00,              0.00],
+			// 57m - 72m Late Game -  MORE CRABBES
+			"tier6": [ 0.09,        0.40,          0.11,            0.00,        0.00,         0.29,          0.11,          0.00,              0.00],
+			// 72m - inf+ Late late Game - TURBO CRABBES
+			"tier7": [ 0.10,        0.35,          0.20,            0.00,        0.00,         0.22,          0.13,          0.00,              0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryveh": {
+		"importance": [0.95, 0.2],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             mason,    dart,       scorcher,  slasher,      leveler,   ravager,      dominatrix,   wolverine, impaler,        crasher
+		"unit":      ["vehcon", "vehscout", "vehraid", "vehsupport", "vehriot", "vehassault", "vehcapture", "veharty", "vehheavyarty", "vehaa"],
+		"land": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.12,       0.00,      0.00,         0.20,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.20,      0.60,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.59,         0.01,         0.00,      0.04,           0.00],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.10,       0.00,      0.00,         0.10,      0.56,         0.02,         0.00,      0.07,           0.00],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.10,       0.00,      0.00,         0.06,      0.57,         0.05,         0.00,      0.07,           0.00]
+		},
+		"air": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.10,       0.00,      0.00,         0.22,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.15,      0.65,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.05,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.05],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.56,         0.02,         0.00,      0.03,           0.05],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.56,         0.01,         0.00,      0.04,           0.03],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.15,       0.00,      0.00,         0.10,      0.46,         0.02,         0.00,      0.07,           0.05],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.05,       0.00,      0.00,         0.16,      0.47,         0.05,         0.00,      0.07,           0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryhover": {
+		"importance": [1.00, 1.1],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             quill,      dagger,      scalpel,      halberd,        claymore,           mace,        penetrator,  flail,        bolas
+		"unit":      ["hovercon", "hoverraid", "hoverskirm", "hoverassault", "hoverdepthcharge", "hoverriot", "hoverarty", "hoveraa", "hoverheavyraid"],
+		"land": {
+			// 0-8m Opening - Raiders and Riots
+			"tier0": [ 0.00,       0.55,        0.10,         0.00,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 9-16m Early Game - Mostly Mace, some support
+			"tier1": [ 0.00,       0.10,        0.44,         0.11,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 17-24m Expanding - MAXIMUM OP Scalpel time
+			"tier2": [ 0.05,       0.10,        0.43,         0.20,           0.00,               0.14,        0.08,        0.00,        0.00],
+			// 25-32m Expansions meet - Mix in some Halberds
+			"tier3": [ 0.15,       0.10,        0.26,         0.20,           0.01,               0.16,        0.12,        0.00,        0.00],
+			// 33m -40m Solid Fronts - 	More Halberd and Pene
+			"tier4": [ 0.17,       0.13,        0.19,         0.31,           0.01,               0.05,        0.14,        0.00,        0.00],
+			// 41m - 56m Mid Game - Even more Halberd and Pene
+			"tier5": [ 0.17,       0.11,        0.17,         0.30,           0.01,               0.05,        0.19,        0.00,        0.00],
+			// 57m - 72m Late Game - More Pene
+			"tier6": [ 0.20,       0.04,        0.10,         0.34,           0.01,               0.10,        0.21,        0.00,        0.00],
+			// 72m - inf+ Late late Game - MAXIMUM PENE
+			"tier7": [ 0.25,       0.02,        0.07,         0.21,           0.00,               0.10,        0.35,        0.00,        0.00]
+		},
+		"water": {
+			// 33m -40m
+			"tier4": [ 0.00,       0.49,        0.10,         0.20,           0.10,               0.10,        0.01,        0.00],
+			// 41m - inf+4
+			"tier5": [ 0.00,       0.24,        0.05,         0.41,           0.20,               0.05,        0.05,        0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryplane": {
+		"importance": [12.0, 12.1],
+		"require_energy": false,
+
+		"income_tier": [30, 60],
+		//             crane,      swift,          hawk,                raven,        phoenix,      thunderbird,    wyvern,        vulture
+		"unit":      ["planecon", "planefighter", "planeheavyfighter", "bomberprec", "bomberriot", "bomberdisarm", "bomberheavy", "planescout"],
+		"air": {
+			// 0-10m Early Game
+			"tier0": [ 0.00,       0.00,           0.75,                0.15,         0.00,         0.00,           0.05,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.00,       0.00,           0.51,                0.00,         0.02,         0.01,           0.24,          0.22]
+		},
+		"land": {
+			// 0-10m Early Game
+			"tier0": [ 0.10,       0.00,           0.00,                0.60,         0.05,         0.00,           0.20,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.10,       0.00,           0.00,                0.05,         0.00,         0.00,           0.40,          0.45]
+		},
+		"caretaker": 6
+	},
+
+	"factorytank": {
+		"importance": [0.9, 1.5],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             welder,    kodachi,    panther,         banisher,   reaper,        goliath,            pillager,   tremor,          copperhead
+		"unit":      ["tankcon", "tankraid", "tankheavyraid", "tankriot", "tankassault", "tankheavyassault", "tankarty", "tankheavyarty", "tankaa"],
+		"land": {
+			// 0-8m Opening - Koda and Banisher
+			"tier0": [ 0.10,      0.60,       0.10,            0.20,       0.00,          0.00,               0.00,       0.00,            0.00],
+			// 9-16m Early Game - Mostly Banisher
+			"tier1": [ 0.10,      0.15,       0.10,            0.23,       0.42,          0.00,               0.00,       0.00,            0.00],
+			// 17-24m Expanding - Begin mixing in Reapers!
+			"tier2": [ 0.30,      0.13,       0.07,            0.16,       0.34,          0.00,               0.00,       0.00,            0.00],
+			// 25-32m Expansions meet - More Reapers!
+			"tier3": [ 0.46,      0.15,       0.03,            0.04,       0.32,          0.00,               0.00,       0.00,            0.00],
+			// 33m -40m Solid Fronts - 	MAXIMUM REAPERS
+			"tier4": [ 0.45,      0.14,       0.00,            0.02,       0.37,          0.02,               0.00,       0.00,            0.00],
+			// 41m - 56m Mid Game - More arty & Golly
+			"tier5": [ 0.46,      0.16,       0.00,            0.02,       0.32,          0.04,               0.00,       0.00,            0.00],
+			// 57m - 72m Late Game - Even more arty & Golly
+			"tier6": [ 0.40,      0.13,       0.00,            0.02,       0.34,          0.11,               0.00,       0.00,            0.00],
+			// 72m - inf+ Late late Game - MAXIMUM GOLLY
+			"tier7": [ 0.42,      0.08,       0.00,            0.02,       0.32,          0.16,               0.00,       0.00,            0.00]
+		},
+
+		"caretaker": 15
+	},
+
+	"factoryjump": {
+		"importance": [0.73, 1.1],
+		"require_energy": false,
+
+		"income_tier": [20, 40, 60, 80],
+		//             freaker,   puppy,       pyro,       placeholder,     moderator,   jack,          sumo,       firewalker, skuttle,    archangel
+		"unit":      ["jumpcon", "jumpscout", "jumpraid", "jumpblackhole", "jumpskirm", "jumpassault", "jumpsumo", "jumparty", "jumpbomb", "jumpaa"],
+		"land": {
+			"tier0": [ 0.05,      0.24,        0.50,       0.00,            0.15,        0.06,          0.00,       0.00,       0.00,       0.00],
+			"tier1": [ 0.10,      0.20,        0.20,       0.10,            0.16,        0.24,          0.00,       0.00,       0.00,       0.00],
+			"tier2": [ 0.20,      0.20,        0.00,       0.15,            0.04,        0.31,          0.00,       0.10,       0.00,       0.00],
+			"tier3": [ 0.25,      0.15,        0.00,       0.15,            0.00,        0.33,          0.00,       0.12,       0.00,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryshield": {
+		"importance": [0.88, 0.6],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 48, 66],
+		//             convict,     dirtbag,       bandit,       rogue,         thug,            outlaw,       felon,         racketeer,    roach,        aspis,          vandal
+		"unit":      ["shieldcon", "shieldscout", "shieldraid", "shieldskirm", "shieldassault", "shieldriot", "shieldfelon", "shieldarty", "shieldbomb", "shieldshield", "shieldaa"],
+		"land": {
+			"tier0": [ 0.05,        0.05,          0.70,         0.00,          0.20,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier1": [ 0.08,        0.01,          0.10,         0.24,          0.57,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier2": [ 0.12,        0.03,          0.00,         0.20,          0.54,            0.00,         0.05,          0.00,         0.00,         0.06,           0.00],
+			"tier3": [ 0.15,        0.07,          0.00,         0.00,          0.62,            0.00,         0.08,          0.00,         0.00,         0.08,           0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryship": {
+		"importance": [5.5, 5.5],
+		"require_energy": false,
+
+		"income_tier": [30],
+		//             mariner    cutter,      hunter,           seawolf,     corsair,    mistral,     siren,         ronin,      zephyr
+		"unit":      ["shipcon", "shipscout", "shiptorpraider", "subraider", "shipriot", "shipskirm", "shipassault", "shiparty", "shipaa"],
+		"water": {
+			"tier0": [ 0.05,      0.15,        0.35,             0.10,        0.10,       0.10,        0.15,          0.00,       0.00],
+			"tier1": [ 0.05,      0.10,        0.20,             0.10,        0.05,       0.10,        0.25,          0.15,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"striderhub": {
+		"importance": [0, 1.5],
+		"require_energy": false,
+
+		"income_tier": [60, 80, 100],
+		//             ultimatum,          scorpion,          dante,          catapult,      funnelweb,          bantha,          detriment,          scylla,          reef,          battleship
+		"unit":      ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"land": {
+			"tier0": [ 0.01,               0.10,              0.81,           0.00,          0.05,               0.03,            0.00,               0.00,            0.00,          0.00],
+			"tier1": [ 0.03,               0.14,              0.22,           0.24,          0.20,               0.16,            0.01,               0.00,            0.00,          0.00],
+			"tier2": [ 0.05,               0.10,              0.16,           0.35,          0.10,               0.21,            0.03,               0.00,            0.00,          0.00],
+			"tier3": [ 0.05,               0.10,              0.01,           0.26,          0.10,               0.35,            0.13,               0.00,            0.00,          0.00]
+		},
+		"water": {
+			"tier1": [ 0.50,               0.00,              0.00,           0.00,          0.00,               0.00,            0.00,               0.00,            0.25,          0.25],
+			"tier2": [ 0.10,               0.00,              0.00,           0.00,          0.00,               0.00,            0.10,               0.00,            0.40,          0.40]
+		},
+
+		"caretaker": 100
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/response.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/response.json
@@ -1,0 +1,136 @@
+// Mono-space font required
+{
+// Build special units when enemy_metal*ratio > response_metal*eps; eps=teamSize*eps_step+(1-eps_step)
+// AA condition for 3v3: (enemy_air_metal*0.67 > (aa_metal+aa_cost)*1.12) and (aa_metal+aa_cost < army_metal*0.5)
+//
+// Probability of UnitDef for AA role depends on income tier: (tierN[UnitDef]+_weight_)*enemy_air_metal/aa_metal*importance
+// armjeth probability for tier 1: (0.00+10.00)*enemy_air_metal*600.0
+"response": {
+	"_weight_": 70.0,  // base weight of response probability, default=0.5
+
+	"assault": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "super", "missileskirm", "turtle"],
+		"ratio":      [ 0.75,   2.0,      0.00,      0.20,        0.00,    0.75,    1.5,            3.0],
+		"importance": [ 15.00,  45.00,    25.00,     75.00,       0.00,    45.00,   125.00,         50.0],
+		"max_percent": 1.00
+	},
+	"skirmish": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "anti_heavy"],
+		"ratio":      [ 1.50,   0.75,     1.00,      0.00,        0.00,    0.00],
+		"importance": [ 35.00,  25.00,    25.00,     75.00,       0.00,    0.00],
+		"max_percent": 1.00
+	},
+	"raider": {
+		"vs":         ["anti_air", "scout", "raider", "anti_heavy", "mine", "skirmish", "artillery"],
+		"ratio":      [ 0.00,       1.00,    1.0,      0.10,         0.35,   0.40,       0.8],
+		"importance": [ 15.00,      75.00,   75.00,    15.00,        60.00,  45.00,      10.00],
+		"max_percent": 1.00,
+		"eps_step": 0.75
+	},
+	"riot": {
+		"vs":         ["raider", "scout", "commander", "bullshit_raider"],
+		"ratio":      [ 0.8,      0.8,     0.33,        1.5],
+		"importance": [ 100.00,   100.00,  75.00,       125.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"missileskirm": {
+		"vs":         ["raider", "scout", "riot"],
+		"ratio":      [ 0.25,     0.5,     0.25],
+		"importance": [ 35.00,    50.00,   35.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"transport": {
+		"vs":         ["super", "support", "shieldball"],
+		"ratio":      [ 0.75,    0.75,      0.75],
+		"importance": [ 50.00,   50.00,     50.00],
+		"max_percent": 0.30,
+		"eps_step": 0.015
+	},
+	"scout": {
+		"vs":         ["mine", "artillery", "anti_air", "scout", "static", "heavy", "anti_heavy", "cloaked_raider"],
+		"ratio":      [ 0.35,   0.05,        0.10,       1.00,    0.00,     0.00,    0.05,         0.5],
+		"importance": [ 60.00,  60.0,        60.0,       35.00,   0.00,     0.00,    10.00,        100.00],
+		"max_percent": 0.09,
+		"eps_step": 0.025
+	},
+	"artillery": {
+		"vs":         ["static", "artillery", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.66,     0.00,        0.66,    0.25,         3.0],
+		"importance": [ 20.00,    0.00,        40.00,   40.00,        40.0],
+		"max_percent": 0.66,
+		"eps_step": 0.02
+	},
+	"anti_air": {
+		"vs":         ["air"],
+		"ratio":      [ 0.8],
+		"importance": [ 75.0],
+		"max_percent": 0.4,
+		"eps_step": 0.75
+	},
+	"anti_sub": {
+		"vs":         ["sub"],
+		"ratio":      [ 0.0],
+		"importance": [ 0.0],
+		"max_percent": 0.00,
+		"eps_step": 0.0
+	},
+	"anti_heavy": {
+		"vs":         ["heavy", "artillery", "support", "anti_heavy", "commander", "super", "turtle"],
+		"ratio":      [ 0.45,    0.00,        0.00,      0.00,         0.4,         0.50,    3.00],
+		"importance": [ 85.00,   0.00,        0.00,      0.00,         50.00,       85.0,    50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"disarm_target": {
+		"vs":         ["disarm_target"],
+		"ratio":      [ 0.50],
+		"importance": [ 100.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"snipe_target": {
+		"vs":         ["snipe_target", "commander"],
+		"ratio":      [ 1.00,           0.20],
+		"importance": [ 100.00,         50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"cloaked_raider": {
+		"vs":         ["snipe_target", "commander", "transport"],
+		"ratio":      [ 0.50,           0.20,        2.00],
+		"importance": [ 35.00,          35.00,       125.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"heavy": {
+		"vs":         ["heavy", "static", "support", "skirmish", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.75,    0.5,      0.00,      0.75,       0.75,    0.75,         3.00],
+		"importance": [ 75.00,   15.00,    0.00,      15.00,      75.00,   75.00,        75.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"bomber": {
+		"vs":         ["shieldball", "anti_heavy", "artillery", "super"],
+		"ratio":      [ 0.50,         0.50,         0.50,        0.50],
+		"importance": [ 0.50,         50.00,        50.00,       50.00],
+		"max_percent": 1.0,
+		"eps_step": 0.00
+	},
+	"super": {
+		"vs":         ["heavy", "static", "support", "skirmish", "artillery", "super", "turtle"],
+		"ratio":      [ 0.3,     0.55,     0.00,      0.00,       0.00,        0.00,    0.5],
+		"importance": [ 45.00,   25.00,    0.00,      0.00,       0.00,        0.00,    45.00],
+		"max_percent": 0.2,
+		"eps_step": 0.00
+	},
+	"support": {
+		"vs":         ["assault", "bullshit_raider"],
+		"ratio":      [ 1.00,      0.4],
+		"importance": [ 35.00,     75.00],
+		"max_percent": 0.25,
+		"eps_step": 0.00
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/behaviour.json
@@ -1,0 +1,1122 @@
+// Mono-space font required
+{
+"quota": {
+	"scout": 1,  // max scout units out of raiders
+	"raid": [7.0, 42.0],  // [<min>, <avg>] power of raider squad
+	"attack": 20.0,  // min power of attack group
+	"thr_mod": {
+		"attack": [0.45, 0.45],  // [<min>, <max>] enemy threat modifier for target selection of attack task
+		"defence": [0.80, 0.80],  // [<min>, <max>] enemy threat modifier for group size calculation of defence task
+		"mobile": 1.075,  // initial modifier for power of attack group based on mobile enemy threat
+		"static": 4.25,  // initial modifier for power of attack group based on static enemy threat
+		"comm": 0.75
+	},
+	"aa_threat": 80.0,  // anti-air threat threshold, air factories will stop production when AA threat exceeds
+	"slack_mod": {
+		"all": 0.5,  // threat map 64-elmos slack multiplier for all units
+		"static": 1.5,  // additional 64-elmo-cells for static units
+		"speed": [0.75, 4.0]  // [<64elmo_cells_speed_mod>, <max_64elmo_cells>]
+	}
+},
+
+// If unit's health drops below specified percent it will retreat
+"retreat": {
+	"builder": [0.70, 1.0],  // [<default>, <UnitDef modifier>] for all builders
+	"fighter": [0.45, 1.0],  // [<default>, <UnitDef modifier>] for all not-builder units
+	"shield": [0.25, 0.275]  // [<empty>, <full>] shield power
+},
+
+"defence": {
+	"infl_rad": 7,  // influenece cell radius for defendAlly map
+	"base_rad": [1000.0, 2000.0],  // defend if enemy within clamp(distance(lane_pos, base_pos), 1000, 2000) radius
+	"comm_rad": [1000.0, 500.0]  // 0 distance from base ~ 1000, base_rad ~ 500.0
+},
+
+
+"behaviour": {
+	// factorycloak
+	"cloakcon": {
+		// "role": [<main>, <enemy>, <enemy>, ...]
+		// <main> is the role to make desicions of when to build it and what task to assign
+		// <enemy> is to decide how to counter enemy unit, if missing then equals to <main>
+		// Roles: builder, scout, raider, riot, assault, skirmish, artillery, anti_air, anti_sub, anti_heavy, bomber, support, mine, transport, air, sub, static, heavy, super, commander
+		// Auto-assigned roles: builder, air, static, super, commander
+		"role": ["builder", "mine"]
+
+		// Attributes - optinal states
+		// "melee" - always move close to target, disregard attack range
+		// "boost" - boost speed on retreat
+		// "no_jump" - disable jump on retreat
+		// "no_strafe" - disable gunship's strafe
+		// "stockpile" - load weapon before any task, auto-assigned
+		// "siege" - mostly use fight command instead of move
+		// "ret_hold" - hold fire on retreat
+		// "ret_fight" - fight on retreat
+		// "jump" - enable jump on regular move
+		// "dg_cost" - DGun by metal cost instead of by threat
+		// "anti_stat" - only static targets
+		// "no_dgun" - do not use DGun
+//		"attribute": ["boost", "no_strafe"],
+
+		// Fire state (open by default)
+		// "hold" - hold fire
+		// "return" - return fire
+		// "open" - fire at will
+//		"fire_state": "open",
+
+		// Overrides reloadTime in seconds
+//		"reload": 1.0,
+
+		// Limits number of units
+//		"limit": 10,
+
+		// Unit can be built only since specific time in seconds
+//		"since": 60,
+
+		// Minimum hp percent before retreat
+//		"retreat": 0.8,
+
+		// Ally threat multiplier
+//		"pwr_mod": 1.0,
+		// Enemy threat multiplier
+//		"thr_mod": 1.0,
+
+		// Ignore enemy
+//		"ignore": false
+	},
+	"cloakraid": {
+		"role": ["raider", "scout"],
+		"attribute": ["scout"],
+		"retreat": 0.1,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.75
+	},
+	"cloakheavyraid": {
+		"role": ["cloaked_raider", "raider"],
+		"attribute": ["ret_fight"],
+		"since": 180,
+		"limit": 3,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.1,
+		"retreat": 0.4
+	},
+	"cloakskirm": {
+		"role": ["skirmish"],
+		"attribute": ["ret_fight"],
+		"pwr_mod": 0.85,
+		"since": 180,
+		"limit": 20,
+		"retreat": 0.35  // mostly disposable
+	},
+	"cloakriot": {
+		"role": ["riot", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"since": 180,
+		"retreat": 0.55,
+		"pwr_mod": 1.4,
+		"thr_mod": 2.3
+	},
+	"cloakassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.35,  // assaults need to assault
+		"since": 240,
+		"pwr_mod": 0.7,
+		"thr_mod": 1.1
+	},
+	"cloakarty": {
+		"role": ["artillery"],
+		"since": 550,
+		"limit": 8,
+		"retreat": 0.9,
+		"thr_mod": 0.0
+	},
+	"cloaksnipe": {
+		"role": ["snipe_target"],
+		"attribute": ["support"],
+		"pwr_mod": 3.0,
+		"since": 520,
+		"thr_mod": 0.0,
+		"retreat": 0.69
+	},
+	"cloakbomb": {
+		"role": ["mine"],
+		"retreat": 0.01
+	},
+	"cloakjammer": {
+		"role": ["assault"],
+		"since": 480,
+		"retreat": 0.5,
+		"limit": 1
+	},
+	"cloakaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factorygunship
+	"gunshipcon": {
+		"role": ["builder", "air"],
+		"limit": 2,
+		"since": 240,
+		"retreat": 0.99
+	},
+	"gunshipbomb": {
+		"role": ["bomber", "air"],
+		"attribute": ["melee"],
+		"limit": 1,
+		"thr_mod": 1.0,
+		"retreat": 0.01
+	},
+	"gunshipemp": {
+		"role": ["anti_heavy", "air"],
+		"thr_mod": 0.1,
+		"pwr_mod": 0.1,
+		"since": 600,
+		"limit": 6,
+		"retreat": 0.9
+	},
+	"gunshipskirm": {
+		"role": ["air", "bullshit_raider"],
+		"retreat": 0.65,
+		"pwr_mod": 0.7,
+		"limit": 8,
+		"thr_mod": 0.66
+	},
+	"gunshipraid": {
+		"role": ["scout", "air"],
+		"retreat": 0.7,
+		"limit": 1,
+		"pwr_mod": 1.25,
+		"thr_mod": 1.1
+	},
+	"gunshipheavyskirm": {
+		"role": ["assault", "air"],
+		"since": 330,
+		"attribute": ["no_strafe"],
+		"retreat": 0.65,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.00
+	},
+	"gunshipassault": {
+		"role": ["anti_heavy", "air"],
+		"limit": 3,
+		"since": 330,
+		"retreat": 0.5,
+		"pwr_mod": 1.65,
+		"thr_mod": 1.00
+	},
+	"gunshipkrow": {
+		"role": ["anti_heavy", "air", "disarm_target"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"since": 720,
+		"pwr_mod": 0.3,
+		"thr_mod": 0.3,
+		"limit": 0
+	},
+	"gunshiptrans": {
+		"role": ["air"],
+		"limit": 0
+	},
+	"gunshipheavytrans": {
+		"role": ["air"],
+		"limit": 0,
+		"thr_mod": 0.0
+	},
+	"gunshipaa": {
+		"role": ["anti_air", "air"],
+		"limit": 6,
+		"retreat": 0.95,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryamph
+	"amphcon": {
+		"role": ["builder", "mine"]
+	},
+	"amphraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"limit": 10,
+		"retreat": 0.25  // pretty disposable
+	},
+	"amphimpulse": {
+		"role": ["riot"],
+		"limit": 1,
+		"retreat": 0.36,
+		"pwr_mod": 2.25,
+		"thr_mod": 2.25
+	},
+	"amphfloater": {
+		"role": ["assault", "snipe_target", "super"],
+		"limit": 14,
+		"since": 120,
+		"retreat": 0.25, // too slow to be retreating all the time
+		"pwr_mod": 1.3,
+		"thr_mod": 1.3
+	},
+	"amphriot": {
+		"role": ["riot"],
+		"attribute": ["melee", "ret_fight"],
+		"pwr_mod": 1.5,
+		"retreat": 0.35 // too slow to be retreating all the time
+	},
+	"amphassault": {
+		"role": ["heavy", "disarm_target"],
+		"retreat": 0.66,
+		"since": 520,
+		"pwr_mod": 1.4,
+		"thr_mod": 1.0
+	},
+	"amphtele": {
+		"role": ["transport"],
+		"limit": 0
+	},
+	"amphaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight", "support"],
+		"retreat": 0.3,
+		"limit": 5,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.5
+	},
+
+	// factoryspider
+	"spidercon": {
+		"role": ["builder", "mine"]
+	},
+	"spiderscout": {
+		"role": ["scout", "raider"],
+		"thr_mod": 0.5,
+		"limit": 20,
+		"retreat": 0.01
+	},
+	"spiderassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.15,
+		"retreat": 0.35
+	},
+	"spideremp": {
+		"role": ["raider", "riot"],
+		"pwr_mod": 3.0,
+		"limit": 1,
+		"retreat": 0.5
+	},
+	"spiderriot": {
+		"role": ["riot"],
+		"pwr_mod": 2.0,
+		"limit": 4,
+		"attribute": ["support"],
+		"retreat": 0.35
+	},
+	"spiderskirm": {
+		"role": ["skirmish", "snipe_target", "super"],
+		"pwr_mod": 2.0,
+		"thr_mod": 1.0,
+		"since": 180,
+		"retreat": 0.4
+	},
+	"spidercrabe": {
+		"role": ["heavy", "disarm_target", "turtle"],
+		"attribute": ["siege", "ret_fight", "support"],
+		"retreat": 0.5,
+		"thr_mod": 2.5,
+		"pwr_mod": 2.5,
+		"since": 300,
+		"thr_mod": 1.0
+	},
+	"spiderantiheavy": {
+		"role": ["anti_heavy", "mine"],
+		"retreat": 0.99,
+		"pwr_mod": 2.0,
+		"thr_mod": 0.1,
+		"since": 600,
+		"limit": 1
+	},
+	"spideraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryshield
+	"shieldcon": {
+		"role": ["builder", "shieldball", "mine"],
+		"retreat": 1.3
+	},
+	"shieldscout": {
+		"role": ["transport", "raider"],
+		"limit": 20,
+		"attribute": ["siege", "melee"],
+		"pwr_mod": 0.11,
+		"thr_mod": 0.1,
+		"retreat": 0.0
+	},
+	"shieldraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"retreat": 0.25,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.9
+	},
+	"shieldskirm": {
+		"role": ["skirmish"],
+		"limit": 15,
+		"since": 200,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"retreat": 0.3
+	},
+	"shieldassault": {
+		"role": ["assault", "support", "shieldball"],
+		"attribute": ["melee"],
+		"limit": 20,
+		"retreat": 0.3,
+		"since": 120,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.35
+	},
+	"shieldriot": {
+		"role": ["riot", "shieldball"],
+		"fire_state": "hold",
+		"since": 100,
+		"limit": 5,
+		"retreat": 0.3,
+		"pwr_mod": 1.7,
+		"thr_mod": 1.7
+	},
+	"shieldfelon": {
+		"role": ["heavy", "shieldball", "snipe_target"],
+		"since": 420,
+		"retreat": 0.35,
+		"pwr_mod": 1.1,
+		"thr_mod": 1.1
+	},
+	"shieldarty": {
+		"role": ["disarm_target"],
+		"since": 300,
+		"retreat": 0.3,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"shieldbomb": {
+		"role": ["mine"]
+	},
+	"shieldshield": {
+		"role": ["super", "heavy", "shieldball"],
+		"since": 540,
+		"attribute": ["support"],
+		"retreat": 0.36,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.25
+	},
+	"shieldaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryveh
+	"vehcon": {
+		"role": ["builder", "mine"]
+	},
+	"vehscout": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"thr_mod": 0.6,
+		"pwr_mod": 1.2,
+		"retreat": 0.01,
+		"limit": 4
+	},
+	"vehraid": {
+		"role": ["raider"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.3,
+		"pwr_mod": 1.1,
+		"thr_mod": 0.8
+	},
+	"vehsupport": {
+		"role": ["artillery", "missileskirm"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.4,
+		"retreat": 0.6  // cannot retreat
+	},
+	"vehriot": {
+		"role": ["riot"],
+		"retreat": 0.6,
+		"pwr_mod": 1.5,
+		"thr_mod": 1.5
+	},
+	"vehassault": {
+		"role": ["assault"],
+		"attribute": ["melee"],
+		"retreat": 0.4,  // slow to turn around
+		"since": 180,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9
+	},
+	"vehcapture": {
+		"role": ["support", "disarm_target", "snipe_target"],
+		"since": 180,
+		"pwr_mod": 1,
+		"thr_mod": 1,
+		"retreat": 0.8
+	},
+	"veharty": {
+		"role": ["transport", "super"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 15,
+		"since": 460,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0,
+		"retreat": 0.8
+	},
+	"vehheavyarty": {
+		"role": ["artillery", "heavy", "turtle"],
+		"since": 300,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.00
+	},
+	"vehaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.75,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryjump
+	"jumpcon": {
+		"role": ["builder", "mine"]
+	},
+	"jumpscout": {
+		"role": ["riot", "raider"],
+		"limit": 15,
+		"attribute": ["melee", "siege"],
+		"retreat": 0
+	},
+	"jumpraid": {
+		"role": ["raider", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.4,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.9
+	},
+	"jumpblackhole": {
+		"role": ["support"],
+		"since": 300,
+		"limit": 6,
+		"retreat": 0.36
+	},
+	"jumpskirm": {
+		"role": ["skirmish", "super", "snipe_target"],
+		"retreat": 0.4
+	},
+	"jumpassault": {
+		"role": ["assault", "anti_sub", "disarm_target"],
+		"attribute": ["melee", "siege", "ret_fight"],
+		"retreat": 0.4,
+		"pwr_mod": 1.3,
+		"thr_mod": 0.5
+	},
+	"jumpsumo": {
+		"role": ["heavy", "support", "disarm_target"],
+		"limit": 0,
+		"attribute": ["melee", "no_jump"]  // jump on attack
+	},
+	"jumparty": {
+		"role": ["heavy", "turtle", "snipe_target"],
+		"attribute": ["support"],
+		"since": 600,
+		"pwr_mod": 0.1,
+		"limit": 2,
+		"thr_mod": 0.00,
+		"retreat": 0.99
+	},
+	"jumpbomb": {
+		"role": ["anti_heavy", "builder"],
+		"attribute": ["melee", "mine"],
+		"fire_state": "open",
+		"since": 720,
+		"limit": 2,
+		"retreat": 0.01,
+		"pwr_mod": 3.0,
+		"thr_mod": 0.01
+	},
+	"jumpaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryhover
+	"hovercon": {
+		"role": ["builder", "mine"]
+	},
+	"hoverraid": {
+		"role": ["scout"],
+		"attribute": ["melee"],		
+		"pwr_mod": 0.9,
+		"thr_mod": 0.8,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9,
+		"limit": 4,
+		"retreat": 0.5
+	},
+	"hoverheavyraid": {
+		"role": ["raider", "bullshit_raider"],	
+		"retreat": 0.35,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.8
+	},
+	"hoverskirm": {
+		"role": ["skirmish", "support"],
+		"retreat": 0.55,
+		"limit": 12,
+		"reload": 4.0,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.6
+	},
+	"hoverassault": {
+		"role": ["assault", "raider"],
+		"attribute": ["melee", "ret_hold"],
+		"retreat": 0.4,
+		"limit": 12,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.45
+	},
+	"hoverdepthcharge": {
+		"role": ["anti_sub", "riot"],
+		"attribute": ["melee"],
+		"retreat": 0.6
+	},
+	"hoverriot": {
+		"role": ["riot", "snipe_target"],
+		"retreat": 0.4,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.25
+	},
+	"hoverarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"attribute": ["siege"],
+		"retreat": 0.99,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"hoveraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryplane
+	"planecon": {
+		"role": ["builder", "air"],
+		"since": 240,
+		"limit": 2,
+		"retreat": 0.99
+	},
+	"planefighter": {
+		"role": ["scout", "air"],
+		"attribute": ["boost"],
+		"pwr_mod": 1.5,
+		"limit": 1,
+		"thr_mod": 3.0,
+		"retreat": 0.8
+	},
+	"planeheavyfighter": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"limit": 8,
+		"retreat": 0.4,
+		"pwr_mod": 2.5,
+		"thr_mod": 3.0
+	},
+	"bomberprec": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"attribute": ["siege"],
+		"limit": 10,
+		"retreat": 0.8,
+		"pwr_mod": 0.10,
+		"thr_mod": 0.01
+	},
+	"bomberriot": {
+		"role": ["bomber", "air"],
+		"limit": 0,
+		"retreat": 0.6,
+		"pwr_mod": 0.01,
+		"thr_mod": 0.01
+	},
+	"bomberdisarm": {
+		"role": ["anti_heavy", "air"],
+		"attribute": ["siege", "bomber"],
+		"limit": 2,
+		"since": 1200,
+		"retreat": 0.95,
+		"pwr_mod": 100.00,
+		"thr_mod": 0.01
+	},
+	"bomberheavy": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"fire_state": "return",
+		"limit": 4,
+		"since": 420,
+		"retreat": 0.95,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.1
+	},
+	"bomberassault": {
+		"role": ["bomber", "air"],
+		"attribute": ["anti_stat", "no_dgun"],
+		"fire_state": "hold",
+		"limit": 1,
+		"since": 1800,
+		"retreat": 0.65,
+		"pwr_mod": 1.25,
+		"thr_mod": 0.01
+	},
+	"planescout": {
+		"role": ["scout", "air"],
+		"since": 360,
+		"limit": 2,
+		"retreat": 0.8
+	},
+
+	// factorytank
+	"tankcon": {
+		"role": ["builder"],
+		"pwr_mod": 0.40,
+		"thr_mod": 0.40,
+		"retreat": 0.9
+	},
+	"tankraid": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"limit": 2,
+		"thr_mod": 0.66,
+		"pwr_mod": 0.8,
+		"retreat": 0.45
+	},
+	"tankheavyraid": {
+		"role": ["raider", "bullshit_raider"],
+		"thr_mod": 0.6,
+		"pwr_mod": 0.65,
+		"retreat": 0.65
+	},
+	"tankriot": {
+		"role": ["riot", "heavy", "snipe_target"],
+		"thr_mod": 1.25,
+		"pwr_mod": 0.75,
+		"retreat": 0.55
+	},
+	"tankassault": {
+		"role": ["assault", "heavy", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7
+	},
+	"tankheavyassault": {
+		"role": ["heavy", "disarm_target", "super"],
+		"attribute": ["melee"],
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7,
+		"since": 480,
+		"retreat": 0.55
+	},
+	"tankarty": {
+		"role": ["artillery", "snipe_target", "heavy"],
+		"attribute": ["support"],
+		"since": 1000,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.0
+	},
+	"tankheavyarty": {
+		"role": ["transport"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 1,
+		"retreat": 0.99,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0
+	},
+	"tankaa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryship
+	"shipcon": {
+		"role": ["builder"]
+	},
+	"shipscout": {
+		"role": ["scout"]
+	},
+	"shiptorpraider": {
+		"role": ["raider"]
+	},
+	"subraider": {
+		"role": ["raider"]
+	},
+	"shipriot": {
+		"role": ["riot"]
+	},
+	"shipskirm": {
+		"role": ["skirmish"]
+	},
+	"shipassault": {
+		"role": ["assault"]
+	},
+	"shiparty": {
+		"role": ["artillery"]
+	},
+	"shipaa": {
+		"role": ["anti_air"]
+	},
+
+	// striderhub
+	"striderantiheavy": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"pwr_mod": 0.5,
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.35
+	},
+	"striderscorpion": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"fire_state": "return",
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"since": 1800,
+		"thr_mod": 0.5
+	},
+	"striderdante": {
+		"role": ["heavy", "disarm_target", "snipe_target"],
+		"attribute": ["melee"],
+		"limit": 2,
+		"retreat": 0.45,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.75
+	},
+	"striderarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"pwr_mod": 5.0,
+		"thr_mod": 0.0,
+		"retreat": 0.9
+	},
+	"striderfunnelweb": {
+		"role": ["heavy", "turtle", "shieldball"],
+		"attribute": ["support"],
+		"retreat": 1.4,
+		"pwr_mod": 1.0,
+		"limit": 1,
+		"since": 3000,
+		"thr_mod": 0.0
+	},
+	"striderbantha": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.5
+	},
+	"striderdetriment": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.50,  // deffo retreat, running into nab annihlator farm and sploding is silly :)
+		"pwr_mod": 0.34,
+		"thr_mod": 0.34
+	},
+	"subtacmissile": {
+		"role": ["artillery", "heavy"],
+		"attribute": ["stockpile"]
+	},
+	"shipcarrier": {
+		"role": ["artillery", "heavy"]
+	},
+	"shipheavyarty": {
+		"role": ["artillery", "heavy"]
+	},
+
+	// statics
+	"staticnuke": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 30.0,
+		"limit": 1,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"staticmissilesilo": {
+		"role": ["static", "support", "heavy"],
+		"thr_mod": 0.01
+	},
+	"raveparty": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"zenith": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 105.0,  // 105sec / 0.7sec/met = 150 meteorsControlled
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"mahlazer": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"staticheavyarty": {
+		"role": ["artillery", "turtle", "heavy"],
+		"limit": 5,
+		"thr_mod": 0.0,
+		"pwr_mod": 10.00
+	},
+	"turretheavy": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 1.00
+	},
+	"turretantiheavy": {
+		"role": ["static", "turtle", "static"],
+		"thr_mod": 0.55
+	},
+	"staticarty": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 0.55
+	},
+	"staticantinuke": {
+		"role": ["static", "heavy", "support"],
+		"since": 720,
+		"limit": 1
+	},
+	"turretheavylaser": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.0
+	},
+	"energysingu": {
+		"role": ["static", "turtle", "heavy"],
+		"attribute": ["support"],  // build at home
+		"since": 660
+	},
+	"energyfusion": {
+		"role": ["static", "mine", "heavy"],
+		"attribute": ["support"],  // build at home
+		"since": 280
+	},
+	"turretaalaser": {
+		"role": ["anti_air"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.0
+	},
+	"turretaaheavy": {
+		"role": ["anti_air", "heavy", "turtle"],
+		"limit": 1,
+		"thr_mod": 1.0
+	},
+	"turretlaser": {
+		"role": ["static", "riot", "builder"],
+		"thr_mod": 1.5
+	},
+	"turretmissile": {
+		"role": ["missileskirm", "riot", "builder"],
+		"thr_mod": 0.34
+	},
+	"turretriot": {
+		"role": ["static", "riot", "snipe_target"],
+		"thr_mod": 1.65
+	},
+	"turretaafar": {
+		"role": ["anti_air", "heavy", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaflak": {
+		"role": ["anti_air", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaclose": {
+		"role": ["anti_air"],
+		"thr_mod": 1.0
+	},
+	"turretgauss": {
+		"role": ["static", "turtle", "transport"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.6
+	},
+	"turretemp": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.5
+	},
+
+	// support factories won't be built in front
+	"factoryplane": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"factorygunship": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"striderhub": {
+		"role": ["static"],
+		"since": 900,
+		"attribute": ["support"]
+	},
+
+	// Enemy Eco!! //
+	"staticmex": {
+		"role": ["mine"]
+	},
+	"energywind": {
+		"role": ["mine"]
+	},
+	"staticradar": {
+		"role": ["mine"]
+	},
+	"staticcon": {
+		"role": ["mine"]
+	},
+	"energypylon": {
+		"role": ["mine"],
+		"since": 600
+	},
+	"staticheavyradar": {
+		"role": ["mine", "turtle"],
+		"limit": 1
+	},
+	"staticstorage": {
+		"role": ["mine", "turtle"],
+		"limit": 5
+	},
+	"energysolar": {
+		"role": ["mine"]
+	},
+	"staticshield": {
+		"role": ["static", "turtle"]
+	},
+
+	// Chickens!! //
+	"dronecarry": {
+		"role": ["transport"]
+	},
+	"chicken": {
+		"role": ["raider"]
+	},
+	"chicken_blimpy": {
+		"role": ["mine"]
+	},
+	"chicken_digger": {
+		"role": ["riot"]
+	},
+	"chicken_dodo": {
+		"role": ["mine"]
+	},
+	"chicken_dragon": {
+		"role": ["heavy"],
+		"thr_mod": 0.4
+	},
+	"chicken_drone": {
+		"role": ["raider"]
+	},
+	"chicken_drone_starter": {
+		"role": ["raider"]
+	},
+	"chicken_leaper": {
+		"role": ["raider"]
+	},
+	"chicken_listener": {
+		"role": ["static"]
+	},
+	"chicken_pigeon": {
+		"role": ["air"]
+	},
+	"chicken_roc": {
+		"role": ["air"]
+	},
+	"chicken_shield": {
+		"role": ["support"]
+	},
+	"chicken_spidermonkey": {
+		"role": ["anti_air"]
+	},
+	"chicken_tiamat": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenblobber": {
+		"role": ["artillery"]
+	},
+	"chickenbroodqueen": {
+		"role": ["heavy"],
+		"thr_mod": 0.05
+	},
+	"chickenflyerqueen": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenlandqueen": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenspire": {
+		"role": ["static"]
+	},
+	"chickena": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenc": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickend": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenf": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenr": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenwurm": {
+		"role": ["heavy"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/block_map.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/block_map.json
@@ -1,0 +1,139 @@
+// Mono-space font required
+{
+"building": {
+	"class_land": {
+		"fac_land": {
+			// "type": [<blocker_shape>, <structure_type>]
+			// Available blocker_shape: rectangle, circle.
+			// Available structure_type: factory, mex, engy_low, engy_mid, engy_high, pylon, def_low, def_mid, def_high, special, nano, terra, unknown
+			"type": ["rectangle", "factory"],
+
+			// Unit of measurement: 1 size/yard/radius = SQUARE_SIZE * 2 = 16 elmos, integer.
+			// Offset in South facing
+			"offset": [0, 6],  // default: [0, 0]
+
+			// Size of a blocker without yard
+//			"size": [7, 7],  // default: size of a unit
+
+			// Spacer, blocker_size = size + yard
+			"yard": [12, 12]  // default: [0, 0]
+
+			// "ignore": [<structure_type>, <structure_type>, ...]
+			// Ignore specified structures.
+			// Additional values: none, all
+//			"ignore": ["none"]  // default: ["none"]
+		},
+		"fac_air": {
+			"type": ["rectangle", "factory"],
+			"yard": [8, 8]
+		},
+		"fac_water": {
+			"type": ["rectangle", "factory"],
+			"offset": [0, 4],
+			"yard": [10, 12]
+		},
+		"fac_strider": {
+			"type": ["rectangle", "special"],
+			"offset": [0, 12],
+			"yard": [16, 16]
+		},
+		"solar": {
+			"type": ["circle", "engy_low"],
+			"ignore": ["mex", "engy_mid", "engy_high", "def_low", "pylon", "nano"],
+			"radius": 7
+		},
+		"wind": {
+			"type": ["circle", "engy_low"],
+			// Integer radius of a blocker or description string.
+			// Available string values: explosion, expl_ally
+//			"radius": "explosion",  // default: "explosion"
+			"radius": 4,
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"fusion": {
+			"type": ["circle", "engy_mid"],
+			"ignore": ["mex", "pylon", "def_low"]
+		},
+		"singu": {
+			"type": ["circle", "engy_high"],
+			"radius": "expl_ally",  // [radius ~ 1 player .. radius/2 ~ 4+ players]
+			"ignore": ["mex", "engy_low", "def_low", "pylon", "nano"]
+		},
+		"pylon": {
+			"type": ["circle", "pylon"],
+			"not_ignore": ["factory", "engy_low", "pylon", "terra"]  // default: ["all"]
+		},
+		"store": {
+			"type": ["rectangle", "mex"],
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"mex": {
+			"type": ["rectangle", "mex"],
+			"ignore": ["all"]
+		},
+		"def_low": {
+			"type": ["circle", "def_low"],
+			"radius": 10,  // 160 / (SQUARE_SIZE * 2)
+			"ignore": ["engy_mid", "engy_high", "pylon", "nano"]
+		},
+		"caretaker": {
+			"type": ["rectangle", "nano"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+		"small": {
+			"type": ["rectangle", "unknown"],
+			"not_ignore": ["factory", "def_low", "terra"]
+		},
+		"superweapon": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "pylon", "engy_high"]
+		},
+		"protector": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+//		"terraform": {
+//			"type": ["rectangle", "special"],
+//			"size": [7, 7]  // int2(3 + 4, 3 + 4)
+//		},
+		"strider": {
+			"type": ["rectangle", "special"],
+			"yard": [2, 2],
+			"ignore": ["all"]
+		},
+		"_default_": {
+			"type": ["rectangle", "unknown"],
+			"yard": [4, 4],
+			"ignore": ["pylon", "engy_high"]
+		}
+	},
+	// Water overrides land. Map considered as water if amount of land < 40%
+	"class_water" : {
+		"wind": {
+			"type": ["circle", "engy_low"],
+			"radius": 1,  // default: "explosion"
+			"ignore": ["mex", "engy_mid", "engy_high", "pylon", "nano"]
+		}
+	},
+	"instance": {
+		"fac_land": ["factorycloak", "factoryamph", "factoryhover", "factoryjump", "factoryshield", "factoryspider", "factorytank", "factoryveh"],
+		"fac_air": ["factoryplane", "factorygunship"],
+		"fac_water": ["factoryship"],
+		"fac_strider": ["striderhub"],
+		"solar": ["energysolar"],
+		"wind": ["energywind"],
+		"fusion": ["energyfusion"],
+		"singu": ["energysingu"],
+		"pylon": ["energypylon"],
+		"store": ["staticstorage"],
+		"mex": ["staticmex"],
+		"def_low": ["turretmissile", "turretlaser", "staticarty"],
+		"caretaker": ["staticcon", "staticrearm"],
+		"superweapon": ["raveparty", "staticnuke", "zenith", "turretaaheavy", "staticheavyarty", "staticantinuke", "staticheavyradar"],
+//		"protector": ["staticantinuke"],
+//		"terraform": ["terraunit"],
+		"strider": ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"small": ["staticradar"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/build_chain.json
@@ -1,0 +1,249 @@
+// Mono-space font required
+{
+"porcupine": {
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//        5              6                7             8                 9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10             11               12            13                14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		        16
+		"staticantinuke", "staticheavyradar"
+	],
+	// Actual number of defences per cluster bounded by income
+	"land":  [0, 0, 1, 3, 5, 1, 2, 14, 1, 9, 5, 6, 2, 3, 5, 0, 8, 9, 14, 1, 3, 6, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
+	"prevent": 1,  // number of preventive defences
+	"amount": {  // income bound factor
+		"offset": [-0.15, 0.4],
+		// Amount factor: 4x4 ~ 1.85, 20x20 ~ 1.45
+		"factor": [1.55, 1.30],
+		"map": [4, 20]
+	},
+
+
+	// Base defence and time to build it, in seconds
+	"base": [[0, 10], [1, 300], [0, 310], [1, 400], [6, 450], [0, 500], [16, 600], [5, 660], [1, 990], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [15, 1850]],
+
+	"superweapon": {
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "mahlazer", "staticantinuke"],  // FIXME: last aren't superweapon
+		"weight": [ 0.10,         0.20,        0.20,              0.10,     0.10,    0.10],
+
+		"condition": [16, 20000]  // [<Minimum income>, <maximum seconds to build>]
+	},
+
+	// Fallback defence
+	"default": "turretmissile"
+},
+
+// Actions on building finished event
+"build_chain": {
+	// WARNING: Avoid recursion
+	// <category>: factory, nano, store, pylon, energy, defence, bunker, big_gun, radar, sonar, mex, repair
+	"energy": {
+		// <UnitDef>: {<elements>}
+		"energysingu": {
+			// Available elements:
+			// "energy": [max energy income, <"mex"|true>]
+			// "pylon": <boolean>
+			// "porc": <boolean>
+			// "terra": <boolean>
+			// "hub": [
+			//     // chain1
+			//     [{<unit1>, <category>, <offset>, <condition>}, {<unit2>, <category>, <offset>, <condition>}, ...],
+			//     // chain2
+			//     [{...}, {...}, ...],
+			//     ...
+			// ]
+			// <unit>: UnitDef
+			// <offset>:
+			//     1) [x, z] in South facing, elmos
+			//     2) {<direction>: <delta>} - left, right, front, back
+			// <condition>: air, no_air, maybe
+
+			// Build pylon in direction of nearby mex cluster
+//			"pylon": true,
+
+			// Build chain of units
+			"hub": [
+				[  // chain1
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				],
+				[  // chain2
+					{"unit": "turretlaser", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 80}},
+					{"unit": "turretmissile", "category": "defence", "offset": [70, -70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				]
+			]
+		},
+		"energyfusion": {
+//			"pylon": true,
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, 80]}
+				]]
+		}
+	},
+	"factory": {
+		"factoryplane": {
+			"hub": [[{"unit": "staticrearm", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"factorygunship": {
+			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"striderhub": {
+			"pylon": true
+		}
+	},
+	"mex": {
+		"staticmex": {
+//			"terra": true,
+			"energy": [20, "mex"],
+			"porc": true
+		}
+	},
+	"big_gun": {
+		"staticheavyarty": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"raveparty": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"mahlazer": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"zenith": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticheavyradar": {
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]}
+				]]
+		},
+		"staticnuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"energypylon": {
+			"hub": [[
+					{"unit": "turretmissile", "category": "radar", "offset": {"back": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": {"left": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": {"back": -100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]}
+				]]
+		},
+		"turretaaheavy": {
+			"pylon": true,
+			"hub": [
+					[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		}
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/commander.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/commander.json
@@ -1,0 +1,383 @@
+// Mono-space font required
+{
+"commander": {
+	"prefix": "dyntrainer_",
+	"suffix": "_base",
+	"unit": {
+		"support": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["builder", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "builder", "scout", "skirmish", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["scout", "builder", "scout", "riot", "raider", "raider", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.9, ["builder", "raider", "scout", "raider", "raider", "scout", "raider", "raider", "scout", "builder"]],
+						[0.1, ["builder", "raider", "raider", "scout",  "skirmish", "builder", "skirmish", "scout"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "riot"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "scout", "scout", "raider", "raider", "builder", "builder"]],
+						[0.5, ["builder", "scout", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout","builder", "scout", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["riot", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[13, 42],  // shotgun
+					[31, 42],  // Cloak, Nano
+					[15, 41, 37],  // sniper, range, health
+					[34, 34, 34],  // companion drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 34],  // battle drones, companion drones
+					[34, 34, 34],  // companion drones
+					[34, 40, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 36, 36],  // health, regen
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 27, 29],  // nano, disruptor ammo, jammer
+					[32, 33, 30],  // area cloak, lazarus, radar
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 38, 38],  // range, high density
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39]  // damage
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 360,  // seconds
+				"threat": 30,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"recon": {
+			// Choice importance, 0 by default
+			"importance": 0.65,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["builder", "raider", "riot", "raider", "raider", "raider", "raider"]]
+						],
+					"factorygunship": [
+						[0.8, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.2, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.2, ["scout", "scout", "builder", "raider", "raider", "raider", "raider", "scout"]],
+						[0.8, ["builder", "scout",  "raider", "scout", "raider", "raider", "raider", "scout", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider"]],
+						[0.5, ["builder", "raider", "raider", "scout", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider", "raider",  "raider"]],
+						[0.5, ["builder", "scout", "scout", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["builder", "scout", "scout", "raider", "builder", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "scout", "builder", "scout", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 240,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[7, 37],  // Machinegun
+					[31, 36],  // Cloak, Regen
+					[19, 38, 39],  // disruptor bomb, high density, damage boost
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 37, 37],  // speed, health
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, builder
+					[42, 42, 42],  // builder
+					[42, 42, 42],  // builder
+					[30, 27, 29],  // radar, disruptor ammo, jammer
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 41, 39],  // range, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 600,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"assault": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["anti_heavy"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.10, ["scout", "builder", "skirmish", "builder", "riot", "builder", "scout", "scout", "scout", "skirmish", "skirmish", "skirmish"]],
+						[0.15, ["scout", "scout", "builder", "riot", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "skirmish", "builder", "riot"]],
+						[0.75, ["scout", "scout", "raider", "raider", "builder", "builder", "raider", "raider", "raider", "raider", "raider", "builder", "scout"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "raider", "raider", "raider", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "heavy"]],
+						[0.25, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "raider", "raider", "raider", "builder", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "scout", "scout", "scout", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout", "builder", "assault"]],
+						[0.5, ["scout", "scout", "builder", "raider", "scout", "raider", "builder", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[11],  // shotgun
+					[24, 37],  // shield, health
+					[11, 41, 41],  // Double Riot, range
+					[38, 41, 41],  // high density, range
+					[36, 41, 36],  // regen, range, regen
+					[41, 41, 41],  // range
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39, 25],  // damage, area shield
+					[26, 29, 30],  // napalm, jammer, radar
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 36, 36],  // speed, regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 38, 38],  // health, high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 140,  // seconds
+				"threat": 70,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"strike": {
+		   // Choice importance, 0 by default
+			"importance": 0.1,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "scout", "scout", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "scout", "builder", "riot"]],
+						[0.9, ["builder", "scout",  "scout",  "raider", "raider", "raider", "raider", "raider", "builder", "builder", "scout",  "raider", "raider", "raider", "raider", "raider", "builder"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "scout", "scout", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "raider", "raider", "skirmish", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.25, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "assault"]],
+						[0.5, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "scout", "scout", "raider", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 315,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[8, 37],  // beam laser
+					[31, 36],  // cloak, regen
+					[8, 40, 36],  // lightning, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[40, 40, 40],  // speed
+					[28, 29, 30],  // flux, jammer, radar
+					[36, 36, 37],  // regen, health
+					[37, 37, 37],  // health
+					[32, 41, 41],  // area cloak, range
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 42],  // companion drones, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 39, 39],  // nano, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 480,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		}
+	}
+}
+} 

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/economy.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/economy.json
@@ -1,0 +1,69 @@
+// Mono-space font required
+{
+"economy": {
+	// Plain list of energy UnitDef and its limit. AI sorts list by efficiency (inverse)
+	// which is = cost * sizeX * sizeZ / make^2
+	// With ZK v1.8.5.2:
+	//   energysingu = 15.486420
+	//   energygeo = 65.306122
+	//   energyfusion = 80.000000
+	//   energywind = 874.999939
+	//   energysolar = 1750.000000
+	// When e-stalling AI will build bottom-most energy that didn't reach its limit.
+	// On normal AI will select top-most energy that it can build under 40 seconds.
+	"energy": {
+		// If land area >= 40% of the map then "land" config used, "water" otherwise
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>]
+			// limit = random(<lower limit>..<upper limit>)
+			"energysingu": [6],
+			"energygeo": [0, 2],
+			"energyfusion": [6, 10],
+			"energywind": [8, 12],
+			"energysolar": [40]
+		},
+		"water": {
+			"energysingu": [1],
+			"energygeo": [0],
+			"energyfusion": [4],
+			"energywind": [20],
+			"energysolar": [8, 12]
+		},
+		// income factor for energy, time is in seconds
+		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]
+		"factor": [[0.15, 1], [7.0, 3600]],
+
+		"link_inc": 16.0,  // minimum metal-income for energy linking
+		"pylon": ["energypylon", "energysolar", "energywind"]
+	},
+
+	// Scales metal income
+	// ecoFactor = teamSize*eps_step+(1-eps_step)
+	"eps_step": 0.2,
+
+	// Mobile buildpower to metal income ratio
+	"buildpower": 1,
+	// Metal excess to income ratio, -1 to disable
+	"excess": -1.0,
+	// Mobile constructor to static constructor metal pull ratio
+	// [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
+//	"ms_pull": [[0.75, 0.0], [0.45, 0.10], [0.53, 0.25], [0.56, 0.40], [0.63, 0.44],[0.52, 0.48],[0.66, 0.52],[0.50, 0.56],[0.66, 0.60], [0.60, 0.65], [0.7, 0.66], [0.8, 0.66], [0.9, 0.75], [0.99, 0.90]],
+	"ms_pull": [[2.0, 0.0], [0.45, 0.20], [0.99, 0.90]],
+	// Max percent of mexes circuit team allowed to take.
+	// If its <1.0 then expansion obeys ms_pull rule, if >=1.0 then ms_pull doesn't affect expansion (mex, pylon, energy).
+	// [<cap_percent>, <is_ally_cap>]
+	"mex_max": [0.6, true],  // 60%
+	// Construction order delay in seconds, -1 to disable
+	"build_delay": [[20, 300], [15, 1800]],
+
+	// New factory switch interval, in seconds (each new factory resets timer, switch event is also based on eco + caretakers)
+	// switch = random(<min_interval>..<max_interval>)
+	"switch": [800, 900],
+
+	"terra": "terraunit",
+	"airpad": "staticrearm",
+
+	// Unknown UnitDef replacer
+	"default": "turretmissile"
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/factory.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/factory.json
@@ -1,0 +1,380 @@
+// Mono-space font required
+{
+// Factory selection parameters
+"select": {
+	"air_map": 80,
+	"offset": [-20, 20],
+	// Speed factor: 8x8 ~ 0%, 24x24 ~ 40%
+	"speed": [0, 40],
+	"map": [8, 24],
+	"no_air": 3
+},
+
+// Utility param: warning on unit's total probability not equal to 100%
+"warn_probability": true,
+
+// Define factories
+"factory": {
+	"factorycloak": {
+		// Adjusts the priority of factory choice (factories with map_percent < 20 are ignored)
+		// map_percent is [20..100]
+		// On start:
+		//   if factory has available builder in current frame: priority ~= map_percent * importance0 + random(-20..+20)
+		//   if factory's builder unavailable in current frame: priority ~= map_percent * importance0 / 10 + random(-20..+20)
+		// During game: priority ~= map_percent * importance1 + random(-20..+20)
+		// importanceN = 1.0 by default if not set
+		"importance": [0.78, 0.2],
+
+		// 'require_energy' adds energy requirement for tierN (N>0): fallback to lowest tier on low energy
+		"require_energy": true,
+
+		// If income*ecoFactor < income_tier[N] then 'tierN' probability will be used
+		"income_tier": [20, 30, 40],
+
+		//             conjurer,   glaive,      scythe,           rocko,        warrior,     zeus,           hammer,      sniper,       tick,        eraser,        gremlin
+		"unit":      ["cloakcon", "cloakraid", "cloakheavyraid", "cloakskirm", "cloakriot", "cloakassault", "cloakarty", "cloaksnipe", "cloakbomb", "cloakjammer", "cloakaa"],
+
+		"land": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.03,             0.30,         0.03,        0.00,           0.00,        0.00,         0.00,        0.00,          0.00],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.20,       0.10,        0.06,             0.51,         0.10,        0.00,           0.00,        0.03,         0.00,        0.00,          0.00],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.25,       0.01,        0.20,             0.20,         0.03,        0.00,           0.00,        0.20,         0.00,        0.11,          0.00]
+
+			// 25-32m Expansions meet - Economy can afford to begin producing in bulk so unit compositions alter.
+	//		"tier3": [ 0.10,       0.40,        0.05,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 33m -40m Solid Fronts - Now we stop raiding and start pushing.
+	//		"tier4": [ 0.10,       0.35,        0.10,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 41m - 56m Mid Game - we must have 2 facs by now, stop making balanced compositions and start being abusive.
+	//		"tier5": [ 0.10,       0.05,        0.25,             0.10,         0.00,        0.20,           0.10,        0.00,         0.00,        0.10,          0.00],
+
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+	//		"tier6": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00],
+
+			// 72m - inf+ Late late Game - This fac sucks!
+	//		"tier7": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00]
+		},
+		"air": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.26,             0.00,         0.00,        0.00,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.10,       0.25,        0.11,             0.38,         0.00,        0.06,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.20,       0.10,        0.10,             0.33,         0.00,        0.12,           0.00,        0.00,         0.00,        0.05,          0.10]
+		},
+		"caretaker": 6
+	},
+
+	"factorygunship": {
+		"importance": [15.0, 1.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 85],
+		//             wasp,         blastwing,     gnat,         banshee,       rapier,         brawler,             blackdawn,        krow,          valkyrie,       vindicator,          trident
+		"unit":      ["gunshipcon", "gunshipbomb", "gunshipemp", "gunshipraid", "gunshipskirm", "gunshipheavyskirm", "gunshipassault", "gunshipkrow", "gunshiptrans", "gunshipheavytrans", "gunshipaa"],
+		"land": {
+			// 0-8m Opening - Blastwing and banshee Harass
+			"tier0": [ 0.00,         0.00,          0.00,         0.00,          0.98,           0.00,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 9-16m Early Game - Banshee with a chance of Blackdawn
+			"tier1": [ 0.00,         0.20,          0.00,         0.02,          0.45,           0.31,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 17-24m Expanding - Time to start a-makin Brawlers
+			"tier2": [ 0.00,         0.02,          0.00,         0.00,          0.04,           0.90,                0.04,             0.00,          0.00,           0.00,                0.00],
+			// 25-32m Expansions meet - Time to keep a-makin Brawlers
+			"tier3": [ 0.00,         0.05,          0.00,         0.00,          0.04,           0.83,                0.08,             0.00,          0.00,           0.00,                0.00],
+			// 33m -40m Solid Fronts - Brawlers with a chance of Krow
+			"tier4": [ 0.00,         0.04,          0.00,         0.00,          0.05,           0.80,                0.10,             0.01,          0.00,           0.00,                0.00],
+			// 41m - 56m Mid Game - Brawlers with a bigger chance of Krow
+			"tier5": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.87,                0.06,             0.02,          0.00,           0.00,                0.00],
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+			"tier6": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.84,                0.07,             0.04,          0.00,           0.00,                0.00],
+			// 72m - inf+ Late late Game - Spam Krows!
+			"tier7": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.90,                0.00,             0.05,          0.00,           0.00,                0.00]
+		},
+		"caretaker": 6
+	},
+
+	"factoryamph": {
+		"importance": [0.85, 1.0],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             conch,     duck,       archer,        buoy,          scallop,    grizzly,       djinn,      angler
+		"unit":      ["amphcon", "amphraid", "amphimpulse", "amphfloater", "amphriot", "amphassault", "amphtele", "amphaa"],
+		"land": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.53,       0.25,          0.20,          0.02,       0.00,          0.00,       0.00],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.16,          0.47,          0.22,       0.00,          0.00,       0.00],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.10,       0.09,          0.51,          0.15,       0.05,          0.00,       0.00],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.47,          0.12,       0.13,          0.00,       0.00],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.16,      0.11,       0.02,          0.52,          0.04,       0.15,          0.00,       0.00],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.20,      0.10,       0.02,          0.49,          0.02,       0.17,          0.00,       0.00],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.48,          0.02,       0.18,          0.00,       0.00],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.46,          0.02,       0.22,          0.00,       0.00]
+		},
+		"air": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.58,       0.25,          0.10,          0.02,       0.00,          0.00,       0.05],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.11,          0.47,          0.22,       0.00,          0.00,       0.05],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.11,       0.04,          0.53,          0.12,       0.05,          0.00,       0.05],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.42,          0.12,       0.13,          0.00,       0.05],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.15,      0.10,       0.02,          0.49,          0.04,       0.15,          0.00,       0.05],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.16,      0.13,       0.02,          0.45,          0.02,       0.17,          0.00,       0.05],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.43,          0.02,       0.18,          0.00,       0.05],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.41,          0.02,       0.22,          0.00,       0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryspider": {
+		"importance": [0.71, 0.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             weaver,      flea,          hermit,          venom,       redback,      recluse,       crabe,         infiltrator,       tarantula
+		"unit":      ["spidercon", "spiderscout", "spiderassault", "spideremp", "spiderriot", "spiderskirm", "spidercrabe", "spiderantiheavy", "spideraa"],
+		"land": {
+			// 0-12m Opening - Opening turbo Flea spam & Riots
+			"tier0": [ 0.00,        0.73,          0.00,            0.22,        0.05,         0.00,          0.00,          0.00,              0.00],
+			// 13-18m Early Game - Reducing Flea spam, still mostly Riots
+			"tier1": [ 0.00,        0.59,          0.00,            0.05,        0.05,         0.31,          0.00,          0.00,              0.00],
+			// 17-24m Expanding - Slant production towards Hermit & Redback
+			"tier2": [ 0.06,        0.48,          0.04,            0.05,        0.00,         0.35,          0.02,          0.00,              0.00],
+			// 25-32m Expansions meet - Slant production towards Hermit & Recluse
+			"tier3": [ 0.08,        0.45,          0.06,            0.03,        0.00,         0.33,          0.05,          0.00,              0.00],
+			// 33m -40m Solid Fronts - 	Greater Emphasis on Hermit & Crabbe
+			"tier4": [ 0.08,        0.40,          0.09,            0.03,        0.00,         0.32,          0.08,          0.00,              0.00],
+			// 41m - 56m Mid Game - We need more Crabbes
+			"tier5": [ 0.08,        0.42,          0.07,            0.02,        0.00,         0.31,          0.10,          0.00,              0.00],
+			// 57m - 72m Late Game -  MORE CRABBES
+			"tier6": [ 0.09,        0.40,          0.11,            0.00,        0.00,         0.29,          0.11,          0.00,              0.00],
+			// 72m - inf+ Late late Game - TURBO CRABBES
+			"tier7": [ 0.10,        0.35,          0.20,            0.00,        0.00,         0.22,          0.13,          0.00,              0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryveh": {
+		"importance": [0.95, 0.2],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             mason,    dart,       scorcher,  slasher,      leveler,   ravager,      dominatrix,   wolverine, impaler,        crasher
+		"unit":      ["vehcon", "vehscout", "vehraid", "vehsupport", "vehriot", "vehassault", "vehcapture", "veharty", "vehheavyarty", "vehaa"],
+		"land": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.12,       0.00,      0.00,         0.20,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.20,      0.60,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.59,         0.01,         0.00,      0.04,           0.00],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.10,       0.00,      0.00,         0.10,      0.56,         0.02,         0.00,      0.07,           0.00],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.10,       0.00,      0.00,         0.06,      0.57,         0.05,         0.00,      0.07,           0.00]
+		},
+		"air": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.10,       0.00,      0.00,         0.22,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.15,      0.65,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.05,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.05],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.56,         0.02,         0.00,      0.03,           0.05],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.56,         0.01,         0.00,      0.04,           0.03],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.15,       0.00,      0.00,         0.10,      0.46,         0.02,         0.00,      0.07,           0.05],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.05,       0.00,      0.00,         0.16,      0.47,         0.05,         0.00,      0.07,           0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryhover": {
+		"importance": [1.00, 1.1],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             quill,      dagger,      scalpel,      halberd,        claymore,           mace,        penetrator,  flail,        bolas
+		"unit":      ["hovercon", "hoverraid", "hoverskirm", "hoverassault", "hoverdepthcharge", "hoverriot", "hoverarty", "hoveraa", "hoverheavyraid"],
+		"land": {
+			// 0-8m Opening - Raiders and Riots
+			"tier0": [ 0.00,       0.55,        0.10,         0.00,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 9-16m Early Game - Mostly Mace, some support
+			"tier1": [ 0.00,       0.10,        0.44,         0.11,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 17-24m Expanding - MAXIMUM OP Scalpel time
+			"tier2": [ 0.05,       0.10,        0.43,         0.20,           0.00,               0.14,        0.08,        0.00,        0.00],
+			// 25-32m Expansions meet - Mix in some Halberds
+			"tier3": [ 0.15,       0.10,        0.26,         0.20,           0.01,               0.16,        0.12,        0.00,        0.00],
+			// 33m -40m Solid Fronts - 	More Halberd and Pene
+			"tier4": [ 0.17,       0.13,        0.19,         0.31,           0.01,               0.05,        0.14,        0.00,        0.00],
+			// 41m - 56m Mid Game - Even more Halberd and Pene
+			"tier5": [ 0.17,       0.11,        0.17,         0.30,           0.01,               0.05,        0.19,        0.00,        0.00],
+			// 57m - 72m Late Game - More Pene
+			"tier6": [ 0.20,       0.04,        0.10,         0.34,           0.01,               0.10,        0.21,        0.00,        0.00],
+			// 72m - inf+ Late late Game - MAXIMUM PENE
+			"tier7": [ 0.25,       0.02,        0.07,         0.21,           0.00,               0.10,        0.35,        0.00,        0.00]
+		},
+		"water": {
+			// 33m -40m
+			"tier4": [ 0.00,       0.49,        0.10,         0.20,           0.10,               0.10,        0.01,        0.00],
+			// 41m - inf+4
+			"tier5": [ 0.00,       0.24,        0.05,         0.41,           0.20,               0.05,        0.05,        0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryplane": {
+		"importance": [12.0, 12.1],
+		"require_energy": false,
+
+		"income_tier": [30, 60],
+		//             crane,      swift,          hawk,                raven,        phoenix,      thunderbird,    wyvern,        vulture
+		"unit":      ["planecon", "planefighter", "planeheavyfighter", "bomberprec", "bomberriot", "bomberdisarm", "bomberheavy", "planescout"],
+		"air": {
+			// 0-10m Early Game
+			"tier0": [ 0.00,       0.00,           0.75,                0.15,         0.00,         0.00,           0.05,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.00,       0.00,           0.51,                0.00,         0.02,         0.01,           0.24,          0.22]
+		},
+		"land": {
+			// 0-10m Early Game
+			"tier0": [ 0.10,       0.00,           0.00,                0.60,         0.05,         0.00,           0.20,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.10,       0.00,           0.00,                0.05,         0.00,         0.00,           0.40,          0.45]
+		},
+		"caretaker": 6
+	},
+
+	"factorytank": {
+		"importance": [0.9, 1.5],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             welder,    kodachi,    panther,         banisher,   reaper,        goliath,            pillager,   tremor,          copperhead
+		"unit":      ["tankcon", "tankraid", "tankheavyraid", "tankriot", "tankassault", "tankheavyassault", "tankarty", "tankheavyarty", "tankaa"],
+		"land": {
+			// 0-8m Opening - Koda and Banisher
+			"tier0": [ 0.10,      0.60,       0.10,            0.20,       0.00,          0.00,               0.00,       0.00,            0.00],
+			// 9-16m Early Game - Mostly Banisher
+			"tier1": [ 0.10,      0.15,       0.10,            0.23,       0.42,          0.00,               0.00,       0.00,            0.00],
+			// 17-24m Expanding - Begin mixing in Reapers!
+			"tier2": [ 0.30,      0.13,       0.07,            0.16,       0.34,          0.00,               0.00,       0.00,            0.00],
+			// 25-32m Expansions meet - More Reapers!
+			"tier3": [ 0.46,      0.15,       0.03,            0.04,       0.32,          0.00,               0.00,       0.00,            0.00],
+			// 33m -40m Solid Fronts - 	MAXIMUM REAPERS
+			"tier4": [ 0.45,      0.14,       0.00,            0.02,       0.37,          0.02,               0.00,       0.00,            0.00],
+			// 41m - 56m Mid Game - More arty & Golly
+			"tier5": [ 0.46,      0.16,       0.00,            0.02,       0.32,          0.04,               0.00,       0.00,            0.00],
+			// 57m - 72m Late Game - Even more arty & Golly
+			"tier6": [ 0.40,      0.13,       0.00,            0.02,       0.34,          0.11,               0.00,       0.00,            0.00],
+			// 72m - inf+ Late late Game - MAXIMUM GOLLY
+			"tier7": [ 0.42,      0.08,       0.00,            0.02,       0.32,          0.16,               0.00,       0.00,            0.00]
+		},
+
+		"caretaker": 15
+	},
+
+	"factoryjump": {
+		"importance": [0.73, 1.1],
+		"require_energy": false,
+
+		"income_tier": [20, 40, 60, 80],
+		//             freaker,   puppy,       pyro,       placeholder,     moderator,   jack,          sumo,       firewalker, skuttle,    archangel
+		"unit":      ["jumpcon", "jumpscout", "jumpraid", "jumpblackhole", "jumpskirm", "jumpassault", "jumpsumo", "jumparty", "jumpbomb", "jumpaa"],
+		"land": {
+			"tier0": [ 0.05,      0.24,        0.50,       0.00,            0.15,        0.06,          0.00,       0.00,       0.00,       0.00],
+			"tier1": [ 0.10,      0.20,        0.20,       0.10,            0.16,        0.24,          0.00,       0.00,       0.00,       0.00],
+			"tier2": [ 0.20,      0.20,        0.00,       0.15,            0.04,        0.31,          0.00,       0.10,       0.00,       0.00],
+			"tier3": [ 0.25,      0.15,        0.00,       0.15,            0.00,        0.33,          0.00,       0.12,       0.00,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryshield": {
+		"importance": [0.88, 0.6],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 48, 66],
+		//             convict,     dirtbag,       bandit,       rogue,         thug,            outlaw,       felon,         racketeer,    roach,        aspis,          vandal
+		"unit":      ["shieldcon", "shieldscout", "shieldraid", "shieldskirm", "shieldassault", "shieldriot", "shieldfelon", "shieldarty", "shieldbomb", "shieldshield", "shieldaa"],
+		"land": {
+			"tier0": [ 0.05,        0.05,          0.70,         0.00,          0.20,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier1": [ 0.08,        0.01,          0.10,         0.24,          0.57,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier2": [ 0.12,        0.03,          0.00,         0.20,          0.54,            0.00,         0.05,          0.00,         0.00,         0.06,           0.00],
+			"tier3": [ 0.15,        0.07,          0.00,         0.00,          0.62,            0.00,         0.08,          0.00,         0.00,         0.08,           0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryship": {
+		"importance": [5.5, 5.5],
+		"require_energy": false,
+
+		"income_tier": [30],
+		//             mariner    cutter,      hunter,           seawolf,     corsair,    mistral,     siren,         ronin,      zephyr
+		"unit":      ["shipcon", "shipscout", "shiptorpraider", "subraider", "shipriot", "shipskirm", "shipassault", "shiparty", "shipaa"],
+		"water": {
+			"tier0": [ 0.05,      0.15,        0.35,             0.10,        0.10,       0.10,        0.15,          0.00,       0.00],
+			"tier1": [ 0.05,      0.10,        0.20,             0.10,        0.05,       0.10,        0.25,          0.15,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"striderhub": {
+		"importance": [0, 1.5],
+		"require_energy": false,
+
+		"income_tier": [60, 80, 100],
+		//             ultimatum,          scorpion,          dante,          catapult,      funnelweb,          bantha,          detriment,          scylla,          reef,          battleship
+		"unit":      ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"land": {
+			"tier0": [ 0.01,               0.10,              0.81,           0.00,          0.05,               0.03,            0.00,               0.00,            0.00,          0.00],
+			"tier1": [ 0.03,               0.14,              0.22,           0.24,          0.20,               0.16,            0.01,               0.00,            0.00,          0.00],
+			"tier2": [ 0.05,               0.10,              0.16,           0.35,          0.10,               0.21,            0.03,               0.00,            0.00,          0.00],
+			"tier3": [ 0.05,               0.10,              0.01,           0.26,          0.10,               0.35,            0.13,               0.00,            0.00,          0.00]
+		},
+		"water": {
+			"tier1": [ 0.50,               0.00,              0.00,           0.00,          0.00,               0.00,            0.00,               0.00,            0.25,          0.25],
+			"tier2": [ 0.10,               0.00,              0.00,           0.00,          0.00,               0.00,            0.10,               0.00,            0.40,          0.40]
+		},
+
+		"caretaker": 100
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/response.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/response.json
@@ -1,0 +1,136 @@
+// Mono-space font required
+{
+// Build special units when enemy_metal*ratio > response_metal*eps; eps=teamSize*eps_step+(1-eps_step)
+// AA condition for 3v3: (enemy_air_metal*0.67 > (aa_metal+aa_cost)*1.12) and (aa_metal+aa_cost < army_metal*0.5)
+//
+// Probability of UnitDef for AA role depends on income tier: (tierN[UnitDef]+_weight_)*enemy_air_metal/aa_metal*importance
+// armjeth probability for tier 1: (0.00+10.00)*enemy_air_metal*600.0
+"response": {
+	"_weight_": 70.0,  // base weight of response probability, default=0.5
+
+	"assault": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "super", "missileskirm", "turtle"],
+		"ratio":      [ 0.75,   2.0,      0.00,      0.20,        0.00,    0.75,    1.5,            3.0],
+		"importance": [ 15.00,  45.00,    25.00,     75.00,       0.00,    45.00,   125.00,         50.0],
+		"max_percent": 1.00
+	},
+	"skirmish": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "anti_heavy"],
+		"ratio":      [ 1.50,   0.75,     1.00,      0.00,        0.00,    0.00],
+		"importance": [ 35.00,  25.00,    25.00,     75.00,       0.00,    0.00],
+		"max_percent": 1.00
+	},
+	"raider": {
+		"vs":         ["anti_air", "scout", "raider", "anti_heavy", "mine", "skirmish", "artillery"],
+		"ratio":      [ 0.00,       1.00,    1.0,      0.10,         0.35,   0.40,       0.8],
+		"importance": [ 15.00,      75.00,   75.00,    15.00,        60.00,  45.00,      10.00],
+		"max_percent": 1.00,
+		"eps_step": 0.75
+	},
+	"riot": {
+		"vs":         ["raider", "scout", "commander", "bullshit_raider"],
+		"ratio":      [ 0.8,      0.8,     0.33,        1.5],
+		"importance": [ 100.00,   100.00,  75.00,       125.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"missileskirm": {
+		"vs":         ["raider", "scout", "riot"],
+		"ratio":      [ 0.25,     0.5,     0.25],
+		"importance": [ 35.00,    50.00,   35.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"transport": {
+		"vs":         ["super", "support", "shieldball"],
+		"ratio":      [ 0.75,    0.75,      0.75],
+		"importance": [ 50.00,   50.00,     50.00],
+		"max_percent": 0.30,
+		"eps_step": 0.015
+	},
+	"scout": {
+		"vs":         ["mine", "artillery", "anti_air", "scout", "static", "heavy", "anti_heavy", "cloaked_raider"],
+		"ratio":      [ 0.35,   0.05,        0.10,       1.00,    0.00,     0.00,    0.05,         0.5],
+		"importance": [ 60.00,  60.0,        60.0,       35.00,   0.00,     0.00,    10.00,        100.00],
+		"max_percent": 0.09,
+		"eps_step": 0.025
+	},
+	"artillery": {
+		"vs":         ["static", "artillery", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.66,     0.00,        0.66,    0.25,         3.0],
+		"importance": [ 20.00,    0.00,        40.00,   40.00,        40.0],
+		"max_percent": 0.66,
+		"eps_step": 0.02
+	},
+	"anti_air": {
+		"vs":         ["air"],
+		"ratio":      [ 0.8],
+		"importance": [ 75.0],
+		"max_percent": 0.4,
+		"eps_step": 0.75
+	},
+	"anti_sub": {
+		"vs":         ["sub"],
+		"ratio":      [ 0.0],
+		"importance": [ 0.0],
+		"max_percent": 0.00,
+		"eps_step": 0.0
+	},
+	"anti_heavy": {
+		"vs":         ["heavy", "artillery", "support", "anti_heavy", "commander", "super", "turtle"],
+		"ratio":      [ 0.45,    0.00,        0.00,      0.00,         0.4,         0.50,    3.00],
+		"importance": [ 85.00,   0.00,        0.00,      0.00,         50.00,       85.0,    50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"disarm_target": {
+		"vs":         ["disarm_target"],
+		"ratio":      [ 0.50],
+		"importance": [ 100.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"snipe_target": {
+		"vs":         ["snipe_target", "commander"],
+		"ratio":      [ 1.00,           0.20],
+		"importance": [ 100.00,         50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"cloaked_raider": {
+		"vs":         ["snipe_target", "commander", "transport"],
+		"ratio":      [ 0.50,           0.20,        2.00],
+		"importance": [ 35.00,          35.00,       125.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"heavy": {
+		"vs":         ["heavy", "static", "support", "skirmish", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.75,    0.5,      0.00,      0.75,       0.75,    0.75,         3.00],
+		"importance": [ 75.00,   15.00,    0.00,      15.00,      75.00,   75.00,        75.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"bomber": {
+		"vs":         ["shieldball", "anti_heavy", "artillery", "super"],
+		"ratio":      [ 0.50,         0.50,         0.50,        0.50],
+		"importance": [ 0.50,         50.00,        50.00,       50.00],
+		"max_percent": 1.0,
+		"eps_step": 0.00
+	},
+	"super": {
+		"vs":         ["heavy", "static", "support", "skirmish", "artillery", "super", "turtle"],
+		"ratio":      [ 0.3,     0.55,     0.00,      0.00,       0.00,        0.00,    0.5],
+		"importance": [ 45.00,   25.00,    0.00,      0.00,       0.00,        0.00,    45.00],
+		"max_percent": 0.2,
+		"eps_step": 0.00
+	},
+	"support": {
+		"vs":         ["assault", "bullshit_raider"],
+		"ratio":      [ 1.00,      0.4],
+		"importance": [ 35.00,     75.00],
+		"max_percent": 0.25,
+		"eps_step": 0.00
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/behaviour.json
@@ -1,0 +1,1180 @@
+// Mono-space font required
+{
+"quota": {
+	"scout": 1,  // max scout units out of raiders
+	"raid": [6.0, 20.0],  // [<min>, <avg>] power of raider squad
+	"attack": 6.0,  // min power of attack group
+	"thr_mod": {
+		"attack": [0.1, 0.1],  // [<min>, <max>] enemy threat modifier for target selection of attack task
+		"defence": [0.1, 0.1],  // [<min>, <max>] enemy threat modifier for group size calculation of defence task
+		"mobile": 0.6,  // initial modifier for power of attack group based on mobile enemy threat
+		"static": 2,  // initial modifier for power of attack group based on static enemy threat
+		"comm": 0.75
+	},
+	"aa_threat": 80.0,  // anti-air threat threshold, air factories will stop production when AA threat exceeds
+	"slack_mod": {
+		"all": 0.5,  // threat map 64-elmos slack multiplier for all units
+		"static": 1.5,  // additional 64-elmo-cells for static units
+		"speed": [0.75, 4.0]  // [<64elmo_cells_speed_mod>, <max_64elmo_cells>]
+	}
+},
+
+// If unit's health drops below specified percent it will retreat
+"retreat": {
+	// units fighting to the death is more fun for noobs
+	"builder": [0.01, 1.0],  // [<default>, <UnitDef modifier>] for all builders
+	"fighter": [0.01, 1.0],  // [<default>, <UnitDef modifier>] for all not-builder units
+	"shield": [0.01, 0.275]  // [<empty>, <full>] shield power
+},
+
+"defence": {
+	"infl_rad": 7,  // influenece cell radius for defendAlly map
+	"base_rad": [1000.0, 2000.0],  // defend if enemy within clamp(distance(lane_pos, base_pos), 1000, 2000) radius
+	"comm_rad": [1000.0, 500.0]  // 0 distance from base ~ 1000, base_rad ~ 500.0
+},
+
+
+"behaviour": {
+	// factorycloak
+	"cloakcon": {
+		// "role": [<main>, <enemy>, <enemy>, ...]
+		// <main> is the role to make desicions of when to build it and what task to assign
+		// <enemy> is to decide how to counter enemy unit, if missing then equals to <main>
+		// Roles: builder, scout, raider, riot, assault, skirmish, artillery, anti_air, anti_sub, anti_heavy, bomber, support, mine, transport, air, sub, static, heavy, super, commander
+		// Auto-assigned roles: builder, air, static, super, commander
+		"role": ["builder", "mine"],
+
+		// Attributes - optinal states
+		// "melee" - always move close to target, disregard attack range
+		// "no_jump" - disable jump on retreat
+		// "boost" - boost speed on retreat
+		// "no_strafe" - disable gunship's strafe
+		// "stockpile" - load weapon before any task (NOT IMPLEMENTED), auto-assigned
+		// "siege" - mostly use fight command instead of move
+		// "ret_hold" - hold fire on retreat
+		// "ret_fight" - fight on retreat
+//		"attribute": ["boost", "no_strafe"],
+
+		// Fire state (open by default)
+		// "hold" - hold fire
+		// "return" - return fire
+		// "open" - fire at will
+//		"fire_state": "open",
+
+		// Overrides reloadTime in seconds
+//		"reload": 1.0,
+
+		// Limits number of units
+//		"limit": 10,
+		"limit": 3
+
+		// Unit can be built only since specific time in seconds
+//		"since": 60,
+
+		// Minimum hp percent before retreat
+//		"retreat": 0.8,
+
+		// Ally threat multiplier
+//		"pwr_mod": 1.0,
+		// Enemy threat multiplier
+//		"thr_mod": 1.0,
+
+		// Ignore enemy
+//		"ignore": false
+	},
+	"cloakraid": {
+		"role": ["raider", "scout"],
+		"attribute": ["scout"],
+		"retreat": 0.1,
+		"limit": 3,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.75
+	},
+	"cloakheavyraid": {
+		"role": ["cloaked_raider", "raider"],
+		"attribute": ["ret_fight"],
+		"since": 180,
+		"limit": 0,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.1,
+		"retreat": 0.4
+	},
+	"cloakskirm": {
+		"role": ["skirmish"],
+		"attribute": ["ret_fight"],
+		"pwr_mod": 0.85,
+		"since": 180,
+		"limit": 3,
+		"retreat": 0.35  // mostly disposable
+	},
+	"cloakriot": {
+		"role": ["riot", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"since": 180,
+		"limit": 3,
+		"retreat": 0.55,
+		"pwr_mod": 1.4,
+		"thr_mod": 2.3
+	},
+	"cloakassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.35,  // assaults need to assault
+		"since": 240,
+		"limit": 3,
+		"pwr_mod": 0.7,
+		"thr_mod": 1.1
+	},
+	"cloakarty": {
+		"role": ["artillery"],
+		"since": 550,
+		"limit": 1,
+		"retreat": 0.9,
+		"thr_mod": 0.0
+	},
+	"cloaksnipe": {
+		"role": ["snipe_target"],
+		"attribute": ["support"],
+		"pwr_mod": 3.0,
+		"limit": 0,
+		"since": 520,
+		"thr_mod": 0.0,
+		"retreat": 0.69
+	},
+	"cloakbomb": {
+		"role": ["mine"],
+		"limit": 0,
+		"retreat": 0.01
+	},
+	"cloakjammer": {
+		"role": ["assault"],
+		"since": 480,
+		"retreat": 0.5,
+		"limit": 0
+	},
+	"cloakaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"limit": 0,
+		"thr_mod": 1.2
+	},
+
+	// factorygunship
+	"gunshipcon": {
+		"role": ["builder", "air"],
+		"limit": 3,
+		"since": 240,
+		"retreat": 0.99
+	},
+	"gunshipbomb": {
+		"role": ["bomber", "air"],
+		"attribute": ["melee"],
+		"limit": 3,
+		"thr_mod": 1.0,
+		"retreat": 0.01
+	},
+	"gunshipemp": {
+		"role": ["anti_heavy", "air"],
+		"thr_mod": 0.1,
+		"pwr_mod": 0.1,
+		"since": 600,
+		"limit": 3,
+		"retreat": 0.9
+	},
+	"gunshipskirm": {
+		"role": ["air", "bullshit_raider"],
+		"retreat": 0.65,
+		"pwr_mod": 0.7,
+		"limit": 3,
+		"thr_mod": 0.66
+	},
+	"gunshipraid": {
+		"role": ["scout", "air"],
+		"retreat": 0.7,
+		"limit": 3,
+		"pwr_mod": 1.25,
+		"thr_mod": 1.1
+	},
+	"gunshipheavyskirm": {
+		"role": ["assault", "air"],
+		"since": 330,
+		"limit": 2,
+		"attribute": ["no_strafe"],
+		"retreat": 0.65,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.00
+	},
+	"gunshipassault": {
+		"role": ["anti_heavy", "air"],
+		"limit": 2,
+		"since": 330,
+		"retreat": 0.5,
+		"pwr_mod": 1.65,
+		"thr_mod": 1.00
+	},
+	"gunshipkrow": {
+		"role": ["anti_heavy", "air", "disarm_target"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"since": 720,
+		"pwr_mod": 0.3,
+		"thr_mod": 0.3,
+		"limit": 0
+	},
+	"gunshiptrans": {
+		"role": ["air"],
+		"limit": 0
+	},
+	"gunshipheavytrans": {
+		"role": ["air"],
+		"limit": 0,
+		"thr_mod": 0.0
+	},
+	"gunshipaa": {
+		"role": ["anti_air", "air"],
+		"limit": 3,
+		"retreat": 0.95,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryamph
+	"amphcon": {
+		"limit": 3,
+		"role": ["builder", "mine"]
+	},
+	"amphraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"limit": 3,
+		"retreat": 0.25  // pretty disposable
+	},
+	"amphimpulse": {
+		"role": ["riot"],
+		"limit": 2,
+		"retreat": 0.36,
+		"pwr_mod": 2.25,
+		"thr_mod": 2.25
+	},
+	"amphfloater": {
+		"role": ["assault", "snipe_target", "super"],
+		"limit": 2,
+		"since": 120,
+		"retreat": 0.25, // too slow to be retreating all the time
+		"pwr_mod": 1.3,
+		"thr_mod": 1.3
+	},
+	"amphriot": {
+		"role": ["riot"],
+		"attribute": ["melee", "ret_fight"],
+		"pwr_mod": 1.5,
+		"limit": 3,
+		"retreat": 0.35 // too slow to be retreating all the time
+	},
+	"amphassault": {
+		"role": ["heavy", "disarm_target"],
+		"retreat": 0.66,
+		"limit": 0,
+		"since": 520,
+		"pwr_mod": 1.4,
+		"thr_mod": 1.0
+	},
+	"amphtele": {
+		"role": ["transport"],
+		"limit": 0
+	},
+	"amphaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight", "support"],
+		"retreat": 0.3,
+		"limit": 3,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.5
+	},
+
+	// factoryspider
+	"spidercon": {
+		"limit": 3,
+		"role": ["builder", "mine"]
+	},
+	"spiderscout": {
+		"role": ["scout", "raider"],
+		"limit": 3,
+		"thr_mod": 0.5,
+		"retreat": 0.01
+	},
+	"spiderassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 3,
+		"pwr_mod": 1.15,
+		"retreat": 0.35
+	},
+	"spideremp": {
+		"role": ["raider", "riot"],
+		"pwr_mod": 3.0,
+		"limit": 3,
+		"retreat": 0.5
+	},
+	"spiderriot": {
+		"role": ["riot"],
+		"pwr_mod": 2.0,
+		"limit": 2,
+		"attribute": ["support"],
+		"retreat": 0.35
+	},
+	"spiderskirm": {
+		"role": ["skirmish", "snipe_target", "super"],
+		"pwr_mod": 2.0,
+		"thr_mod": 1.0,
+		"limit": 2,
+		"since": 180,
+		"retreat": 0.4
+	},
+	"spidercrabe": {
+		"role": ["heavy", "disarm_target", "turtle"],
+		"attribute": ["siege", "ret_fight", "support"],
+		"retreat": 0.5,
+		"thr_mod": 2.5,
+		"pwr_mod": 2.5,
+		"limit": 0,
+		"since": 300,
+		"thr_mod": 1.0
+	},
+	"spiderantiheavy": {
+		"role": ["anti_heavy", "mine"],
+		"retreat": 0.99,
+		"pwr_mod": 2.0,
+		"thr_mod": 0.1,
+		"since": 600,
+		"limit": 0
+	},
+	"spideraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 3.0,
+		"limit": 0,
+		"thr_mod": 1.2
+	},
+
+	// factoryshield
+	"shieldcon": {
+		"role": ["builder", "shieldball", "mine"],
+		"limit": 3,
+		"retreat": 1.3
+	},
+	"shieldscout": {
+		"role": ["transport", "raider"],
+		"limit": 3,
+		"attribute": ["siege", "melee"],
+		"pwr_mod": 0.11,
+		"thr_mod": 0.1,
+		"retreat": 0.0
+	},
+	"shieldraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"retreat": 0.25,
+		"limit": 3,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.9
+	},
+	"shieldskirm": {
+		"role": ["skirmish"],
+		"limit": 3,
+		"since": 200,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"retreat": 0.3
+	},
+	"shieldassault": {
+		"role": ["assault", "support", "shieldball"],
+		"attribute": ["melee"],
+		"limit": 3,
+		"retreat": 0.3,
+		"since": 120,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.35
+	},
+	"shieldriot": {
+		"role": ["riot", "shieldball"],
+		"fire_state": "hold",
+		"since": 100,
+		"limit": 3,
+		"retreat": 0.3,
+		"pwr_mod": 1.7,
+		"thr_mod": 1.7
+	},
+	"shieldfelon": {
+		"role": ["heavy", "shieldball", "snipe_target"],
+		"since": 420,
+		"limit": 0,
+		"retreat": 0.35,
+		"pwr_mod": 1.1,
+		"thr_mod": 1.1
+	},
+	"shieldarty": {
+		"role": ["disarm_target"],
+		"since": 300,
+		"limit": 0,
+		"retreat": 0.3,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"shieldbomb": {
+		"limit": 0,
+		"role": ["mine"]
+	},
+	"shieldshield": {
+		"role": ["super", "heavy", "shieldball"],
+		"since": 540,
+		"limit": 0,
+		"attribute": ["support"],
+		"retreat": 0.36,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.25
+	},
+	"shieldaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 3,
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryveh
+	"vehcon": {
+		"limit": 3,
+		"role": ["builder", "mine"]
+	},
+	"vehscout": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"thr_mod": 0.6,
+		"pwr_mod": 1.2,
+		"retreat": 0.01,
+		"limit": 3
+	},
+	"vehraid": {
+		"role": ["raider"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.3,
+		"limit": 3,
+		"pwr_mod": 1.1,
+		"thr_mod": 0.8
+	},
+	"vehsupport": {
+		"role": ["artillery", "missileskirm"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 2,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.4,
+		"retreat": 0.6  // cannot retreat
+	},
+	"vehriot": {
+		"role": ["riot"],
+		"retreat": 0.6,
+		"limit": 2,
+		"pwr_mod": 1.5,
+		"thr_mod": 1.5
+	},
+	"vehassault": {
+		"role": ["assault"],
+		"attribute": ["melee"],
+		"retreat": 0.4,  // slow to turn around
+		"limit": 3,
+		"since": 180,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9
+	},
+	"vehcapture": {
+		"role": ["support", "disarm_target", "snipe_target"],
+		"since": 180,
+		"limit": 0,
+		"pwr_mod": 1,
+		"thr_mod": 1,
+		"retreat": 0.8
+	},
+	"veharty": {
+		"role": ["transport", "super"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 15,
+		"since": 460,
+		"limit": 0,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0,
+		"retreat": 0.8
+	},
+	"vehheavyarty": {
+		"role": ["artillery", "heavy", "turtle"],
+		"since": 300,
+		"limit": 0,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.00
+	},
+	"vehaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.75,
+		"limit": 1,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryjump
+	"jumpcon": {
+		"limit": 3,
+		"role": ["builder", "mine"]
+	},
+	"jumpscout": {
+		"role": ["riot", "raider"],
+		"limit": 1,
+		"attribute": ["melee", "siege"],
+		"retreat": 3
+	},
+	"jumpraid": {
+		"role": ["raider", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.4,
+		"limit": 2,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.9
+	},
+	"jumpblackhole": {
+		"role": ["support"],
+		"since": 300,
+		"limit": 0,
+		"retreat": 0.36
+	},
+	"jumpskirm": {
+		"role": ["skirmish", "super", "snipe_target"],
+		"limit": 1,
+		"retreat": 0.4
+	},
+	"jumpassault": {
+		"role": ["assault", "anti_sub", "disarm_target"],
+		"attribute": ["melee", "siege", "ret_fight"],
+		"retreat": 0.4,
+		"limit": 0,
+		"pwr_mod": 1.3,
+		"thr_mod": 0.5
+	},
+	"jumpsumo": {
+		"role": ["heavy", "support", "disarm_target"],
+		"limit": 0,
+		"attribute": ["melee", "no_jump"]  // jump on attack
+	},
+	"jumparty": {
+		"role": ["heavy", "turtle", "snipe_target"],
+		"attribute": ["support"],
+		"since": 600,
+		"pwr_mod": 0.1,
+		"limit": 0,
+		"thr_mod": 0.00,
+		"retreat": 0.99
+	},
+	"jumpbomb": {
+		"role": ["anti_heavy", "builder"],
+		"attribute": ["melee", "mine"],
+		"fire_state": "open",
+		"since": 720,
+		"limit": 0,
+		"retreat": 0.01,
+		"pwr_mod": 3.0,
+		"thr_mod": 0.01
+	},
+	"jumpaa": {
+		"role": ["anti_air"],
+		"limit": 1,
+		"attribute": ["melee"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryhover
+	"hovercon": {
+		"limit": 3,
+		"role": ["builder", "mine"]
+	},
+	"hoverraid": {
+		"role": ["scout"],
+		"attribute": ["melee"],		
+		"pwr_mod": 0.9,
+		"thr_mod": 0.8,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9,
+		"limit": 3,
+		"retreat": 0.5
+	},
+	"hoverheavyraid": {
+		"role": ["raider", "bullshit_raider"],	
+		"limit": 1,
+		"retreat": 0.35,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.8
+	},
+	"hoverskirm": {
+		"role": ["skirmish", "support"],
+		"retreat": 0.55,
+		"limit": 2,
+		"reload": 4.0,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.6
+	},
+	"hoverassault": {
+		"role": ["assault", "raider"],
+		"attribute": ["melee", "ret_hold"],
+		"retreat": 0.4,
+		"limit": 3,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.45
+	},
+	"hoverdepthcharge": {
+		"role": ["anti_sub", "riot"],
+		"limit": 2,
+		"attribute": ["melee"],
+		"retreat": 0.6
+	},
+	"hoverriot": {
+		"role": ["riot", "snipe_target"],
+		"limit": 1,
+		"retreat": 0.4,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.25
+	},
+	"hoverarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"attribute": ["siege"],
+		"limit": 0,
+		"retreat": 0.99,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"hoveraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"limit": 2,
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryplane
+	"planecon": {
+		"role": ["builder", "air"],
+		"since": 240,
+		"limit": 3,
+		"retreat": 0.99
+	},
+	"planefighter": {
+		"role": ["scout", "air"],
+		"attribute": ["boost"],
+		"pwr_mod": 1.5,
+		"limit": 3,
+		"thr_mod": 3.0,
+		"retreat": 0.8
+	},
+	"planeheavyfighter": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"limit": 2,
+		"retreat": 0.4,
+		"pwr_mod": 2.5,
+		"thr_mod": 3.0
+	},
+	"bomberprec": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"attribute": ["siege"],
+		"limit": 2,
+		"retreat": 0.8,
+		"pwr_mod": 0.10,
+		"thr_mod": 0.01
+	},
+	"bomberriot": {
+		"role": ["bomber", "air"],
+		"limit": 2,
+		"retreat": 0.6,
+		"pwr_mod": 0.01,
+		"thr_mod": 0.01
+	},
+	"bomberdisarm": {
+		"role": ["anti_heavy", "air"],
+		"attribute": ["siege", "bomber"],
+		"limit": 1,
+		"since": 1200,
+		"retreat": 0.95,
+		"pwr_mod": 100.00,
+		"thr_mod": 0.01
+	},
+	"bomberheavy": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"fire_state": "return",
+		"limit": 0,
+		"since": 420,
+		"retreat": 0.95,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.1
+	},
+	"bomberassault": {
+		"role": ["bomber", "air"],
+		"attribute": ["anti_stat", "no_dgun"],
+		"fire_state": "hold",
+		"limit": 1,
+		"since": 1800,
+		"retreat": 0.65,
+		"pwr_mod": 1.25,
+		"thr_mod": 0.01
+	},
+	"planescout": {
+		"role": ["scout", "air"],
+		"since": 360,
+		"limit": 1,
+		"retreat": 0.8
+	},
+
+	// factorytank
+	"tankcon": {
+		"role": ["builder"],
+		"limit": 3,
+		"pwr_mod": 0.40,
+		"thr_mod": 0.40,
+		"retreat": 0.9
+	},
+	"tankraid": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"limit": 2,
+		"thr_mod": 0.66,
+		"pwr_mod": 0.8,
+		"retreat": 0.45
+	},
+	"tankheavyraid": {
+		"role": ["raider", "bullshit_raider"],
+		"thr_mod": 0.6,
+		"limit": 2,
+		"pwr_mod": 0.65,
+		"retreat": 0.65
+	},
+	"tankriot": {
+		"role": ["riot", "heavy", "snipe_target"],
+		"thr_mod": 1.25,
+		"limit": 1,
+		"pwr_mod": 0.75,
+		"retreat": 0.55
+	},
+	"tankassault": {
+		"role": ["assault", "heavy", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"limit": 1,
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7
+	},
+	"tankheavyassault": {
+		"role": ["heavy", "disarm_target", "super"],
+		"attribute": ["melee"],
+		"pwr_mod": 0.85,
+		"limit": 0,
+		"thr_mod": 0.7,
+		"since": 480,
+		"retreat": 0.55
+	},
+	"tankarty": {
+		"role": ["artillery", "snipe_target", "heavy"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 0,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.0
+	},
+	"tankheavyarty": {
+		"role": ["transport"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 0,
+		"retreat": 0.99,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0
+	},
+	"tankaa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.8,
+		"limit": 2,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryship
+	"shipcon": {
+		"limit": 3,
+		"role": ["builder"]
+	},
+	"shipscout": {
+		"limit": 1,
+		"role": ["scout"]
+	},
+	"shiptorpraider": {
+		"limit": 1,
+		"role": ["raider"]
+	},
+	"subraider": {
+		"limit": 1,
+		"role": ["raider"]
+	},
+	"shipriot": {
+		"limit": 1,
+		"role": ["riot"]
+	},
+	"shipskirm": {
+		"limit": 1,
+		"role": ["skirmish"]
+	},
+	"shipassault": {
+		"limit": 0,
+		"role": ["assault"]
+	},
+	"shiparty": {
+		"limit": 0,
+		"role": ["artillery"]
+	},
+	"shipaa": {
+		"limit": 1,
+		"role": ["anti_air"]
+	},
+
+	// striderhub
+	"striderantiheavy": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 0,
+		"pwr_mod": 0.5,
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.35
+	},
+	"striderscorpion": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"fire_state": "return",
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"since": 1800,
+		"thr_mod": 0.5
+	},
+	"striderdante": {
+		"role": ["heavy", "disarm_target", "snipe_target"],
+		"attribute": ["melee"],
+		"limit": 1,
+		"retreat": 0.45,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.75
+	},
+	"striderarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"pwr_mod": 5.0,
+		"limit": 1,
+		"thr_mod": 0.0,
+		"retreat": 0.9
+	},
+	"striderfunnelweb": {
+		"role": ["heavy", "turtle", "shieldball"],
+		"attribute": ["support"],
+		"retreat": 1.4,
+		"pwr_mod": 1.0,
+		"limit": 1,
+		"since": 3000,
+		"thr_mod": 0.0
+	},
+	"striderbantha": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"limit": 0,
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.5
+	},
+	"striderdetriment": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"limit": 0,
+		"retreat": 0.50,  // deffo retreat, running into nab annihlator farm and sploding is silly :)
+		"pwr_mod": 0.34,
+		"thr_mod": 0.34
+	},
+	"subtacmissile": {
+		"limit": 0,
+		"role": ["artillery", "heavy"],
+		"attribute": ["stockpile"]
+	},
+	"shipcarrier": {
+		"limit": 0,
+		"role": ["artillery", "heavy"]
+	},
+	"shipheavyarty": {
+		"limit": 0,
+		"role": ["artillery", "heavy"]
+	},
+
+	// statics
+	"staticnuke": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 30.0,
+		"limit": 1,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"staticmissilesilo": {
+		"role": ["static", "support", "heavy"],
+		"thr_mod": 0.01
+	},
+	"raveparty": {
+		"role": ["static", "heavy"],
+		"limit": 0,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"zenith": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 105.0,  // 105sec / 0.7sec/met = 150 meteorsControlled
+		"limit": 0,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"mahlazer": {
+		"role": ["static", "heavy"],
+		"limit": 0,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"staticheavyarty": {
+		"role": ["artillery", "turtle", "heavy"],
+		"limit": 0,
+		"thr_mod": 0.0,
+		"pwr_mod": 10.00
+	},
+	"turretheavy": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 1.00
+	},
+	"turretantiheavy": {
+		"role": ["static", "turtle", "static"],
+		"thr_mod": 0.55
+	},
+	"staticarty": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 0.55
+	},
+	"staticantinuke": {
+		"role": ["static", "heavy", "support"],
+		"since": 720,
+		"limit": 1
+	},
+	"turretheavylaser": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.0
+	},
+	"energysingu": {
+		"role": ["static", "turtle", "heavy"],
+		"since": 660
+	},
+	"energyfusion": {
+		"role": ["static", "mine", "heavy"],
+		"since": 280
+	},
+	"turretaalaser": {
+		"role": ["anti_air"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.0
+	},
+	"turretaaheavy": {
+		"role": ["anti_air", "heavy", "turtle"],
+		"limit": 1,
+		"thr_mod": 1.0
+	},
+	"turretlaser": {
+		"role": ["static", "riot", "builder"],
+		"thr_mod": 1.5
+	},
+	"turretmissile": {
+		"role": ["missileskirm", "riot", "builder"],
+		"thr_mod": 0.34
+	},
+	"turretriot": {
+		"role": ["static", "riot", "snipe_target"],
+		"thr_mod": 1.65
+	},
+	"turretaafar": {
+		"role": ["anti_air", "heavy", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaflak": {
+		"role": ["anti_air", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaclose": {
+		"role": ["anti_air"],
+		"thr_mod": 1.0
+	},
+	"turretgauss": {
+		"role": ["static", "turtle", "transport"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.6
+	},
+	"turretemp": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.5
+	},
+
+	// support factories won't be built in front
+	"factoryplane": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"factorygunship": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"striderhub": {
+		"role": ["static"],
+		"since": 900,
+		"attribute": ["support"]
+	},
+
+	// Enemy Eco!! //
+	"staticmex": {
+		"role": ["mine"]
+	},
+	"energywind": {
+		"role": ["mine"]
+	},
+	"staticradar": {
+		"role": ["mine"]
+	},
+	"staticcon": {
+		"role": ["mine"]
+	},
+	"energypylon": {
+		"role": ["mine"],
+		"since": 600
+	},
+	"staticheavyradar": {
+		"role": ["mine", "turtle"],
+		"limit": 1
+	},
+	"staticstorage": {
+		"role": ["mine", "turtle"],
+		"limit": 5
+	},
+	"energysolar": {
+		"role": ["mine"]
+	},
+	"staticshield": {
+		"role": ["static", "turtle"]
+	},
+
+	// Chickens!! //
+	"dronecarry": {
+		"role": ["transport"]
+	},
+	"chicken": {
+		"role": ["raider"]
+	},
+	"chicken_blimpy": {
+		"role": ["mine"]
+	},
+	"chicken_digger": {
+		"role": ["riot"]
+	},
+	"chicken_dodo": {
+		"role": ["mine"]
+	},
+	"chicken_dragon": {
+		"role": ["heavy"],
+		"thr_mod": 0.4
+	},
+	"chicken_drone": {
+		"role": ["raider"]
+	},
+	"chicken_drone_starter": {
+		"role": ["raider"]
+	},
+	"chicken_leaper": {
+		"role": ["raider"]
+	},
+	"chicken_listener": {
+		"role": ["static"]
+	},
+	"chicken_pigeon": {
+		"role": ["air"]
+	},
+	"chicken_roc": {
+		"role": ["air"]
+	},
+	"chicken_shield": {
+		"role": ["support"]
+	},
+	"chicken_spidermonkey": {
+		"role": ["anti_air"]
+	},
+	"chicken_tiamat": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenblobber": {
+		"role": ["artillery"]
+	},
+	"chickenbroodqueen": {
+		"role": ["heavy"],
+		"thr_mod": 0.05
+	},
+	"chickenflyerqueen": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenlandqueen": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenspire": {
+		"role": ["static"]
+	},
+	"chickena": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenc": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickend": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenf": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenr": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenwurm": {
+		"role": ["heavy"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/block_map.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/block_map.json
@@ -1,0 +1,138 @@
+// Mono-space font required
+{
+"building": {
+	"class_land": {
+		"fac_land": {
+			// "type": [<blocker_shape>, <structure_type>]
+			// Available blocker_shape: rectangle, circle.
+			// Available structure_type: factory, mex, engy_low, engy_mid, engy_high, pylon, def_low, def_mid, def_high, special, nano, terra, unknown
+			"type": ["rectangle", "factory"],
+
+			// Unit of measurement: 1 size/yard/radius = SQUARE_SIZE * 2 = 16 elmos, integer.
+			// Offset in South facing
+			"offset": [0, 6],  // default: [0, 0]
+
+			// Size of a blocker without yard
+//			"size": [7, 7],  // default: size of a unit
+
+			// Spacer, blocker_size = size + yard
+			"yard": [12, 12]  // default: [0, 0]
+
+			// "ignore": [<structure_type>, <structure_type>, ...]
+			// Ignore specified structures.
+			// Additional values: none, all
+//			"ignore": ["none"]  // default: ["none"]
+		},
+		"fac_air": {
+			"type": ["rectangle", "factory"],
+			"yard": [8, 8]
+		},
+		"fac_water": {
+			"type": ["rectangle", "factory"],
+			"offset": [0, 4],
+			"yard": [10, 12]
+		},
+		"fac_strider": {
+			"type": ["rectangle", "special"],
+			"offset": [0, 12],
+			"yard": [16, 16]
+		},
+		"solar": {
+			"type": ["circle", "engy_low"],
+			"ignore": ["mex", "engy_mid", "engy_high", "def_low", "pylon", "nano"],
+			"radius": 7
+		},
+		"wind": {
+			"type": ["circle", "engy_low"],
+			// Integer radius of a blocker or description string.
+			// Available string values: explosion, expl_ally
+//			"radius": "explosion",  // default: "explosion"
+			"radius": 4,
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"fusion": {
+			"type": ["circle", "engy_mid"],
+			"ignore": ["mex", "pylon", "def_low"]
+		},
+		"singu": {
+			"type": ["rectangle", "engy_high"],
+			"ignore": ["mex", "engy_low", "def_low", "pylon", "nano"]
+		},
+		"pylon": {
+			"type": ["circle", "pylon"],
+			"not_ignore": ["factory", "engy_low", "pylon", "terra"]  // default: ["all"]
+		},
+		"store": {
+			"type": ["rectangle", "mex"],
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"mex": {
+			"type": ["rectangle", "mex"],
+			"ignore": ["all"]
+		},
+		"def_low": {
+			"type": ["circle", "def_low"],
+			"radius": 10,  // 160 / (SQUARE_SIZE * 2)
+			"ignore": ["engy_mid", "engy_high", "pylon", "nano"]
+		},
+		"caretaker": {
+			"type": ["rectangle", "nano"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+		"small": {
+			"type": ["rectangle", "unknown"],
+			"not_ignore": ["factory", "def_low", "terra"]
+		},
+		"superweapon": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "pylon", "engy_high"]
+		},
+		"protector": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+//		"terraform": {
+//			"type": ["rectangle", "special"],
+//			"size": [7, 7]  // int2(3 + 4, 3 + 4)
+//		},
+		"strider": {
+			"type": ["rectangle", "special"],
+			"yard": [2, 2],
+			"ignore": ["all"]
+		},
+		"_default_": {
+			"type": ["rectangle", "unknown"],
+			"yard": [4, 4],
+			"ignore": ["pylon", "engy_high"]
+		}
+	},
+	// Water overrides land. Map considered as water if amount of land < 40%
+	"class_water" : {
+		"wind": {
+			"type": ["circle", "engy_low"],
+			"radius": 1,  // default: "explosion"
+			"ignore": ["mex", "engy_mid", "engy_high", "pylon", "nano"]
+		}
+	},
+	"instance": {
+		"fac_land": ["factorycloak", "factoryamph", "factoryhover", "factoryjump", "factoryshield", "factoryspider", "factorytank", "factoryveh"],
+		"fac_air": ["factoryplane", "factorygunship"],
+		"fac_water": ["factoryship"],
+		"fac_strider": ["striderhub"],
+		"solar": ["energysolar"],
+		"wind": ["energywind"],
+		"fusion": ["energyfusion"],
+		"singu": ["energysingu"],
+		"pylon": ["energypylon"],
+		"store": ["staticstorage"],
+		"mex": ["staticmex"],
+		"def_low": ["turretmissile", "turretlaser", "staticarty"],
+		"caretaker": ["staticcon", "staticrearm"],
+		"superweapon": ["raveparty", "staticnuke", "zenith", "turretaaheavy", "staticheavyarty", "staticantinuke", "staticheavyradar"],
+//		"protector": ["staticantinuke"],
+//		"terraform": ["terraunit"],
+		"strider": ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"small": ["staticradar"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/build_chain.json
@@ -1,0 +1,249 @@
+// Mono-space font required
+{
+"porcupine": {
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//        5              6                7             8                 9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10             11               12            13                14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		        16
+		"staticantinuke", "staticheavyradar"
+	],
+	// Actual number of defences per cluster bounded by income
+	"land":  [0, 0, 1, 3, 5, 1, 2, 14, 1, 9, 5, 6, 2, 3, 5, 0, 8, 9, 14, 1, 3, 6, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
+	"prevent": 1,  // number of preventive defences
+	"amount": {  // income bound factor
+		"offset": [-0.15, 0.4],
+		// Amount factor: 4x4 ~ 1.85, 20x20 ~ 1.45
+		"factor": [1.55, 1.30],
+		"map": [4, 20]
+	},
+
+
+	// Base defence and time to build it, in seconds
+	"base": [[0, 10], [1, 300], [0, 310], [1, 400], [6, 450], [0, 500], [16, 600], [5, 660], [1, 990], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [15, 1850]],
+
+	"superweapon": {
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "mahlazer", "staticantinuke"],  // FIXME: last aren't superweapon
+		"weight": [ 0.10,         0.20,        0.20,              0.10,     0.10,    0.10],
+
+		"condition": [16, 20000]  // [<Minimum income>, <maximum seconds to build>]
+	},
+
+	// Fallback defence
+	"default": "turretmissile"
+},
+
+// Actions on building finished event
+"build_chain": {
+	// WARNING: Avoid recursion
+	// <category>: factory, nano, store, pylon, energy, defence, bunker, big_gun, radar, sonar, mex, repair
+	"energy": {
+		// <UnitDef>: {<elements>}
+		"energysingu": {
+			// Available elements:
+			// "energy": [max energy income, <"mex"|true>]
+			// "pylon": <boolean>
+			// "porc": <boolean>
+			// "terra": <boolean>
+			// "hub": [
+			//     // chain1
+			//     [{<unit1>, <category>, <offset>, <condition>}, {<unit2>, <category>, <offset>, <condition>}, ...],
+			//     // chain2
+			//     [{...}, {...}, ...],
+			//     ...
+			// ]
+			// <unit>: UnitDef
+			// <offset>:
+			//     1) [x, z] in South facing, elmos
+			//     2) {<direction>: <delta>} - left, right, front, back
+			// <condition>: air, no_air, maybe
+
+			// Build pylon in direction of nearby mex cluster
+//			"pylon": true,
+
+			// Build chain of units
+			"hub": [
+				[  // chain1
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				],
+				[  // chain2
+					{"unit": "turretlaser", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 80}},
+					{"unit": "turretmissile", "category": "defence", "offset": [70, -70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				]
+			]
+		},
+		"energyfusion": {
+//			"pylon": true,
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, 80]}
+				]]
+		}
+	},
+	"factory": {
+		"factoryplane": {
+			"hub": [[{"unit": "staticrearm", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"factorygunship": {
+			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"striderhub": {
+			"pylon": true
+		}
+	},
+	"mex": {
+		"staticmex": {
+//			"terra": true,
+			"energy": [20, "mex"],
+			"porc": true
+		}
+	},
+	"big_gun": {
+		"staticheavyarty": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"raveparty": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"mahlazer": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"zenith": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticheavyradar": {
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]}
+				]]
+		},
+		"staticnuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"energypylon": {
+			"hub": [[
+					{"unit": "turretmissile", "category": "radar", "offset": {"back": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": {"left": 100}},
+					{"unit": "turretmissile", "category": "defence", "offset": {"back": -100}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]}
+				]]
+		},
+		"turretaaheavy": {
+			"pylon": true,
+			"hub": [
+					[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		}
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/commander.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/commander.json
@@ -1,0 +1,383 @@
+// Mono-space font required
+{
+"commander": {
+	"prefix": "dyntrainer_",
+	"suffix": "_base",
+	"unit": {
+		"support": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["builder", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "builder", "scout", "skirmish", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["scout", "builder", "scout", "riot", "raider", "raider", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.9, ["builder", "raider", "scout", "raider", "raider", "scout", "raider", "raider", "scout", "builder"]],
+						[0.1, ["builder", "raider", "raider", "scout",  "skirmish", "builder", "skirmish", "scout"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "riot"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "scout", "scout", "raider", "raider", "builder", "builder"]],
+						[0.5, ["builder", "scout", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout","builder", "scout", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["riot", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[13, 42],  // shotgun
+					[31, 42],  // Cloak, Nano
+					[15, 41, 37],  // sniper, range, health
+					[34, 34, 34],  // companion drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 34],  // battle drones, companion drones
+					[34, 34, 34],  // companion drones
+					[34, 40, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 36, 36],  // health, regen
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 27, 29],  // nano, disruptor ammo, jammer
+					[32, 33, 30],  // area cloak, lazarus, radar
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 38, 38],  // range, high density
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39]  // damage
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 360,  // seconds
+				"threat": 30,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"recon": {
+			// Choice importance, 0 by default
+			"importance": 0.65,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["builder", "raider", "riot", "raider", "raider", "raider", "raider"]]
+						],
+					"factorygunship": [
+						[0.8, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.2, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.2, ["scout", "scout", "builder", "raider", "raider", "raider", "raider", "scout"]],
+						[0.8, ["builder", "scout",  "raider", "scout", "raider", "raider", "raider", "scout", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider"]],
+						[0.5, ["builder", "raider", "raider", "scout", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider", "raider",  "raider"]],
+						[0.5, ["builder", "scout", "scout", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["builder", "scout", "scout", "raider", "builder", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "scout", "builder", "scout", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 240,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[7, 37],  // Machinegun
+					[31, 36],  // Cloak, Regen
+					[19, 38, 39],  // disruptor bomb, high density, damage boost
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 37, 37],  // speed, health
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, builder
+					[42, 42, 42],  // builder
+					[42, 42, 42],  // builder
+					[30, 27, 29],  // radar, disruptor ammo, jammer
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 41, 39],  // range, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 600,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"assault": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["anti_heavy"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.10, ["scout", "builder", "skirmish", "builder", "riot", "builder", "scout", "scout", "scout", "skirmish", "skirmish", "skirmish"]],
+						[0.15, ["scout", "scout", "builder", "riot", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "skirmish", "builder", "riot"]],
+						[0.75, ["scout", "scout", "raider", "raider", "builder", "builder", "raider", "raider", "raider", "raider", "raider", "builder", "scout"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "raider", "raider", "raider", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "heavy"]],
+						[0.25, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "raider", "raider", "raider", "builder", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "scout", "scout", "scout", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout", "builder", "assault"]],
+						[0.5, ["scout", "scout", "builder", "raider", "scout", "raider", "builder", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[11],  // shotgun
+					[24, 37],  // shield, health
+					[11, 41, 41],  // Double Riot, range
+					[38, 41, 41],  // high density, range
+					[36, 41, 36],  // regen, range, regen
+					[41, 41, 41],  // range
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39, 25],  // damage, area shield
+					[26, 29, 30],  // napalm, jammer, radar
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 36, 36],  // speed, regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 38, 38],  // health, high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 140,  // seconds
+				"threat": 70,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"strike": {
+		   // Choice importance, 0 by default
+			"importance": 0.1,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "scout", "scout", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "scout", "builder", "riot"]],
+						[0.9, ["builder", "scout",  "scout",  "raider", "raider", "raider", "raider", "raider", "builder", "builder", "scout",  "raider", "raider", "raider", "raider", "raider", "builder"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "scout", "scout", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "raider", "raider", "skirmish", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.25, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "assault"]],
+						[0.5, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "scout", "scout", "raider", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 315,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[8, 37],  // beam laser
+					[31, 36],  // cloak, regen
+					[8, 40, 36],  // lightning, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[40, 40, 40],  // speed
+					[28, 29, 30],  // flux, jammer, radar
+					[36, 36, 37],  // regen, health
+					[37, 37, 37],  // health
+					[32, 41, 41],  // area cloak, range
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 42],  // companion drones, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 39, 39],  // nano, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 480,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		}
+	}
+}
+} 

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/economy.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/economy.json
@@ -1,0 +1,69 @@
+// Mono-space font required
+{
+"economy": {
+	// Plain list of energy UnitDef and its limit. AI sorts list by efficiency (inverse)
+	// which is = cost * sizeX * sizeZ / make^2
+	// With ZK v1.8.5.2:
+	//   energysingu = 15.486420
+	//   energygeo = 65.306122
+	//   energyfusion = 80.000000
+	//   energywind = 874.999939
+	//   energysolar = 1750.000000
+	// When e-stalling AI will build bottom-most energy that didn't reach its limit.
+	// On normal AI will select top-most energy that it can build under 40 seconds.
+	"energy": {
+		// If land area >= 40% of the map then "land" config used, "water" otherwise
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>]
+			// limit = random(<lower limit>..<upper limit>)
+			"energysingu": [6],
+			"energygeo": [0, 2],
+			"energyfusion": [6, 10],
+			"energywind": [8, 12],
+			"energysolar": [40]
+		},
+		"water": {
+			"energysingu": [1],
+			"energygeo": [0],
+			"energyfusion": [4],
+			"energywind": [20],
+			"energysolar": [8, 12]
+		},
+		// income factor for energy, time is in seconds
+		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]
+		"factor": [[0.15, 1], [7.0, 3600]],
+
+		"link_inc": 16.0,  // minimum metal-income for energy linking
+		"pylon": ["energypylon", "energysolar", "energywind"]
+	},
+
+	// Scales metal income
+	// ecoFactor = teamSize*eps_step+(1-eps_step)
+	"eps_step": 0.25,
+
+	// Mobile buildpower to metal income ratio
+	"buildpower": 1.075,
+	// Metal excess to income ratio, -1 to disable
+	"excess": -1.0,
+	// Mobile constructor to static constructor metal pull ratio
+	// [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
+	//"ms_pull": [[0.75, 0.0], [0.45, 0.10], [0.53, 0.25], [0.56, 0.40], [0.63, 0.44],[0.52, 0.48],[0.66, 0.52],[0.50, 0.56],[0.66, 0.60], [0.60, 0.65], [0.7, 0.66], [0.8, 0.66], [0.9, 0.75], [0.99, 0.90]],
+	"ms_pull": [[2.0, 0.0], [0.45, 0.20], [0.99, 0.90]],
+	// Max percent of mexes circuit team allowed to take.
+	// If its <1.0 then expansion obeys ms_pull rule, if >=1.0 then ms_pull doesn't affect expansion (mex, pylon, energy).
+	// [<cap_percent>, <is_ally_cap>]
+	"mex_max": [0.15, true],  // 15%
+	// Construction order delay in seconds, -1 to disable
+	"build_delay": [[40, 600], [30, 2400]],
+
+	// New factory switch interval, in seconds (each new factory resets timer, switch event is also based on eco + caretakers)
+	// switch = random(<min_interval>..<max_interval>)
+	"switch": [800, 900],
+
+	"terra": "terraunit",
+	"airpad": "staticrearm",
+
+	// Unknown UnitDef replacer
+	"default": "turretmissile"
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/factory.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/factory.json
@@ -1,0 +1,380 @@
+// Mono-space font required
+{
+// Factory selection parameters
+"select": {
+	"air_map": 80,
+	"offset": [-20, 20],
+	// Speed factor: 8x8 ~ 0%, 24x24 ~ 40%
+	"speed": [0, 40],
+	"map": [8, 24],
+	"no_air": 3
+},
+
+// Utility param: warning on unit's total probability not equal to 100%
+"warn_probability": true,
+
+// Define factories
+"factory": {
+	"factorycloak": {
+		// Adjusts the priority of factory choice (factories with map_percent < 20 are ignored)
+		// map_percent is [20..100]
+		// On start:
+		//   if factory has available builder in current frame: priority ~= map_percent * importance0 + random(-20..+20)
+		//   if factory's builder unavailable in current frame: priority ~= map_percent * importance0 / 10 + random(-20..+20)
+		// During game: priority ~= map_percent * importance1 + random(-20..+20)
+		// importanceN = 1.0 by default if not set
+		"importance": [0.78, 0.2],
+
+		// 'require_energy' adds energy requirement for tierN (N>0): fallback to lowest tier on low energy
+		"require_energy": true,
+
+		// If income*ecoFactor < income_tier[N] then 'tierN' probability will be used
+		"income_tier": [20, 30, 40],
+
+		//             conjurer,   glaive,      scythe,           rocko,        warrior,     zeus,           hammer,      sniper,       tick,        eraser,        gremlin
+		"unit":      ["cloakcon", "cloakraid", "cloakheavyraid", "cloakskirm", "cloakriot", "cloakassault", "cloakarty", "cloaksnipe", "cloakbomb", "cloakjammer", "cloakaa"],
+
+		"land": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.03,             0.30,         0.03,        0.00,           0.00,        0.00,         0.00,        0.00,          0.00],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.20,       0.10,        0.06,             0.51,         0.10,        0.00,           0.00,        0.03,         0.00,        0.00,          0.00],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.25,       0.01,        0.20,             0.20,         0.03,        0.00,           0.00,        0.20,         0.00,        0.11,          0.00]
+
+			// 25-32m Expansions meet - Economy can afford to begin producing in bulk so unit compositions alter.
+	//		"tier3": [ 0.10,       0.40,        0.05,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 33m -40m Solid Fronts - Now we stop raiding and start pushing.
+	//		"tier4": [ 0.10,       0.35,        0.10,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 41m - 56m Mid Game - we must have 2 facs by now, stop making balanced compositions and start being abusive.
+	//		"tier5": [ 0.10,       0.05,        0.25,             0.10,         0.00,        0.20,           0.10,        0.00,         0.00,        0.10,          0.00],
+
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+	//		"tier6": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00],
+
+			// 72m - inf+ Late late Game - This fac sucks!
+	//		"tier7": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00]
+		},
+		"air": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.26,             0.00,         0.00,        0.00,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.10,       0.25,        0.11,             0.38,         0.00,        0.06,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.20,       0.10,        0.10,             0.33,         0.00,        0.12,           0.00,        0.00,         0.00,        0.05,          0.10]
+		},
+		"caretaker": 6
+	},
+
+	"factorygunship": {
+		"importance": [15.0, 1.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 85],
+		//             wasp,         blastwing,     gnat,         banshee,       rapier,         brawler,             blackdawn,        krow,          valkyrie,       vindicator,          trident
+		"unit":      ["gunshipcon", "gunshipbomb", "gunshipemp", "gunshipraid", "gunshipskirm", "gunshipheavyskirm", "gunshipassault", "gunshipkrow", "gunshiptrans", "gunshipheavytrans", "gunshipaa"],
+		"land": {
+			// 0-8m Opening - Blastwing and banshee Harass
+			"tier0": [ 0.00,         0.00,          0.00,         0.00,          0.98,           0.00,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 9-16m Early Game - Banshee with a chance of Blackdawn
+			"tier1": [ 0.00,         0.20,          0.00,         0.02,          0.45,           0.31,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 17-24m Expanding - Time to start a-makin Brawlers
+			"tier2": [ 0.00,         0.02,          0.00,         0.00,          0.04,           0.90,                0.04,             0.00,          0.00,           0.00,                0.00],
+			// 25-32m Expansions meet - Time to keep a-makin Brawlers
+			"tier3": [ 0.00,         0.05,          0.00,         0.00,          0.04,           0.83,                0.08,             0.00,          0.00,           0.00,                0.00],
+			// 33m -40m Solid Fronts - Brawlers with a chance of Krow
+			"tier4": [ 0.00,         0.04,          0.00,         0.00,          0.05,           0.80,                0.10,             0.01,          0.00,           0.00,                0.00],
+			// 41m - 56m Mid Game - Brawlers with a bigger chance of Krow
+			"tier5": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.87,                0.06,             0.02,          0.00,           0.00,                0.00],
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+			"tier6": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.84,                0.07,             0.04,          0.00,           0.00,                0.00],
+			// 72m - inf+ Late late Game - Spam Krows!
+			"tier7": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.90,                0.00,             0.05,          0.00,           0.00,                0.00]
+		},
+		"caretaker": 6
+	},
+
+	"factoryamph": {
+		"importance": [0.85, 1.0],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             conch,     duck,       archer,        buoy,          scallop,    grizzly,       djinn,      angler
+		"unit":      ["amphcon", "amphraid", "amphimpulse", "amphfloater", "amphriot", "amphassault", "amphtele", "amphaa"],
+		"land": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.53,       0.25,          0.20,          0.02,       0.00,          0.00,       0.00],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.16,          0.47,          0.22,       0.00,          0.00,       0.00],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.10,       0.09,          0.51,          0.15,       0.05,          0.00,       0.00],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.47,          0.12,       0.13,          0.00,       0.00],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.16,      0.11,       0.02,          0.52,          0.04,       0.15,          0.00,       0.00],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.20,      0.10,       0.02,          0.49,          0.02,       0.17,          0.00,       0.00],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.48,          0.02,       0.18,          0.00,       0.00],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.46,          0.02,       0.22,          0.00,       0.00]
+		},
+		"air": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.58,       0.25,          0.10,          0.02,       0.00,          0.00,       0.05],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.11,          0.47,          0.22,       0.00,          0.00,       0.05],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.11,       0.04,          0.53,          0.12,       0.05,          0.00,       0.05],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.42,          0.12,       0.13,          0.00,       0.05],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.15,      0.10,       0.02,          0.49,          0.04,       0.15,          0.00,       0.05],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.16,      0.13,       0.02,          0.45,          0.02,       0.17,          0.00,       0.05],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.43,          0.02,       0.18,          0.00,       0.05],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.41,          0.02,       0.22,          0.00,       0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryspider": {
+		"importance": [0.71, 0.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             weaver,      flea,          hermit,          venom,       redback,      recluse,       crabe,         infiltrator,       tarantula
+		"unit":      ["spidercon", "spiderscout", "spiderassault", "spideremp", "spiderriot", "spiderskirm", "spidercrabe", "spiderantiheavy", "spideraa"],
+		"land": {
+			// 0-12m Opening - Opening turbo Flea spam & Riots
+			"tier0": [ 0.00,        0.73,          0.00,            0.22,        0.05,         0.00,          0.00,          0.00,              0.00],
+			// 13-18m Early Game - Reducing Flea spam, still mostly Riots
+			"tier1": [ 0.00,        0.59,          0.00,            0.05,        0.05,         0.31,          0.00,          0.00,              0.00],
+			// 17-24m Expanding - Slant production towards Hermit & Redback
+			"tier2": [ 0.06,        0.48,          0.04,            0.05,        0.00,         0.35,          0.02,          0.00,              0.00],
+			// 25-32m Expansions meet - Slant production towards Hermit & Recluse
+			"tier3": [ 0.08,        0.45,          0.06,            0.03,        0.00,         0.33,          0.05,          0.00,              0.00],
+			// 33m -40m Solid Fronts - 	Greater Emphasis on Hermit & Crabbe
+			"tier4": [ 0.08,        0.40,          0.09,            0.03,        0.00,         0.32,          0.08,          0.00,              0.00],
+			// 41m - 56m Mid Game - We need more Crabbes
+			"tier5": [ 0.08,        0.42,          0.07,            0.02,        0.00,         0.31,          0.10,          0.00,              0.00],
+			// 57m - 72m Late Game -  MORE CRABBES
+			"tier6": [ 0.09,        0.40,          0.11,            0.00,        0.00,         0.29,          0.11,          0.00,              0.00],
+			// 72m - inf+ Late late Game - TURBO CRABBES
+			"tier7": [ 0.10,        0.35,          0.20,            0.00,        0.00,         0.22,          0.13,          0.00,              0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryveh": {
+		"importance": [0.95, 0.2],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             mason,    dart,       scorcher,  slasher,      leveler,   ravager,      dominatrix,   wolverine, impaler,        crasher
+		"unit":      ["vehcon", "vehscout", "vehraid", "vehsupport", "vehriot", "vehassault", "vehcapture", "veharty", "vehheavyarty", "vehaa"],
+		"land": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.12,       0.00,      0.00,         0.20,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.20,      0.60,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.59,         0.01,         0.00,      0.04,           0.00],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.10,       0.00,      0.00,         0.10,      0.56,         0.02,         0.00,      0.07,           0.00],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.10,       0.00,      0.00,         0.06,      0.57,         0.05,         0.00,      0.07,           0.00]
+		},
+		"air": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.10,       0.00,      0.00,         0.22,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.15,      0.65,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.05,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.05],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.56,         0.02,         0.00,      0.03,           0.05],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.56,         0.01,         0.00,      0.04,           0.03],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.15,       0.00,      0.00,         0.10,      0.46,         0.02,         0.00,      0.07,           0.05],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.05,       0.00,      0.00,         0.16,      0.47,         0.05,         0.00,      0.07,           0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryhover": {
+		"importance": [1.00, 1.1],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             quill,      dagger,      scalpel,      halberd,        claymore,           mace,        penetrator,  flail,        bolas
+		"unit":      ["hovercon", "hoverraid", "hoverskirm", "hoverassault", "hoverdepthcharge", "hoverriot", "hoverarty", "hoveraa", "hoverheavyraid"],
+		"land": {
+			// 0-8m Opening - Raiders and Riots
+			"tier0": [ 0.00,       0.55,        0.10,         0.00,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 9-16m Early Game - Mostly Mace, some support
+			"tier1": [ 0.00,       0.10,        0.44,         0.11,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 17-24m Expanding - MAXIMUM OP Scalpel time
+			"tier2": [ 0.05,       0.10,        0.43,         0.20,           0.00,               0.14,        0.08,        0.00,        0.00],
+			// 25-32m Expansions meet - Mix in some Halberds
+			"tier3": [ 0.15,       0.10,        0.26,         0.20,           0.01,               0.16,        0.12,        0.00,        0.00],
+			// 33m -40m Solid Fronts - 	More Halberd and Pene
+			"tier4": [ 0.17,       0.13,        0.19,         0.31,           0.01,               0.05,        0.14,        0.00,        0.00],
+			// 41m - 56m Mid Game - Even more Halberd and Pene
+			"tier5": [ 0.17,       0.11,        0.17,         0.30,           0.01,               0.05,        0.19,        0.00,        0.00],
+			// 57m - 72m Late Game - More Pene
+			"tier6": [ 0.20,       0.04,        0.10,         0.34,           0.01,               0.10,        0.21,        0.00,        0.00],
+			// 72m - inf+ Late late Game - MAXIMUM PENE
+			"tier7": [ 0.25,       0.02,        0.07,         0.21,           0.00,               0.10,        0.35,        0.00,        0.00]
+		},
+		"water": {
+			// 33m -40m
+			"tier4": [ 0.00,       0.49,        0.10,         0.20,           0.10,               0.10,        0.01,        0.00],
+			// 41m - inf+4
+			"tier5": [ 0.00,       0.24,        0.05,         0.41,           0.20,               0.05,        0.05,        0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryplane": {
+		"importance": [12.0, 12.1],
+		"require_energy": false,
+
+		"income_tier": [30, 60],
+		//             crane,      swift,          hawk,                raven,        phoenix,      thunderbird,    wyvern,        vulture
+		"unit":      ["planecon", "planefighter", "planeheavyfighter", "bomberprec", "bomberriot", "bomberdisarm", "bomberheavy", "planescout"],
+		"air": {
+			// 0-10m Early Game
+			"tier0": [ 0.00,       0.00,           0.75,                0.15,         0.00,         0.00,           0.05,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.00,       0.00,           0.51,                0.00,         0.02,         0.01,           0.24,          0.22]
+		},
+		"land": {
+			// 0-10m Early Game
+			"tier0": [ 0.10,       0.00,           0.00,                0.60,         0.05,         0.00,           0.20,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.10,       0.00,           0.00,                0.05,         0.00,         0.00,           0.40,          0.45]
+		},
+		"caretaker": 6
+	},
+
+	"factorytank": {
+		"importance": [0.9, 1.5],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             welder,    kodachi,    panther,         banisher,   reaper,        goliath,            pillager,   tremor,          copperhead
+		"unit":      ["tankcon", "tankraid", "tankheavyraid", "tankriot", "tankassault", "tankheavyassault", "tankarty", "tankheavyarty", "tankaa"],
+		"land": {
+			// 0-8m Opening - Koda and Banisher
+			"tier0": [ 0.10,      0.60,       0.10,            0.20,       0.00,          0.00,               0.00,       0.00,            0.00],
+			// 9-16m Early Game - Mostly Banisher
+			"tier1": [ 0.10,      0.15,       0.10,            0.23,       0.42,          0.00,               0.00,       0.00,            0.00],
+			// 17-24m Expanding - Begin mixing in Reapers!
+			"tier2": [ 0.30,      0.13,       0.07,            0.16,       0.34,          0.00,               0.00,       0.00,            0.00],
+			// 25-32m Expansions meet - More Reapers!
+			"tier3": [ 0.46,      0.15,       0.03,            0.04,       0.32,          0.00,               0.00,       0.00,            0.00],
+			// 33m -40m Solid Fronts - 	MAXIMUM REAPERS
+			"tier4": [ 0.45,      0.14,       0.00,            0.02,       0.37,          0.02,               0.00,       0.00,            0.00],
+			// 41m - 56m Mid Game - More arty & Golly
+			"tier5": [ 0.46,      0.16,       0.00,            0.02,       0.32,          0.04,               0.00,       0.00,            0.00],
+			// 57m - 72m Late Game - Even more arty & Golly
+			"tier6": [ 0.40,      0.13,       0.00,            0.02,       0.34,          0.11,               0.00,       0.00,            0.00],
+			// 72m - inf+ Late late Game - MAXIMUM GOLLY
+			"tier7": [ 0.42,      0.08,       0.00,            0.02,       0.32,          0.16,               0.00,       0.00,            0.00]
+		},
+
+		"caretaker": 15
+	},
+
+	"factoryjump": {
+		"importance": [0.73, 1.1],
+		"require_energy": false,
+
+		"income_tier": [20, 40, 60, 80],
+		//             freaker,   puppy,       pyro,       placeholder,     moderator,   jack,          sumo,       firewalker, skuttle,    archangel
+		"unit":      ["jumpcon", "jumpscout", "jumpraid", "jumpblackhole", "jumpskirm", "jumpassault", "jumpsumo", "jumparty", "jumpbomb", "jumpaa"],
+		"land": {
+			"tier0": [ 0.05,      0.24,        0.50,       0.00,            0.15,        0.06,          0.00,       0.00,       0.00,       0.00],
+			"tier1": [ 0.10,      0.20,        0.20,       0.10,            0.16,        0.24,          0.00,       0.00,       0.00,       0.00],
+			"tier2": [ 0.20,      0.20,        0.00,       0.15,            0.04,        0.31,          0.00,       0.10,       0.00,       0.00],
+			"tier3": [ 0.25,      0.15,        0.00,       0.15,            0.00,        0.33,          0.00,       0.12,       0.00,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryshield": {
+		"importance": [0.88, 0.6],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 48, 66],
+		//             convict,     dirtbag,       bandit,       rogue,         thug,            outlaw,       felon,         racketeer,    roach,        aspis,          vandal
+		"unit":      ["shieldcon", "shieldscout", "shieldraid", "shieldskirm", "shieldassault", "shieldriot", "shieldfelon", "shieldarty", "shieldbomb", "shieldshield", "shieldaa"],
+		"land": {
+			"tier0": [ 0.05,        0.05,          0.70,         0.00,          0.20,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier1": [ 0.08,        0.01,          0.10,         0.24,          0.57,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier2": [ 0.12,        0.03,          0.00,         0.20,          0.54,            0.00,         0.05,          0.00,         0.00,         0.06,           0.00],
+			"tier3": [ 0.15,        0.07,          0.00,         0.00,          0.62,            0.00,         0.08,          0.00,         0.00,         0.08,           0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryship": {
+		"importance": [5.5, 5.5],
+		"require_energy": false,
+
+		"income_tier": [30],
+		//             mariner    cutter,      hunter,           seawolf,     corsair,    mistral,     siren,         ronin,      zephyr
+		"unit":      ["shipcon", "shipscout", "shiptorpraider", "subraider", "shipriot", "shipskirm", "shipassault", "shiparty", "shipaa"],
+		"water": {
+			"tier0": [ 0.05,      0.15,        0.35,             0.10,        0.10,       0.10,        0.15,          0.00,       0.00],
+			"tier1": [ 0.05,      0.10,        0.20,             0.10,        0.05,       0.10,        0.25,          0.15,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"striderhub": {
+		"importance": [0, 1.5],
+		"require_energy": false,
+
+		"income_tier": [60, 80, 100],
+		//             ultimatum,          scorpion,          dante,          catapult,      funnelweb,          bantha,          detriment,          scylla,          reef,          battleship
+		"unit":      ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"land": {
+			"tier0": [ 0.01,               0.10,              0.81,           0.00,          0.05,               0.03,            0.00,               0.00,            0.00,          0.00],
+			"tier1": [ 0.03,               0.14,              0.22,           0.24,          0.20,               0.16,            0.01,               0.00,            0.00,          0.00],
+			"tier2": [ 0.05,               0.10,              0.16,           0.35,          0.10,               0.21,            0.03,               0.00,            0.00,          0.00],
+			"tier3": [ 0.05,               0.10,              0.01,           0.26,          0.10,               0.35,            0.13,               0.00,            0.00,          0.00]
+		},
+		"water": {
+			"tier1": [ 0.50,               0.00,              0.00,           0.00,          0.00,               0.00,            0.00,               0.00,            0.25,          0.25],
+			"tier2": [ 0.10,               0.00,              0.00,           0.00,          0.00,               0.00,            0.10,               0.00,            0.40,          0.40]
+		},
+
+		"caretaker": 100
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/response.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/response.json
@@ -1,0 +1,136 @@
+// Mono-space font required
+{
+// Build special units when enemy_metal*ratio > response_metal*eps; eps=teamSize*eps_step+(1-eps_step)
+// AA condition for 3v3: (enemy_air_metal*0.67 > (aa_metal+aa_cost)*1.12) and (aa_metal+aa_cost < army_metal*0.5)
+//
+// Probability of UnitDef for AA role depends on income tier: (tierN[UnitDef]+_weight_)*enemy_air_metal/aa_metal*importance
+// armjeth probability for tier 1: (0.00+10.00)*enemy_air_metal*600.0
+"response": {
+	"_weight_": 70.0,  // base weight of response probability, default=0.5
+
+	"assault": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "super", "missileskirm", "turtle"],
+		"ratio":      [ 0.75,   2.0,      0.00,      0.20,        0.00,    0.75,    1.5,            3.0],
+		"importance": [ 15.00,  45.00,    25.00,     75.00,       0.00,    45.00,   125.00,         50.0],
+		"max_percent": 1.00
+	},
+	"skirmish": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "anti_heavy"],
+		"ratio":      [ 1.50,   0.75,     1.00,      0.00,        0.00,    0.00],
+		"importance": [ 35.00,  25.00,    25.00,     75.00,       0.00,    0.00],
+		"max_percent": 1.00
+	},
+	"raider": {
+		"vs":         ["anti_air", "scout", "raider", "anti_heavy", "mine", "skirmish", "artillery"],
+		"ratio":      [ 0.00,       1.00,    1.0,      0.10,         0.35,   0.40,       0.8],
+		"importance": [ 15.00,      75.00,   75.00,    15.00,        60.00,  45.00,      10.00],
+		"max_percent": 1.00,
+		"eps_step": 0.75
+	},
+	"riot": {
+		"vs":         ["raider", "scout", "commander", "bullshit_raider"],
+		"ratio":      [ 0.8,      0.8,     0.33,        1.5],
+		"importance": [ 100.00,   100.00,  75.00,       125.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"missileskirm": {
+		"vs":         ["raider", "scout", "riot"],
+		"ratio":      [ 0.25,     0.5,     0.25],
+		"importance": [ 35.00,    50.00,   35.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"transport": {
+		"vs":         ["super", "support", "shieldball"],
+		"ratio":      [ 0.75,    0.75,      0.75],
+		"importance": [ 50.00,   50.00,     50.00],
+		"max_percent": 0.30,
+		"eps_step": 0.015
+	},
+	"scout": {
+		"vs":         ["mine", "artillery", "anti_air", "scout", "static", "heavy", "anti_heavy", "cloaked_raider"],
+		"ratio":      [ 0.35,   0.05,        0.10,       1.00,    0.00,     0.00,    0.05,         0.5],
+		"importance": [ 60.00,  60.0,        60.0,       35.00,   0.00,     0.00,    10.00,        100.00],
+		"max_percent": 0.09,
+		"eps_step": 0.025
+	},
+	"artillery": {
+		"vs":         ["static", "artillery", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.66,     0.00,        0.66,    0.25,         3.0],
+		"importance": [ 20.00,    0.00,        40.00,   40.00,        40.0],
+		"max_percent": 0.66,
+		"eps_step": 0.02
+	},
+	"anti_air": {
+		"vs":         ["air"],
+		"ratio":      [ 0.8],
+		"importance": [ 75.0],
+		"max_percent": 0.4,
+		"eps_step": 0.75
+	},
+	"anti_sub": {
+		"vs":         ["sub"],
+		"ratio":      [ 0.0],
+		"importance": [ 0.0],
+		"max_percent": 0.00,
+		"eps_step": 0.0
+	},
+	"anti_heavy": {
+		"vs":         ["heavy", "artillery", "support", "anti_heavy", "commander", "super", "turtle"],
+		"ratio":      [ 0.45,    0.00,        0.00,      0.00,         0.4,         0.50,    3.00],
+		"importance": [ 85.00,   0.00,        0.00,      0.00,         50.00,       85.0,    50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"disarm_target": {
+		"vs":         ["disarm_target"],
+		"ratio":      [ 0.50],
+		"importance": [ 100.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"snipe_target": {
+		"vs":         ["snipe_target", "commander"],
+		"ratio":      [ 1.00,           0.20],
+		"importance": [ 100.00,         50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"cloaked_raider": {
+		"vs":         ["snipe_target", "commander", "transport"],
+		"ratio":      [ 0.50,           0.20,        2.00],
+		"importance": [ 35.00,          35.00,       125.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"heavy": {
+		"vs":         ["heavy", "static", "support", "skirmish", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.75,    0.5,      0.00,      0.75,       0.75,    0.75,         3.00],
+		"importance": [ 75.00,   15.00,    0.00,      15.00,      75.00,   75.00,        75.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"bomber": {
+		"vs":         ["shieldball", "anti_heavy", "artillery", "super"],
+		"ratio":      [ 0.50,         0.50,         0.50,        0.50],
+		"importance": [ 0.50,         50.00,        50.00,       50.00],
+		"max_percent": 1.0,
+		"eps_step": 0.00
+	},
+	"super": {
+		"vs":         ["heavy", "static", "support", "skirmish", "artillery", "super", "turtle"],
+		"ratio":      [ 0.3,     0.55,     0.00,      0.00,       0.00,        0.00,    0.5],
+		"importance": [ 45.00,   25.00,    0.00,      0.00,       0.00,        0.00,    45.00],
+		"max_percent": 0.2,
+		"eps_step": 0.00
+	},
+	"support": {
+		"vs":         ["assault", "bullshit_raider"],
+		"ratio":      [ 1.00,      0.4],
+		"importance": [ 35.00,     75.00],
+		"max_percent": 0.25,
+		"eps_step": 0.00
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/behaviour.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/behaviour.json
@@ -1,0 +1,1128 @@
+// Mono-space font required
+{
+"quota": {
+	"scout": 1,  // max scout units out of raiders
+	"raid": [7.0, 42.0],  // [<min>, <avg>] power of raider squad
+	"attack": 20.0,  // min power of attack group
+	"thr_mod": {
+		"attack": [0.45, 0.45],  // [<min>, <max>] enemy threat modifier for target selection of attack task
+		"defence": [0.80, 0.80],  // [<min>, <max>] enemy threat modifier for group size calculation of defence task
+		"mobile": 1.075,  // initial modifier for power of attack group based on mobile enemy threat
+		"static": 4.25,  // initial modifier for power of attack group based on static enemy threat
+		"comm": 0.75
+	},
+	"aa_threat": 80.0,  // anti-air threat threshold, air factories will stop production when AA threat exceeds
+	"slack_mod": {
+		"all": 0.5,  // threat map 64-elmos slack multiplier for all units
+		"static": 1.5,  // additional 64-elmo-cells for static units
+		"speed": [0.75, 4.0]  // [<64elmo_cells_speed_mod>, <max_64elmo_cells>]
+	}
+},
+
+// If unit's health drops below specified percent it will retreat
+"retreat": {
+	"builder": [0.70, 1.0],  // [<default>, <UnitDef modifier>] for all builders
+	"fighter": [0.45, 1.0],  // [<default>, <UnitDef modifier>] for all not-builder units
+	"shield": [0.25, 0.275]  // [<empty>, <full>] shield power
+},
+
+"defence": {
+	"infl_rad": 4,  // influenece cell radius for defendAlly map
+	"base_rad": [1000.0, 2000.0],  // defend if enemy within clamp(distance(lane_pos, base_pos), 1000, 2000) radius
+	"comm_rad": [1000.0, 500.0]  // 0 distance from base ~ 1000, base_rad ~ 500.0
+},
+
+
+"behaviour": {
+	// factorycloak
+	"cloakcon": {
+		// "role": [<main>, <enemy>, <enemy>, ...]
+		// <main> is the role to make desicions of when to build it and what task to assign
+		// <enemy> is to decide how to counter enemy unit, if missing then equals to <main>
+		// Roles: builder, scout, raider, riot, assault, skirmish, artillery, anti_air, anti_sub, anti_heavy, bomber, support, mine, transport, air, sub, static, heavy, super, commander
+		// Auto-assigned roles: builder, air, static, super, commander
+		"role": ["builder", "mine"]
+
+		// Attributes - optinal states
+		// "melee" - always move close to target, disregard attack range
+		// "boost" - boost speed on retreat
+		// "no_jump" - disable jump on retreat
+		// "no_strafe" - disable gunship's strafe
+		// "stockpile" - load weapon before any task, auto-assigned
+		// "siege" - mostly use fight command instead of move
+		// "ret_hold" - hold fire on retreat
+		// "ret_fight" - fight on retreat
+		// "jump" - enable jump on regular move
+		// "dg_cost" - DGun by metal cost instead of by threat
+		// "anti_stat" - only static targets
+		// "no_dgun" - do not use DGun
+//		"attribute": ["boost", "no_strafe"],
+
+		// Fire state (open by default)
+		// "hold" - hold fire
+		// "return" - return fire
+		// "open" - fire at will
+//		"fire_state": "open",
+
+		// Overrides reloadTime in seconds
+//		"reload": 1.0,
+
+		// Limits number of units
+//		"limit": 10,
+
+		// Unit can be built only since specific time in seconds
+//		"since": 60,
+
+		// Minimum hp percent before retreat
+//		"retreat": 0.8,
+
+		// Ally threat multiplier
+//		"pwr_mod": 1.0,
+		// Enemy threat multiplier
+//		"thr_mod": 1.0,
+
+		// Ignore enemy
+//		"ignore": false
+	},
+	"cloakraid": {
+		"role": ["raider", "scout"],
+		"attribute": ["scout"],
+		"retreat": 0.1,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.75
+	},
+	"cloakheavyraid": {
+		"role": ["cloaked_raider", "raider"],
+		"attribute": ["ret_fight"],
+		"since": 180,
+		"limit": 3,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.1,
+		"retreat": 0.4
+	},
+	"cloakskirm": {
+		"role": ["skirmish"],
+		"attribute": ["ret_fight"],
+		"pwr_mod": 0.85,
+		"since": 180,
+		"limit": 20,
+		"retreat": 0.35  // mostly disposable
+	},
+	"cloakriot": {
+		"role": ["riot", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"since": 180,
+		"retreat": 0.55,
+		"pwr_mod": 1.4,
+		"thr_mod": 2.3
+	},
+	"cloakassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.35,  // assaults need to assault
+		"since": 240,
+		"pwr_mod": 0.7,
+		"thr_mod": 1.1
+	},
+	"cloakarty": {
+		"role": ["artillery"],
+		"since": 550,
+		"limit": 8,
+		"retreat": 0.9,
+		"thr_mod": 0.0
+	},
+	"cloaksnipe": {
+		"role": ["snipe_target"],
+		"attribute": ["support"],
+		"pwr_mod": 3.0,
+		"since": 520,
+		"thr_mod": 0.0,
+		"retreat": 0.69
+	},
+	"cloakbomb": {
+		"role": ["mine"],
+		"retreat": 0.01
+	},
+	"cloakjammer": {
+		"role": ["assault"],
+		"since": 480,
+		"retreat": 0.5,
+		"limit": 1
+	},
+	"cloakaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factorygunship
+	"gunshipcon": {
+		"role": ["builder", "air"],
+		"limit": 2,
+		"since": 240,
+		"retreat": 0.99
+	},
+	"gunshipbomb": {
+		"role": ["scout", "air"],  // "bomber"
+		"attribute": ["melee"],
+		"limit": 1,
+		"thr_mod": 1.0,
+		"retreat": 0.01
+	},
+	"gunshipemp": {
+		"role": ["anti_heavy", "air"],
+		"thr_mod": 0.1,
+		"pwr_mod": 0.1,
+		"since": 600,
+		"limit": 6,
+		"retreat": 0.9
+	},
+	"gunshipskirm": {
+		"role": ["air", "bullshit_raider"],
+		"retreat": 0.65,
+		"pwr_mod": 0.7,
+		"limit": 8,
+		"thr_mod": 0.66
+	},
+	"gunshipraid": {
+		"role": ["scout", "air"],
+		"retreat": 0.7,
+		"limit": 1,
+		"pwr_mod": 1.25,
+		"thr_mod": 1.1
+	},
+	"gunshipheavyskirm": {
+		"role": ["assault", "air"],
+		"since": 330,
+		"attribute": ["no_strafe"],
+		"retreat": 0.65,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.00
+	},
+	"gunshipassault": {
+		"role": ["anti_heavy", "air"],
+		"limit": 3,
+		"since": 330,
+		"retreat": 0.5,
+		"pwr_mod": 1.65,
+		"thr_mod": 1.00
+	},
+	"gunshipkrow": {
+		"role": ["anti_heavy", "air", "disarm_target"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"since": 720,
+		"pwr_mod": 0.3,
+		"thr_mod": 0.3,
+		"limit": 0
+	},
+	"gunshiptrans": {
+		"role": ["air"],
+		"limit": 0
+	},
+	"gunshipheavytrans": {
+		"role": ["air"],
+		"limit": 0,
+		"thr_mod": 0.0
+	},
+	"gunshipaa": {
+		"role": ["anti_air", "air"],
+		"limit": 6,
+		"retreat": 0.95,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryamph
+	"amphcon": {
+		"role": ["builder", "mine"]
+	},
+	"amphraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"limit": 10,
+		"retreat": 0.25  // pretty disposable
+	},
+	"amphimpulse": {
+		"role": ["riot"],
+		"limit": 1,
+		"retreat": 0.36,
+		"pwr_mod": 2.25,
+		"thr_mod": 2.25
+	},
+	"amphfloater": {
+		"role": ["assault", "snipe_target", "super"],
+		"limit": 14,
+		"since": 120,
+		"retreat": 0.25, // too slow to be retreating all the time
+		"pwr_mod": 1.3,
+		"thr_mod": 1.3
+	},
+	"amphriot": {
+		"role": ["riot"],
+		"attribute": ["melee", "ret_fight"],
+		"pwr_mod": 1.5,
+		"retreat": 0.35 // too slow to be retreating all the time
+	},
+	"amphassault": {
+		"role": ["heavy", "disarm_target"],
+		"retreat": 0.66,
+		"since": 520,
+		"pwr_mod": 1.4,
+		"thr_mod": 1.0
+	},
+	"amphtele": {
+		"role": ["transport"],
+		"limit": 0
+	},
+	"amphaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight", "support"],
+		"retreat": 0.3,
+		"limit": 5,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.5
+	},
+
+	// factoryspider
+	"spidercon": {
+		"role": ["builder", "mine"]
+	},
+	"spiderscout": {
+		"role": ["scout", "raider"],
+		"thr_mod": 0.5,
+		"limit": 20,
+		"retreat": 0.01
+	},
+	"spiderassault": {
+		"role": ["assault", "anti_sub"],
+		"attribute": ["melee", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.15,
+		"retreat": 0.35
+	},
+	"spideremp": {
+		"role": ["raider", "riot"],
+		"pwr_mod": 3.0,
+		"limit": 1,
+		"retreat": 0.5
+	},
+	"spiderriot": {
+		"role": ["riot"],
+		"pwr_mod": 2.0,
+		"limit": 4,
+		"attribute": ["support"],
+		"retreat": 0.35
+	},
+	"spiderskirm": {
+		"role": ["skirmish", "snipe_target", "super"],
+		"pwr_mod": 2.0,
+		"thr_mod": 1.0,
+		"since": 180,
+		"retreat": 0.4
+	},
+	"spidercrabe": {
+		"role": ["heavy", "disarm_target", "turtle"],
+		"attribute": ["siege", "ret_fight", "support"],
+		"retreat": 0.5,
+		"thr_mod": 2.5,
+		"pwr_mod": 2.5,
+		"since": 300,
+		"thr_mod": 1.0
+	},
+	"spiderantiheavy": {
+		"role": ["anti_heavy", "mine"],
+		"retreat": 0.99,
+		"pwr_mod": 2.0,
+		"thr_mod": 0.1,
+		"since": 600,
+		"limit": 1
+	},
+	"spideraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryshield
+	"shieldcon": {
+		"role": ["builder", "shieldball", "mine"],
+		"retreat": 1.3
+	},
+	"shieldscout": {
+		"role": ["transport", "raider"],
+		"limit": 20,
+		"attribute": ["siege", "melee"],
+		"pwr_mod": 0.11,
+		"thr_mod": 0.1,
+		"retreat": 0.0
+	},
+	"shieldraid": {
+		"role": ["raider"],
+		"attribute": ["scout", "ret_fight"],
+		"retreat": 0.25,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.9
+	},
+	"shieldskirm": {
+		"role": ["skirmish"],
+		"limit": 15,
+		"since": 200,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.66,
+		"retreat": 0.3
+	},
+	"shieldassault": {
+		"role": ["assault", "support", "shieldball"],
+		"attribute": ["melee"],
+		"limit": 20,
+		"retreat": 0.3,
+		"since": 120,
+		"pwr_mod": 0.7,
+		"thr_mod": 0.35
+	},
+	"shieldriot": {
+		"role": ["riot", "shieldball"],
+		"fire_state": "hold",
+		"since": 100,
+		"limit": 5,
+		"retreat": 0.3,
+		"pwr_mod": 1.7,
+		"thr_mod": 1.7
+	},
+	"shieldfelon": {
+		"role": ["heavy", "shieldball", "snipe_target"],
+		"since": 420,
+		"retreat": 0.35,
+		"pwr_mod": 1.1,
+		"thr_mod": 1.1
+	},
+	"shieldarty": {
+		"role": ["disarm_target"],
+		"since": 300,
+		"retreat": 0.3,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"shieldbomb": {
+		"role": ["mine"]
+	},
+	"shieldshield": {
+		"role": ["super", "heavy", "shieldball"],
+		"since": 540,
+		"attribute": ["support"],
+		"retreat": 0.36,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.25
+	},
+	"shieldaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryveh
+	"vehcon": {
+		"role": ["builder", "mine"]
+	},
+	"vehscout": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"thr_mod": 0.6,
+		"pwr_mod": 1.2,
+		"retreat": 0.01,
+		"limit": 4
+	},
+	"vehraid": {
+		"role": ["raider"],
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.3,
+		"pwr_mod": 1.1,
+		"thr_mod": 0.8
+	},
+	"vehsupport": {
+		"role": ["artillery", "missileskirm"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 4,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.4,
+		"retreat": 0.6  // cannot retreat
+	},
+	"vehriot": {
+		"role": ["riot"],
+		"retreat": 0.6,
+		"pwr_mod": 1.5,
+		"thr_mod": 1.5
+	},
+	"vehassault": {
+		"role": ["assault"],
+		"attribute": ["melee"],
+		"retreat": 0.4,  // slow to turn around
+		"since": 180,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9
+	},
+	"vehcapture": {
+		"role": ["support", "disarm_target", "snipe_target"],
+		"since": 180,
+		"pwr_mod": 1,
+		"thr_mod": 1,
+		"retreat": 0.8
+	},
+	"veharty": {
+		"role": ["transport", "super"],
+		"attribute": ["siege", "ret_fight"],
+		"limit": 15,
+		"since": 460,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0,
+		"retreat": 0.8
+	},
+	"vehheavyarty": {
+		"role": ["artillery", "heavy", "turtle"],
+		"since": 300,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.00
+	},
+	"vehaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.75,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryjump
+	"jumpcon": {
+		"role": ["builder", "mine"]
+	},
+	"jumpscout": {
+		"role": ["riot", "raider"],
+		"limit": 15,
+		"attribute": ["melee", "siege"],
+		"retreat": 0
+	},
+	"jumpraid": {
+		"role": ["raider", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.4,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.9
+	},
+	"jumpblackhole": {
+		"role": ["support"],
+		"since": 300,
+		"limit": 6,
+		"retreat": 0.36
+	},
+	"jumpskirm": {
+		"role": ["skirmish", "super", "snipe_target"],
+		"retreat": 0.4
+	},
+	"jumpassault": {
+		"role": ["assault", "anti_sub", "disarm_target"],
+		"attribute": ["melee", "siege", "ret_fight"],
+		"retreat": 0.4,
+		"pwr_mod": 1.3,
+		"thr_mod": 0.5
+	},
+	"jumpsumo": {
+		"role": ["heavy", "support", "disarm_target"],
+		"limit": 0,
+		"attribute": ["melee", "no_jump"]  // jump on attack
+	},
+	"jumparty": {
+		"role": ["heavy", "turtle", "snipe_target"],
+		"attribute": ["support"],
+		"since": 600,
+		"pwr_mod": 0.1,
+		"limit": 2,
+		"thr_mod": 0.00,
+		"retreat": 0.99
+	},
+	"jumpbomb": {
+		"role": ["anti_heavy", "builder"],
+		"attribute": ["melee", "mine"],
+		"fire_state": "open",
+		"since": 720,
+		"limit": 2,
+		"retreat": 0.01,
+		"pwr_mod": 3.0,
+		"thr_mod": 0.01
+	},
+	"jumpaa": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryhover
+	"hovercon": {
+		"role": ["builder", "mine"]
+	},
+	"hoverraid": {
+		"role": ["scout"],
+		"attribute": ["melee"],		
+		"pwr_mod": 0.9,
+		"thr_mod": 0.8,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.9,
+		"limit": 4,
+		"retreat": 0.5
+	},
+	"hoverheavyraid": {
+		"role": ["raider", "bullshit_raider"],	
+		"retreat": 0.35,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.8
+	},
+	"hoverskirm": {
+		"role": ["skirmish", "support"],
+		"retreat": 0.55,
+		"limit": 12,
+		"reload": 4.0,
+		"pwr_mod": 0.9,
+		"thr_mod": 0.6
+	},
+	"hoverassault": {
+		"role": ["assault", "raider"],
+		"attribute": ["melee", "ret_hold"],
+		"retreat": 0.4,
+		"limit": 12,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.45
+	},
+	"hoverdepthcharge": {
+		"role": ["anti_sub", "riot"],
+		"attribute": ["melee"],
+		"retreat": 0.6
+	},
+	"hoverriot": {
+		"role": ["riot", "snipe_target"],
+		"retreat": 0.4,
+		"pwr_mod": 1.00,
+		"thr_mod": 1.25
+	},
+	"hoverarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"attribute": ["siege"],
+		"retreat": 0.99,
+		"pwr_mod": 1.5,
+		"thr_mod": 0.0
+	},
+	"hoveraa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.7,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryplane
+	"planecon": {
+		"role": ["builder", "air"],
+		"since": 240,
+		"limit": 2,
+		"retreat": 0.99
+	},
+	"planefighter": {
+		"role": ["scout", "air"],
+		"attribute": ["boost"],
+		"pwr_mod": 1.5,
+		"limit": 1,
+		"thr_mod": 3.0,
+		"retreat": 0.8
+	},
+	"planeheavyfighter": {
+		"role": ["anti_air"],
+		"attribute": ["melee"],
+		"limit": 8,
+		"retreat": 0.4,
+		"pwr_mod": 2.5,
+		"thr_mod": 3.0
+	},
+	"bomberprec": {
+		"role": ["bomber", "air"],  // FIXME: should act as anti_heavy?
+		"attribute": ["siege"],
+		"limit": 10,
+		"retreat": 0.8,
+		"pwr_mod": 0.10,
+		"thr_mod": 0.01
+	},
+	"bomberriot": {
+		"role": ["bomber", "air"],
+		"limit": 0,
+		"retreat": 0.6,
+		"pwr_mod": 0.01,
+		"thr_mod": 0.01
+	},
+	"bomberdisarm": {
+		"role": ["anti_heavy", "air"],
+		"attribute": ["siege", "bomber"],
+		"limit": 2,
+		"since": 1200,
+		"retreat": 0.85,
+		"pwr_mod": 100.00,
+		"thr_mod": 0.01
+	},
+	"bomberheavy": {
+		"role": ["bomber", "air"],
+		"fire_state": "return",
+		"limit": 4,
+		"since": 420,
+		"retreat": 0.65,
+		"pwr_mod": 0.75,
+		"thr_mod": 0.1
+	},
+	"bomberassault": {
+		"role": ["bomber", "air"],
+		"attribute": ["anti_stat", "no_dgun"],
+		"fire_state": "hold",
+		"limit": 1,
+		"since": 1800,
+		"retreat": 0.65,
+		"pwr_mod": 1.25,
+		"thr_mod": 0.01
+	},
+	"planescout": {
+		"role": ["scout", "air"],
+		"since": 360,
+		"limit": 2,
+		"retreat": 0.8
+	},
+
+	// factorytank
+	"tankcon": {
+		"role": ["builder"],
+		"pwr_mod": 0.40,
+		"thr_mod": 0.40,
+		"retreat": 0.9
+	},
+	"tankraid": {
+		"role": ["scout"],
+		"attribute": ["scout"],
+		"limit": 2,
+		"thr_mod": 0.66,
+		"pwr_mod": 0.8,
+		"retreat": 0.45
+	},
+	"tankheavyraid": {
+		"role": ["raider", "bullshit_raider"],
+		"thr_mod": 0.6,
+		"pwr_mod": 0.65,
+		"retreat": 0.65
+	},
+	"tankriot": {
+		"role": ["riot", "heavy", "snipe_target"],
+		"thr_mod": 1.25,
+		"pwr_mod": 0.75,
+		"retreat": 0.55
+	},
+	"tankassault": {
+		"role": ["assault", "heavy", "anti_sub"],
+		"attribute": ["melee"],
+		"retreat": 0.55,
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7
+	},
+	"tankheavyassault": {
+		"role": ["heavy", "disarm_target", "super"],
+		"attribute": ["melee"],
+		"pwr_mod": 0.85,
+		"thr_mod": 0.7,
+		"since": 480,
+		"retreat": 0.55
+	},
+	"tankarty": {
+		"role": ["artillery", "snipe_target", "heavy"],
+		"attribute": ["support"],
+		"since": 1000,
+		"retreat": 0.99,
+		"pwr_mod": 1.0,
+		"thr_mod": 0.0
+	},
+	"tankheavyarty": {
+		"role": ["transport"],
+		"attribute": ["support"],
+		"since": 1000,
+		"limit": 1,
+		"retreat": 0.99,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.0
+	},
+	"tankaa": {
+		"role": ["anti_air"],
+		"attribute": ["ret_fight"],
+		"retreat": 0.8,
+		"pwr_mod": 3.0,
+		"thr_mod": 1.2
+	},
+
+	// factoryship
+	"shipcon": {
+		"role": ["builder"]
+	},
+	"shipscout": {
+		"role": ["scout"]
+	},
+	"shiptorpraider": {
+		"role": ["raider"]
+	},
+	"subraider": {
+		"role": ["raider"]
+	},
+	"shipriot": {
+		"role": ["riot"]
+	},
+	"shipskirm": {
+		"role": ["skirmish"]
+	},
+	"shipassault": {
+		"role": ["assault"]
+	},
+	"shiparty": {
+		"role": ["artillery"]
+	},
+	"shipaa": {
+		"role": ["anti_air"]
+	},
+
+	// striderhub
+	"striderantiheavy": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"pwr_mod": 0.5,
+		"attribute": ["melee", "ret_fight"],
+		"retreat": 0.35
+	},
+	"striderscorpion": {
+		"role": ["anti_heavy", "heavy"],
+		"limit": 1,
+		"fire_state": "return",
+		"attribute": ["ret_fight"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"since": 1800,
+		"thr_mod": 0.5
+	},
+	"striderdante": {
+		"role": ["heavy", "disarm_target", "snipe_target"],
+		"attribute": ["melee"],
+		"limit": 2,
+		"retreat": 0.45,
+		"pwr_mod": 0.8,
+		"thr_mod": 0.75
+	},
+	"striderarty": {
+		"role": ["anti_heavy", "heavy", "snipe_target"],
+		"pwr_mod": 5.0,
+		"thr_mod": 0.0,
+		"retreat": 0.9
+	},
+	"striderfunnelweb": {
+		"role": ["heavy", "turtle", "shieldball"],
+		"attribute": ["support"],
+		"retreat": 1.4,
+		"pwr_mod": 1.0,
+		"limit": 1,
+		"since": 3000,
+		"thr_mod": 0.0
+	},
+	"striderbantha": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.6,
+		"pwr_mod": 0.5,
+		"thr_mod": 0.5
+	},
+	"striderdetriment": {
+		"role": ["heavy", "support", "heavy"],
+		"attribute": ["melee"],
+		"retreat": 0.50,  // deffo retreat, running into nab annihlator farm and sploding is silly :)
+		"pwr_mod": 0.34,
+		"thr_mod": 0.34
+	},
+	"subtacmissile": {
+		"role": ["artillery", "heavy"],
+		"attribute": ["stockpile"]
+	},
+	"shipcarrier": {
+		"role": ["artillery", "heavy"]
+	},
+	"shipheavyarty": {
+		"role": ["artillery", "heavy"]
+	},
+
+	// statics
+	"staticnuke": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 30.0,
+		"limit": 1,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"staticmissilesilo": {
+		"role": ["static", "support", "heavy"],
+		"thr_mod": 0.01
+	},
+	"raveparty": {
+		"role": ["static", "heavy"],
+		"limit": 1,
+		"since": 1200,
+		"thr_mod": 0.01
+	},
+	"zenith": {
+		"role": ["static", "heavy"],
+		"fire_state": "hold",  // burst attacks
+		"reload": 105.0,  // 105sec / 0.7sec/met = 150 meteorsControlled
+		"limit": 1,
+		"since": 900,
+		"thr_mod": 0.01
+	},
+	"staticheavyarty": {
+		"role": ["artillery", "turtle", "heavy"],
+		"limit": 5,
+		"thr_mod": 0.0,
+		"pwr_mod": 10.00
+	},
+	"turretheavy": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 1.00
+	},
+	"turretantiheavy": {
+		"role": ["static", "turtle", "static"],
+		"thr_mod": 0.55
+	},
+	"staticarty": {
+		"role": ["static", "snipe_target", "turtle"],
+		"thr_mod": 0.55
+	},
+	"staticantinuke": {
+		"role": ["static", "heavy", "support"],
+		"since": 720,
+		"limit": 1
+	},
+	"turretheavylaser": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.0
+	},
+	"energysingu": {
+		"role": ["static", "turtle", "heavy"],
+		"attribute": ["support"],  // build at home
+		"since": 660
+	},
+	"energyfusion": {
+		"role": ["static", "mine", "heavy"],
+		"attribute": ["support"],  // build at home
+		"since": 280
+	},
+	"turretaalaser": {
+		"role": ["anti_air"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.0
+	},
+	"turretaaheavy": {
+		"role": ["anti_air", "heavy", "turtle"],
+		"limit": 1,
+		"thr_mod": 1.0
+	},
+	"turretlaser": {
+		"role": ["static", "riot", "builder"],
+		"thr_mod": 1.5
+	},
+	"turretmissile": {
+		"role": ["missileskirm", "riot", "builder"],
+		"thr_mod": 0.34
+	},
+	"turretriot": {
+		"role": ["static", "riot", "snipe_target"],
+		"thr_mod": 1.65
+	},
+	"turretaafar": {
+		"role": ["anti_air", "heavy", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaflak": {
+		"role": ["anti_air", "turtle"],
+
+		"thr_mod": 1.0
+	},
+	"turretaaclose": {
+		"role": ["anti_air"],
+		"thr_mod": 1.0
+	},
+	"turretgauss": {
+		"role": ["static", "turtle", "transport"],
+		"attribute": ["siege", "ret_hold"],
+		"retreat": 0.4,  // FIXME: Bunker up turret when it's on low health, doesn't work for statics atm
+		"thr_mod": 1.6
+	},
+	"turretemp": {
+		"role": ["static", "heavy", "snipe_target"],
+		"thr_mod": 2.5
+	},
+
+	// support factories won't be built in front
+	"factoryplane": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"factorygunship": {
+		"role": ["static"],
+		"attribute": ["support"]
+	},
+	"striderhub": {
+		"role": ["static"],
+		"since": 900,
+		"attribute": ["support"]
+	},
+
+	// Enemy Eco!! //
+	"staticmex": {
+		"role": ["mine"]
+	},
+	"energywind": {
+		"role": ["mine"]
+	},
+	"staticradar": {
+		"role": ["mine"]
+	},
+	"staticcon": {
+		"role": ["mine"]
+	},
+	"energypylon": {
+		"role": ["mine"]
+	},
+	"staticheavyradar": {
+		"role": ["mine", "turtle"],
+		"limit": 1
+	},
+	"staticstorage": {
+		"role": ["mine", "turtle"],
+		"limit": 5
+	},
+	"energysolar": {
+		"role": ["mine"]
+	},
+	"staticshield": {
+		"role": ["static", "turtle"]
+	},
+
+	// Chickens!! //
+	"dronecarry": {
+		"role": ["transport"]
+	},
+	"chicken": {
+		"role": ["raider"]
+	},
+	"chicken_blimpy": {
+		"role": ["mine"]
+	},
+	"chicken_digger": {
+		"role": ["riot"]
+	},
+	"chicken_dodo": {
+		"role": ["mine"]
+	},
+	"chicken_dragon": {
+		"role": ["heavy"],
+		"thr_mod": 0.4
+	},
+	"chicken_drone": {
+		"role": ["raider"]
+	},
+	"chicken_drone_starter": {
+		"role": ["raider"]
+	},
+	"chicken_leaper": {
+		"role": ["raider"]
+	},
+	"chicken_listener": {
+		"role": ["static"]
+	},
+	"chicken_pigeon": {
+		"role": ["air"]
+	},
+	"chicken_roc": {
+		"role": ["air"]
+	},
+	"chicken_shield": {
+		"role": ["support"]
+	},
+	"chicken_spidermonkey": {
+		"role": ["anti_air"]
+	},
+	"chicken_tiamat": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenblobber": {
+		"role": ["artillery"]
+	},
+	"chickenbroodqueen": {
+		"role": ["heavy"],
+		"thr_mod": 0.05
+	},
+	"chickenflyerqueen": {
+		"role": ["air"],
+		"thr_mod": 0.05
+	},
+	"chickenlandqueen": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenspire": {
+		"role": ["static"]
+	},
+	"chickena": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenc": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickend": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenf": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenr": {
+		"role": ["raider"],
+		"thr_mod": 0.05
+	},
+	"chickenwurm": {
+		"role": ["heavy"]
+	},
+
+	"tacnuke": {
+		"role": ["super"]
+	},
+	"seismic": {
+		"role": ["super"]
+	},
+	"empmissile": {
+		"role": ["super"]
+	},
+	"napalmmissile": {
+		"role": ["super"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/block_map.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/block_map.json
@@ -1,0 +1,139 @@
+// Mono-space font required
+{
+"building": {
+	"class_land": {
+		"fac_land": {
+			// "type": [<blocker_shape>, <structure_type>]
+			// Available blocker_shape: rectangle, circle.
+			// Available structure_type: factory, mex, engy_low, engy_mid, engy_high, pylon, def_low, def_mid, def_high, special, nano, terra, unknown
+			"type": ["rectangle", "factory"],
+
+			// Unit of measurement: 1 size/yard/radius = SQUARE_SIZE * 2 = 16 elmos, integer.
+			// Offset in South facing
+			"offset": [0, 6],  // default: [0, 0]
+
+			// Size of a blocker without yard
+//			"size": [7, 7],  // default: size of a unit
+
+			// Spacer, blocker_size = size + yard
+			"yard": [12, 12]  // default: [0, 0]
+
+			// "ignore": [<structure_type>, <structure_type>, ...]
+			// Ignore specified structures.
+			// Additional values: none, all
+//			"ignore": ["none"]  // default: ["none"]
+		},
+		"fac_air": {
+			"type": ["rectangle", "factory"],
+			"yard": [8, 8]
+		},
+		"fac_water": {
+			"type": ["rectangle", "factory"],
+			"offset": [0, 4],
+			"yard": [10, 12]
+		},
+		"fac_strider": {
+			"type": ["rectangle", "special"],
+			"offset": [0, 12],
+			"yard": [16, 16]
+		},
+		"solar": {
+			"type": ["circle", "engy_low"],
+			"ignore": ["mex", "engy_mid", "engy_high", "def_low", "pylon", "nano"],
+			"radius": 7
+		},
+		"wind": {
+			"type": ["circle", "engy_low"],
+			// Integer radius of a blocker or description string.
+			// Available string values: explosion, expl_ally
+//			"radius": "explosion",  // default: "explosion"
+			"radius": 4,
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"fusion": {
+			"type": ["circle", "engy_mid"],
+			"ignore": ["mex", "pylon", "def_low"]
+		},
+		"singu": {
+			"type": ["circle", "engy_high"],
+			"radius": "expl_ally",  // [radius ~ 1 player .. radius/2 ~ 4+ players]
+			"ignore": ["mex", "engy_low", "def_low", "pylon", "nano"]
+		},
+		"pylon": {
+			"type": ["circle", "pylon"],
+			"not_ignore": ["factory", "engy_low", "pylon", "terra"]  // default: ["all"]
+		},
+		"store": {
+			"type": ["rectangle", "mex"],
+			"not_ignore": ["factory", "engy_low", "terra"]
+		},
+		"mex": {
+			"type": ["rectangle", "mex"],
+			"ignore": ["all"]
+		},
+		"def_low": {
+			"type": ["circle", "def_low"],
+			"radius": 10,  // 160 / (SQUARE_SIZE * 2)
+			"ignore": ["engy_mid", "engy_high", "pylon", "nano"]
+		},
+		"caretaker": {
+			"type": ["rectangle", "nano"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+		"small": {
+			"type": ["rectangle", "unknown"],
+			"not_ignore": ["factory", "def_low", "terra"]
+		},
+		"superweapon": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "pylon", "engy_high"]
+		},
+		"protector": {
+			"type": ["circle", "special"],
+			"ignore": ["mex", "def_low", "engy_mid", "pylon", "engy_high"]
+		},
+//		"terraform": {
+//			"type": ["rectangle", "special"],
+//			"size": [7, 7]  // int2(3 + 4, 3 + 4)
+//		},
+		"strider": {
+			"type": ["rectangle", "special"],
+			"yard": [2, 2],
+			"ignore": ["all"]
+		},
+		"_default_": {
+			"type": ["rectangle", "unknown"],
+			"yard": [4, 4],
+			"ignore": ["pylon", "engy_high"]
+		}
+	},
+	// Water overrides land. Map considered as water if amount of land < 40%
+	"class_water" : {
+		"wind": {
+			"type": ["circle", "engy_low"],
+			"radius": 1,  // default: "explosion"
+			"ignore": ["mex", "engy_mid", "engy_high", "pylon", "nano"]
+		}
+	},
+	"instance": {
+		"fac_land": ["factorycloak", "factoryamph", "factoryhover", "factoryjump", "factoryshield", "factoryspider", "factorytank", "factoryveh"],
+		"fac_air": ["factoryplane", "factorygunship"],
+		"fac_water": ["factoryship"],
+		"fac_strider": ["striderhub"],
+		"solar": ["energysolar"],
+		"wind": ["energywind"],
+		"fusion": ["energyfusion"],
+		"singu": ["energysingu"],
+		"pylon": ["energypylon"],
+		"store": ["staticstorage"],
+		"mex": ["staticmex"],
+		"def_low": ["turretmissile", "turretlaser", "staticarty"],
+		"caretaker": ["staticcon", "staticrearm"],
+		"superweapon": ["raveparty", "staticnuke", "zenith", "turretaaheavy", "staticheavyarty", "staticantinuke", "staticheavyradar"],
+//		"protector": ["staticantinuke"],
+//		"terraform": ["terraunit"],
+		"strider": ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"small": ["staticradar"]
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/build_chain.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/build_chain.json
@@ -1,0 +1,240 @@
+// Mono-space font required
+{
+"porcupine": {
+	//        0              1                2             3                   4
+	"unit": ["turretlaser", "turretmissile", "turretriot", "turretheavylaser", "turrettorp",
+	//        5              6                7             8                 9
+		"turretaalaser", "staticcon", "turretheavy", "staticshield", "turretemp",
+	//       10             11               12            13                14
+		"turretantiheavy", "staticarty", "turretaafar", "turretaaheavy", "turretgauss",
+	//       15		        16
+		"staticantinuke", "staticheavyradar"
+	],
+	// Actual number of defences per cluster bounded by income
+	"land":  [0, 0, 1, 3, 5, 1, 2, 14, 1, 9, 5, 6, 2, 3, 5, 0, 8, 9, 14, 1, 3, 6, 16, 12, 11, 13],
+	"water": [4, 1, 6, 4, 4, 3, 5, 9, 16],
+	"prevent": 1,  // number of preventive defences
+	"amount": {  // income bound factor
+		"offset": [-0.15, 0.4],
+		// Amount factor: 4x4 ~ 1.85, 20x20 ~ 1.45
+		"factor": [1.55, 1.30],
+		"map": [4, 20]
+	},
+
+
+	// Base defence and time to build it, in seconds
+	"base": [[0, 10], [1, 300], [0, 310], [1, 400], [6, 450], [0, 500], [16, 600], [5, 660], [1, 990], [5, 1160], [1, 1380], [2, 1680], [13, 1800], [15, 1850]],
+
+	"superweapon": {
+		"unit":   ["raveparty", "staticnuke", "staticheavyarty", "zenith", "mahlazer", "staticantinuke"],  // FIXME: last aren't superweapon
+		"weight": [ 0.10,         0.20,        0.20,              0.10,     0.10,    0.10],
+
+		"condition": [16, 20000]  // [<Minimum income>, <maximum seconds to build>]
+	},
+
+	// Fallback defence
+	"default": "turretmissile"
+},
+
+// Actions on building finished event
+"build_chain": {
+	// WARNING: Avoid recursion
+	// <category>: factory, nano, store, pylon, energy, defence, bunker, big_gun, radar, sonar, mex, repair
+	"energy": {
+		// <UnitDef>: {<elements>}
+		"energysingu": {
+			// Available elements:
+			// "energy": [max energy income, <"mex"|true>]
+			// "pylon": <boolean>
+			// "porc": <boolean>
+			// "terra": <boolean>
+			// "hub": [
+			//     // chain1
+			//     [{<unit1>, <category>, <offset>, <condition>}, {<unit2>, <category>, <offset>, <condition>}, ...],
+			//     // chain2
+			//     [{...}, {...}, ...],
+			//     ...
+			// ]
+			// <unit>: UnitDef
+			// <offset>:
+			//     1) [x, z] in South facing, elmos
+			//     2) {<direction>: <delta>} - left, right, front, back
+			// <condition>: air, no_air, maybe
+
+			// Build pylon in direction of nearby mex cluster
+//			"pylon": true,
+
+			// Build chain of units
+			"hub": [
+				[  // chain1
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-70, 70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				],
+				[  // chain2
+					{"unit": "turretlaser", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 80}},
+					{"unit": "turretmissile", "category": "defence", "offset": [70, -70]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretaafar", "category": "defence", "offset": {"front": 120}, "condition": "air"},
+					{"unit": "turretaaflak", "category": "defence", "offset": {"front": 120}, "condition": "no_air"}
+				]
+			]
+		},
+		"energyfusion": {
+//			"pylon": true,
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, 80]}
+				]]
+		}
+	},
+	"factory": {
+		"factoryplane": {
+			"hub": [[{"unit": "staticrearm", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"factorygunship": {
+			"hub": [[{"unit": "staticcon", "category": "nano", "offset": {"front": 150}}]]
+		},
+		"striderhub": {
+			"pylon": true
+		}
+	},
+	"mex": {
+		"staticmex": {
+//			"terra": true,
+			"energy": [20, "mex"],
+			"porc": true
+		}
+	},
+	"big_gun": {
+		"staticheavyarty": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"raveparty": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"mahlazer": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"zenith": {
+			"hub": [[
+					{"unit": "energypylon", "category": "defence", "offset": [250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, 250]},
+					{"unit": "energypylon", "category": "defence", "offset": [-250, -250]},
+					{"unit": "energypylon", "category": "defence", "offset": [250, 250]},
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "staticshield", "category": "defence", "offset": [-10, -10]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [-80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticheavyradar": {
+			"hub": [[
+					{"unit": "turretlaser", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, 80]}
+				]]
+		},
+		"staticnuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretaafar", "category": "defence", "offset": {"left": 120}, "condition": "air"},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"staticantinuke": {
+			"hub": [[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"left": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"back": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"right": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": {"front": 40}},
+					{"unit": "turretemp", "category": "defence", "offset": {"front": 60}},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "turretlaser", "category": "defence", "offset": {"back": 40}},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"left": 60}},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretemp", "category": "defence", "offset": {"right": 60}},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		},
+		"turretaaheavy": {
+			"pylon": true,
+			"hub": [
+					[
+					{"unit": "staticradar", "category": "radar", "offset": {"back": 40}},
+					{"unit": "turretlaser", "category": "defence", "offset": [-80, 80]},
+					{"unit": "turretmissile", "category": "defence", "offset": [80, 80]},
+					{"unit": "turretriot", "category": "defence", "offset": [80, -80]},
+					{"unit": "staticshield", "category": "defence", "offset": [10, 10]},
+					{"unit": "staticstorage", "category": "defence", "offset": [-10, -10]},
+					{"unit": "turretmissile", "category": "defence", "offset": [-80, -80]}
+				]]
+		}
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/commander.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/commander.json
@@ -1,0 +1,383 @@
+// Mono-space font required
+{
+"commander": {
+	"prefix": "dyntrainer_",
+	"suffix": "_base",
+	"unit": {
+		"support": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["builder", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "builder", "scout", "skirmish", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["scout", "builder", "scout", "riot", "raider", "raider", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.9, ["builder", "raider", "scout", "raider", "raider", "scout", "raider", "raider", "scout", "builder"]],
+						[0.1, ["builder", "raider", "raider", "scout",  "skirmish", "builder", "skirmish", "scout"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "riot"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "builder", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "scout", "scout", "raider", "raider", "builder", "builder"]],
+						[0.5, ["builder", "scout", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout","builder", "scout", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["riot", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[13, 42],  // shotgun
+					[31, 42],  // Cloak, Nano
+					[15, 41, 37],  // sniper, range, health
+					[34, 34, 34],  // companion drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 35],  // battle drones
+					[35, 35, 34],  // battle drones, companion drones
+					[34, 34, 34],  // companion drones
+					[34, 40, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 36, 36],  // health, regen
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 27, 29],  // nano, disruptor ammo, jammer
+					[32, 33, 30],  // area cloak, lazarus, radar
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 38, 38],  // range, high density
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39]  // damage
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 360,  // seconds
+				"threat": 30,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"recon": {
+			// Choice importance, 0 by default
+			"importance": 0.65,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "raider", "raider", "raider"]],
+						[0.1, ["builder", "raider", "riot", "raider", "raider", "raider", "raider"]]
+						],
+					"factorygunship": [
+						[0.8, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.2, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.1, ["builder", "riot", "raider", "raider", "raider", "raider", "raider"]],
+						[0.9, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "riot"]]
+					],
+					"factoryveh": [
+						[0.2, ["scout", "scout", "builder", "raider", "raider", "raider", "raider", "scout"]],
+						[0.8, ["builder", "scout",  "raider", "scout", "raider", "raider", "raider", "scout", "raider", "raider"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider"]],
+						[0.5, ["builder", "raider", "raider", "scout", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["builder", "scout", "scout", "raider", "raider",  "raider"]],
+						[0.5, ["builder", "scout", "scout", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["builder", "scout", "scout", "raider", "builder", "scout", "raider"]],
+						[0.5, ["builder", "scout", "scout", "scout", "builder", "scout", "raider", "scout", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 240,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[7, 37],  // Machinegun
+					[31, 36],  // Cloak, Regen
+					[19, 38, 39],  // disruptor bomb, high density, damage boost
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 37, 37],  // speed, health
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[36, 36, 36],  // regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, builder
+					[42, 42, 42],  // builder
+					[42, 42, 42],  // builder
+					[30, 27, 29],  // radar, disruptor ammo, jammer
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[41, 41, 39],  // range, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 600,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"assault": {
+			// Choice importance, 0 by default
+			"importance": 0.25,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["raider", "builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["anti_heavy"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.10, ["scout", "builder", "skirmish", "builder", "riot", "builder", "scout", "scout", "scout", "skirmish", "skirmish", "skirmish"]],
+						[0.15, ["scout", "scout", "builder", "riot", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "skirmish", "builder", "riot"]],
+						[0.75, ["scout", "scout", "raider", "raider", "builder", "builder", "raider", "raider", "raider", "raider", "raider", "builder", "scout"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "raider", "raider", "raider", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.5, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "heavy"]],
+						[0.25, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["scout", "scout", "scout", "builder", "scout", "raider", "raider", "raider", "builder", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "scout", "scout", "scout", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "raider", "scout", "builder", "assault"]],
+						[0.5, ["scout", "scout", "builder", "raider", "scout", "raider", "builder", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 420,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[11],  // shotgun
+					[24, 37],  // shield, health
+					[11, 41, 41],  // Double Riot, range
+					[38, 41, 41],  // high density, range
+					[36, 41, 36],  // regen, range, regen
+					[41, 41, 41],  // range
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[39, 39, 25],  // damage, area shield
+					[26, 29, 30],  // napalm, jammer, radar
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 40],  // companion drones, speed
+					[40, 40, 40],  // speed
+					[40, 40, 40],  // speed
+					[40, 36, 36],  // speed, regen
+					[36, 36, 36],  // regen
+					[36, 42, 42],  // regen, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[37, 37, 37],  // health
+					[37, 37, 37],  // health
+					[37, 38, 38],  // health, high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 140,  // seconds
+				"threat": 70,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		},
+		"strike": {
+		   // Choice importance, 0 by default
+			"importance": 0.1,
+
+			// Starting units (order matters)
+			"start": {
+				"factory": {
+					"factorycloak": [
+						// [<weight>, [<role>, <role>, ...]]
+						[0.8, ["raider", "raider", "builder", "raider", "raider", "builder", "raider", "raider", "raider", "raider"]],
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider"]]
+					],
+					"factorygunship": [
+						[0.5, ["support", "support", "support", "support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]],
+						[0.5, ["scout", "support", "builder","support", "skirmish", "skirmish", "support", "skirmish", "skirmish"]]
+					],
+					"factoryamph": [
+						[0.2, ["builder", "riot", "builder", "raider", "raider", "raider", "raider", "raider"]],
+						[0.8, ["builder", "raider", "raider", "raider", "raider", "raider", "builder", "builder", "riot", "raider", "builder", "raider"]]
+					],
+					"factoryveh": [
+						[0.1, ["scout", "scout", "scout", "builder", "skirmish", "builder", "skirmish", "skirmish", "skirmish", "scout", "builder", "riot"]],
+						[0.9, ["builder", "scout",  "scout",  "raider", "raider", "raider", "raider", "raider", "builder", "builder", "scout",  "raider", "raider", "raider", "raider", "raider", "builder"]]
+					],
+					"factoryhover": [
+						[0.5, ["builder", "scout", "scout", "scout", "raider", "builder", "raider", "raider", "raider", "raider", "raider", "builder"]],
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder", "scout", "raider", "raider", "skirmish", "builder", "skirmish", "skirmish"]]
+					],
+					"factoryplane": [
+						[0.5, ["anti_air", "builder", "anti_air", "anti_air"]],
+						[0.5, ["anti_air", "builder", "anti_air", "builder"]]
+					],
+					"factorytank": [
+						[0.25, ["riot", "builder", "assault", "builder", "assault", "builder", "builder", "assault"]],
+						[0.5, ["raider", "builder", "raider", "builder", "raider", "raider", "raider", "builder", "assault"]],
+						[0.25, ["builder", "riot", "builder", "riot", "assault", "builder", "assault"]]
+					],
+					"factoryspider": [
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "riot", "scout", "builder", "scout", "riot", "scout", "builder"]],
+						[0.5, ["builder", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "scout", "builder", "riot", "scout", "builder", "support"]]
+					],
+					"factoryshield": [
+						[0.5, ["builder", "scout", "raider", "raider", "raider", "builder"]],
+						[0.5, ["scout", "builder", "raider", "raider", "builder", "raider", "raider", "raider"]]
+					],
+					"factoryjump": [
+						[0.5, ["scout", "scout", "scout", "scout", "raider", "raider"]],
+						[0.5, ["scout", "scout", "scout", "scout", "builder", "raider", "raider"]]
+					]
+				},
+				"default": ["raider", "raider", "builder"]
+			},
+
+			// Morph params
+			"upgrade": {
+				"time": 315,  // Force-morph delay, in seconds
+				"module": [  // List of dynamic module IDs
+					[8, 37],  // beam laser
+					[31, 36],  // cloak, regen
+					[8, 40, 36],  // lightning, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[37, 40, 36],  // health, speed, regen
+					[40, 40, 40],  // speed
+					[28, 29, 30],  // flux, jammer, radar
+					[36, 36, 37],  // regen, health
+					[37, 37, 37],  // health
+					[32, 41, 41],  // area cloak, range
+					[41, 41, 41],  // range
+					[41, 41, 41],  // range
+					[34, 34, 34],  // companion drones
+					[34, 34, 34],  // companion drones
+					[34, 34, 42],  // companion drones, nano
+					[42, 42, 42],  // nano
+					[42, 42, 42],  // nano
+					[42, 39, 39],  // nano, damage
+					[39, 39, 39],  // damage
+					[39, 39, 39],  // damage
+					[38, 38, 38],  // high density
+					[38, 38, 38],  // high density
+					[38, 38]  // high density
+				]
+			},
+
+			// Commander hides if ("time" elapsed) and ("threat" exceeds value or enemy has "air")
+			"hide": {
+				"time": 480,  // seconds
+				"threat": 50,
+				"air": true,
+				"task_rad": 2000.0
+			}
+		}
+	}
+}
+} 

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/economy.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/economy.json
@@ -1,0 +1,69 @@
+// Mono-space font required
+{
+"economy": {
+	// Plain list of energy UnitDef and its limit. AI sorts list by efficiency (inverse)
+	// which is = cost * sizeX * sizeZ / make^2
+	// With ZK v1.8.5.2:
+	//   energysingu = 15.486420
+	//   energygeo = 65.306122
+	//   energyfusion = 80.000000
+	//   energywind = 874.999939
+	//   energysolar = 1750.000000
+	// When e-stalling AI will build bottom-most energy that didn't reach its limit.
+	// On normal AI will select top-most energy that it can build under 40 seconds.
+	"energy": {
+		// If land area >= 40% of the map then "land" config used, "water" otherwise
+		"land": {
+			// "<energy_def>": [<lower limit>, <upper limit>]
+			// limit = random(<lower limit>..<upper limit>)
+			"energysingu": [6],
+			"energyfusion": [6, 10],
+			"energysolar": [10, 20]
+		},
+		"water": {
+			"energysingu": [1],
+			"energyfusion": [4],
+			"energywind": [20]
+		},
+		// income factor for energy, time is in seconds
+		// [[<start_factor>, <start_time>], [<end_factor>, <end_time>]]
+		"factor": [[0.15, 1], [7.0, 3600]],
+
+		"link_inc": 16.0,  // minimum metal-income for energy linking
+		"pylon": ["energypylon", "energysolar", "energywind"]
+	},
+
+	// Scales metal income
+	// ecoFactor = teamSize*eps_step+(1-eps_step)
+	"eps_step": 0.2,
+
+	// Mobile buildpower to metal income ratio
+	"buildpower": 1.25,
+
+	// Metal excess to income ratio, -1 to disable
+	"excess": -1.0,
+
+	// Mobile constructor to static constructor metal pull ratio
+	// [[<value>, <start_mex_percent>], [<value>, <end_mex_percent>]]
+	"ms_pull": [[2.0, 0.0], [0.45, 0.20], [0.99, 0.90]],
+
+	// Max percent of mexes circuit team allowed to take.
+	// If its <1.0 then expansion obeys ms_pull rule, if >=1.0 then ms_pull doesn't affect expansion (mex, pylon, energy).
+	// [<cap_percent>, <is_ally_cap>]
+	"mex_max": [2.0, false],  // 200%
+
+	// Construction order delay in seconds, -1 to disable
+	// [[<start_delay>, <start_time>], [<end_delay>, <end_time>]]
+	"build_delay": [[-1.0, 0], [-1.0, 0]],
+
+	// New factory switch interval, in seconds (each new factory resets timer, switch event is also based on eco + caretakers)
+	// switch = random(<min_interval>..<max_interval>)
+	"switch": [800, 900],
+
+	"terra": "terraunit",
+	"airpad": "staticrearm",
+
+	// Unknown UnitDef replacer
+	"default": "turretmissile"
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/factory.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/factory.json
@@ -1,0 +1,393 @@
+// Mono-space font required
+{
+// Factory selection parameters
+"select": {
+	"air_map": 80,
+	"offset": [-20, 20],
+	// Speed factor: 8x8 ~ 0%, 24x24 ~ 40%
+	"speed": [0, 40],
+	"map": [8, 24],
+	"no_air": 3
+},
+
+// Utility param: warning on unit's total probability not equal to 100%
+"warn_probability": true,
+
+// Define factories
+"factory": {
+	"factorycloak": {
+		// Adjusts the priority of factory choice (factories with map_percent < 20 are ignored)
+		// map_percent is [20..100]
+		// On start:
+		//   if factory has available builder in current frame: priority ~= map_percent * importance0 + random(-20..+20)
+		//   if factory's builder unavailable in current frame: priority ~= map_percent * importance0 / 10 + random(-20..+20)
+		// During game: priority ~= map_percent * importance1 + random(-20..+20)
+		// importanceN = 1.0 by default if not set
+		"importance": [0.78, 0.2],
+
+		// 'require_energy' adds energy requirement for tierN (N>0): fallback to lowest tier on low energy
+		"require_energy": true,
+
+		// If income*ecoFactor < income_tier[N] then 'tierN' probability will be used
+		"income_tier": [20, 30, 40],
+
+		//             conjurer,   glaive,      scythe,           rocko,        warrior,     zeus,           hammer,      sniper,       tick,        eraser,        gremlin
+		"unit":      ["cloakcon", "cloakraid", "cloakheavyraid", "cloakskirm", "cloakriot", "cloakassault", "cloakarty", "cloaksnipe", "cloakbomb", "cloakjammer", "cloakaa"],
+
+		"land": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.03,             0.30,         0.03,        0.00,           0.00,        0.00,         0.00,        0.00,          0.00],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.20,       0.10,        0.06,             0.51,         0.10,        0.00,           0.00,        0.03,         0.00,        0.00,          0.00],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.25,       0.01,        0.20,             0.20,         0.03,        0.00,           0.00,        0.20,         0.00,        0.11,          0.00]
+
+			// 25-32m Expansions meet - Economy can afford to begin producing in bulk so unit compositions alter.
+	//		"tier3": [ 0.10,       0.40,        0.05,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 33m -40m Solid Fronts - Now we stop raiding and start pushing.
+	//		"tier4": [ 0.10,       0.35,        0.10,             0.30,         0.00,        0.10,           0.00,        0.00,         0.00,        0.05,          0.00],
+
+			// 41m - 56m Mid Game - we must have 2 facs by now, stop making balanced compositions and start being abusive.
+	//		"tier5": [ 0.10,       0.05,        0.25,             0.10,         0.00,        0.20,           0.10,        0.00,         0.00,        0.10,          0.00],
+
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+	//		"tier6": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00],
+
+			// 72m - inf+ Late late Game - This fac sucks!
+	//		"tier7": [ 0.10,       0.00,        0.65,             0.00,         0.00,        0.00,           0.00,        0.15,         0.00,        0.10,          0.00]
+		},
+		"air": {
+			// 0-8m Opening - Glaives & Warriors most important for scouting, map control and defence.
+			"tier0": [ 0.10,       0.54,        0.26,             0.00,         0.00,        0.00,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 9-16m Early Game - Map control still important but move towards Scythe raiding and Riot defense from raider balls.
+			"tier1": [ 0.10,       0.25,        0.11,             0.38,         0.00,        0.06,           0.00,        0.00,         0.00,        0.00,          0.10],
+
+			// 17-24m Expanding - Good size terriotiry now, so less scouting and begin producing a little assault/arty on the side.
+			"tier2": [ 0.20,       0.10,        0.10,             0.33,         0.00,        0.12,           0.00,        0.00,         0.00,        0.05,          0.10]
+		},
+		"caretaker": 6
+	},
+
+	"factorygunship": {
+		"importance": [15.0, 1.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 85],
+		//             wasp,         blastwing,     gnat,         banshee,       rapier,         brawler,             blackdawn,        krow,          valkyrie,       vindicator,          trident
+		"unit":      ["gunshipcon", "gunshipbomb", "gunshipemp", "gunshipraid", "gunshipskirm", "gunshipheavyskirm", "gunshipassault", "gunshipkrow", "gunshiptrans", "gunshipheavytrans", "gunshipaa"],
+		"land": {
+			// 0-8m Opening - Blastwing and banshee Harass
+			"tier0": [ 0.00,         0.00,          0.00,         0.00,          0.98,           0.00,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 9-16m Early Game - Banshee with a chance of Blackdawn
+			"tier1": [ 0.00,         0.20,          0.00,         0.02,          0.45,           0.31,                0.02,             0.00,          0.00,           0.00,                0.00],
+			// 17-24m Expanding - Time to start a-makin Brawlers
+			"tier2": [ 0.00,         0.02,          0.00,         0.00,          0.04,           0.90,                0.04,             0.00,          0.00,           0.00,                0.00],
+			// 25-32m Expansions meet - Time to keep a-makin Brawlers
+			"tier3": [ 0.00,         0.05,          0.00,         0.00,          0.04,           0.83,                0.08,             0.00,          0.00,           0.00,                0.00],
+			// 33m -40m Solid Fronts - Brawlers with a chance of Krow
+			"tier4": [ 0.00,         0.04,          0.00,         0.00,          0.05,           0.80,                0.10,             0.01,          0.00,           0.00,                0.00],
+			// 41m - 56m Mid Game - Brawlers with a bigger chance of Krow
+			"tier5": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.87,                0.06,             0.02,          0.00,           0.00,                0.00],
+			// 57m - 72m Late Game - we must have 2 facs & Striders by now, go nuts!
+			"tier6": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.84,                0.07,             0.04,          0.00,           0.00,                0.00],
+			// 72m - inf+ Late late Game - Spam Krows!
+			"tier7": [ 0.00,         0.05,          0.00,         0.00,          0.00,           0.90,                0.00,             0.05,          0.00,           0.00,                0.00]
+		},
+		"caretaker": 6
+	},
+
+	"factoryamph": {
+		"importance": [0.85, 1.0],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             conch,     duck,       archer,        buoy,          scallop,    grizzly,       djinn,      angler
+		"unit":      ["amphcon", "amphraid", "amphimpulse", "amphfloater", "amphriot", "amphassault", "amphtele", "amphaa"],
+		"land": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.53,       0.25,          0.20,          0.02,       0.00,          0.00,       0.00],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.16,          0.47,          0.22,       0.00,          0.00,       0.00],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.10,       0.09,          0.51,          0.15,       0.05,          0.00,       0.00],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.47,          0.12,       0.13,          0.00,       0.00],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.16,      0.11,       0.02,          0.52,          0.04,       0.15,          0.00,       0.00],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.20,      0.10,       0.02,          0.49,          0.02,       0.17,          0.00,       0.00],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.48,          0.02,       0.18,          0.00,       0.00],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.46,          0.02,       0.22,          0.00,       0.00]
+		},
+		"air": {
+			// 0-8m Opening - Ducks and Archers
+			"tier0": [ 0.00,      0.58,       0.25,          0.10,          0.02,       0.00,          0.00,       0.05],
+			// 9-16m Early Game - Still mostly Ducks, Ducks are amazing
+			"tier1": [ 0.05,      0.10,       0.11,          0.47,          0.22,       0.00,          0.00,       0.05],
+			// 17-24m Expanding - Less Ducks, more Scallop/Bouy
+			"tier2": [ 0.10,      0.11,       0.04,          0.53,          0.12,       0.05,          0.00,       0.05],
+			// 25-32m Expansions meet - Time to start producing Bouy
+			"tier3": [ 0.15,      0.11,       0.02,          0.42,          0.12,       0.13,          0.00,       0.05],
+			// 33m -40m Solid Fronts - Time to start producing even more Bouy
+			"tier4": [ 0.15,      0.10,       0.02,          0.49,          0.04,       0.15,          0.00,       0.05],
+			// 41m - 56m Mid Game - Switch to Grizzly
+			"tier5": [ 0.16,      0.13,       0.02,          0.45,          0.02,       0.17,          0.00,       0.05],
+			// 57m - 72m Late Game -  MORE Grizzly
+			"tier6": [ 0.20,      0.10,       0.02,          0.43,          0.02,       0.18,          0.00,       0.05],
+			// 72m - inf+ Late late Game - SPAM GRIZZLY
+			"tier7": [ 0.20,      0.08,       0.02,          0.41,          0.02,       0.22,          0.00,       0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryspider": {
+		"importance": [0.71, 0.7],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             weaver,      flea,          hermit,          venom,       redback,      recluse,       crabe,         infiltrator,       tarantula
+		"unit":      ["spidercon", "spiderscout", "spiderassault", "spideremp", "spiderriot", "spiderskirm", "spidercrabe", "spiderantiheavy", "spideraa"],
+		"land": {
+			// 0-12m Opening - Opening turbo Flea spam & Riots
+			"tier0": [ 0.00,        0.73,          0.00,            0.22,        0.05,         0.00,          0.00,          0.00,              0.00],
+			// 13-18m Early Game - Reducing Flea spam, still mostly Riots
+			"tier1": [ 0.00,        0.59,          0.00,            0.05,        0.05,         0.31,          0.00,          0.00,              0.00],
+			// 17-24m Expanding - Slant production towards Hermit & Redback
+			"tier2": [ 0.06,        0.48,          0.04,            0.05,        0.00,         0.35,          0.02,          0.00,              0.00],
+			// 25-32m Expansions meet - Slant production towards Hermit & Recluse
+			"tier3": [ 0.08,        0.45,          0.06,            0.03,        0.00,         0.33,          0.05,          0.00,              0.00],
+			// 33m -40m Solid Fronts - 	Greater Emphasis on Hermit & Crabbe
+			"tier4": [ 0.08,        0.40,          0.09,            0.03,        0.00,         0.32,          0.08,          0.00,              0.00],
+			// 41m - 56m Mid Game - We need more Crabbes
+			"tier5": [ 0.08,        0.42,          0.07,            0.02,        0.00,         0.31,          0.10,          0.00,              0.00],
+			// 57m - 72m Late Game -  MORE CRABBES
+			"tier6": [ 0.09,        0.40,          0.11,            0.00,        0.00,         0.29,          0.11,          0.00,              0.00],
+			// 72m - inf+ Late late Game - TURBO CRABBES
+			"tier7": [ 0.10,        0.35,          0.20,            0.00,        0.00,         0.22,          0.13,          0.00,              0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryveh": {
+		"importance": [0.95, 0.2],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             mason,    dart,       scorcher,  slasher,      leveler,   ravager,      dominatrix,   wolverine, impaler,        crasher
+		"unit":      ["vehcon", "vehscout", "vehraid", "vehsupport", "vehriot", "vehassault", "vehcapture", "veharty", "vehheavyarty", "vehaa"],
+		"land": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.12,       0.00,      0.00,         0.20,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.20,      0.60,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.00],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.59,         0.01,         0.00,      0.04,           0.00],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.10,       0.00,      0.00,         0.10,      0.56,         0.02,         0.00,      0.07,           0.00],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.10,       0.00,      0.00,         0.06,      0.57,         0.05,         0.00,      0.07,           0.00]
+		},
+		"air": {
+			// 0-8m Opening - Dart, Riot & Slasher
+			"tier0": [ 0.00,     0.33,       0.55,      0.12,         0.00,      0.00,         0.00,         0.00,      0.00,           0.00],
+			// 9-16m Early Game - Slasher/Riot with an occasional Ravager
+			"tier1": [ 0.05,     0.10,       0.00,      0.00,         0.22,      0.61,         0.00,         0.00,      0.02,           0.00],
+			// 17-24m Expanding - Less scouting and Riot, more Ravager
+			"tier2": [ 0.05,     0.10,       0.00,      0.00,         0.15,      0.65,         0.02,         0.00,      0.03,           0.00],
+			// 25-32m Expansions meet - Begin serious Ravager production
+			"tier3": [ 0.05,     0.10,       0.00,      0.00,         0.14,      0.61,         0.02,         0.00,      0.03,           0.05],
+			// 33m -40m Solid Fronts - 	Overdrive Ravager production
+			"tier4": [ 0.10,     0.10,       0.00,      0.00,         0.14,      0.56,         0.02,         0.00,      0.03,           0.05],
+			// 41m - 56m Mid Game - Drop Slashers, more Artillery
+			"tier5": [ 0.10,     0.10,       0.00,      0.00,         0.16,      0.56,         0.01,         0.00,      0.04,           0.03],
+			// 57m - 72m Late Game -  More artillery and Ravager
+			"tier6": [ 0.15,     0.15,       0.00,      0.00,         0.10,      0.46,         0.02,         0.00,      0.07,           0.05],
+			// 72m - inf+ Late late Game - Maximum Artillery
+			"tier7": [ 0.15,     0.05,       0.00,      0.00,         0.16,      0.47,         0.05,         0.00,      0.07,           0.05]
+		},
+		"caretaker": 6
+	},
+
+	"factoryhover": {
+		"importance": [1.00, 1.1],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             quill,      dagger,      scalpel,      halberd,        claymore,           mace,        penetrator,  flail,        bolas
+		"unit":      ["hovercon", "hoverraid", "hoverskirm", "hoverassault", "hoverdepthcharge", "hoverriot", "hoverarty", "hoveraa", "hoverheavyraid"],
+		"land": {
+			// 0-8m Opening - Raiders and Riots
+			"tier0": [ 0.00,       0.55,        0.10,         0.00,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 9-16m Early Game - Mostly Mace, some support
+			"tier1": [ 0.00,       0.10,        0.44,         0.11,           0.00,               0.35,        0.00,        0.00,        0.00],
+			// 17-24m Expanding - MAXIMUM OP Scalpel time
+			"tier2": [ 0.05,       0.10,        0.43,         0.20,           0.00,               0.14,        0.08,        0.00,        0.00],
+			// 25-32m Expansions meet - Mix in some Halberds
+			"tier3": [ 0.15,       0.10,        0.26,         0.20,           0.01,               0.16,        0.12,        0.00,        0.00],
+			// 33m -40m Solid Fronts - 	More Halberd and Pene
+			"tier4": [ 0.17,       0.13,        0.19,         0.31,           0.01,               0.05,        0.14,        0.00,        0.00],
+			// 41m - 56m Mid Game - Even more Halberd and Pene
+			"tier5": [ 0.17,       0.11,        0.17,         0.30,           0.01,               0.05,        0.19,        0.00,        0.00],
+			// 57m - 72m Late Game - More Pene
+			"tier6": [ 0.20,       0.04,        0.10,         0.34,           0.01,               0.10,        0.21,        0.00,        0.00],
+			// 72m - inf+ Late late Game - MAXIMUM PENE
+			"tier7": [ 0.25,       0.02,        0.07,         0.21,           0.00,               0.10,        0.35,        0.00,        0.00]
+		},
+		"water": {
+			// 33m -40m
+			"tier4": [ 0.00,       0.49,        0.10,         0.20,           0.10,               0.10,        0.01,        0.00],
+			// 41m - inf+4
+			"tier5": [ 0.00,       0.24,        0.05,         0.41,           0.20,               0.05,        0.05,        0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryplane": {
+		"importance": [12.0, 12.1],
+		"require_energy": false,
+
+		"income_tier": [30, 60],
+		//             crane,      swift,          hawk,                raven,        phoenix,      thunderbird,    wyvern,        vulture
+		"unit":      ["planecon", "planefighter", "planeheavyfighter", "bomberprec", "bomberriot", "bomberdisarm", "bomberheavy", "planescout"],
+		"air": {
+			// 0-10m Early Game
+			"tier0": [ 0.00,       0.00,           0.75,                0.15,         0.00,         0.00,           0.05,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.00,       0.00,           0.51,                0.00,         0.02,         0.01,           0.24,          0.22]
+		},
+		"land": {
+			// 0-10m Early Game
+			"tier0": [ 0.10,       0.00,           0.00,                0.60,         0.05,         0.00,           0.20,          0.05],
+			// 11-20m Expansion
+			"tier1": [ 0.10,       0.00,           0.00,                0.05,         0.00,         0.00,           0.40,          0.45]
+		},
+		"caretaker": 6
+	},
+
+	"factorytank": {
+		"importance": [0.9, 1.5],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 32, 40, 56, 72, 100],
+		//             welder,    kodachi,    panther,         banisher,   reaper,        goliath,            pillager,   tremor,          copperhead
+		"unit":      ["tankcon", "tankraid", "tankheavyraid", "tankriot", "tankassault", "tankheavyassault", "tankarty", "tankheavyarty", "tankaa"],
+		"land": {
+			// 0-8m Opening - Koda and Banisher
+			"tier0": [ 0.10,      0.60,       0.10,            0.20,       0.00,          0.00,               0.00,       0.00,            0.00],
+			// 9-16m Early Game - Mostly Banisher
+			"tier1": [ 0.10,      0.15,       0.10,            0.23,       0.42,          0.00,               0.00,       0.00,            0.00],
+			// 17-24m Expanding - Begin mixing in Reapers!
+			"tier2": [ 0.30,      0.13,       0.07,            0.16,       0.34,          0.00,               0.00,       0.00,            0.00],
+			// 25-32m Expansions meet - More Reapers!
+			"tier3": [ 0.46,      0.15,       0.03,            0.04,       0.32,          0.00,               0.00,       0.00,            0.00],
+			// 33m -40m Solid Fronts - 	MAXIMUM REAPERS
+			"tier4": [ 0.45,      0.14,       0.00,            0.02,       0.37,          0.02,               0.00,       0.00,            0.00],
+			// 41m - 56m Mid Game - More arty & Golly
+			"tier5": [ 0.46,      0.16,       0.00,            0.02,       0.32,          0.04,               0.00,       0.00,            0.00],
+			// 57m - 72m Late Game - Even more arty & Golly
+			"tier6": [ 0.40,      0.13,       0.00,            0.02,       0.34,          0.11,               0.00,       0.00,            0.00],
+			// 72m - inf+ Late late Game - MAXIMUM GOLLY
+			"tier7": [ 0.42,      0.08,       0.00,            0.02,       0.32,          0.16,               0.00,       0.00,            0.00]
+		},
+
+		"caretaker": 15
+	},
+
+	"factoryjump": {
+		"importance": [0.73, 1.1],
+		"require_energy": false,
+
+		"income_tier": [20, 40, 60, 80],
+		//             freaker,   puppy,       pyro,       placeholder,     moderator,   jack,          sumo,       firewalker, skuttle,    archangel
+		"unit":      ["jumpcon", "jumpscout", "jumpraid", "jumpblackhole", "jumpskirm", "jumpassault", "jumpsumo", "jumparty", "jumpbomb", "jumpaa"],
+		"land": {
+			"tier0": [ 0.05,      0.24,        0.50,       0.00,            0.15,        0.06,          0.00,       0.00,       0.00,       0.00],
+			"tier1": [ 0.10,      0.20,        0.20,       0.10,            0.16,        0.24,          0.00,       0.00,       0.00,       0.00],
+			"tier2": [ 0.20,      0.20,        0.00,       0.15,            0.04,        0.31,          0.00,       0.10,       0.00,       0.00],
+			"tier3": [ 0.25,      0.15,        0.00,       0.15,            0.00,        0.33,          0.00,       0.12,       0.00,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryshield": {
+		"importance": [0.88, 0.6],
+		"require_energy": false,
+
+		"income_tier": [16, 24, 48, 66],
+		//             convict,     dirtbag,       bandit,       rogue,         thug,            outlaw,       felon,         racketeer,    roach,        aspis,          vandal
+		"unit":      ["shieldcon", "shieldscout", "shieldraid", "shieldskirm", "shieldassault", "shieldriot", "shieldfelon", "shieldarty", "shieldbomb", "shieldshield", "shieldaa"],
+		"land": {
+			"tier0": [ 0.05,        0.05,          0.70,         0.00,          0.20,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier1": [ 0.08,        0.01,          0.10,         0.24,          0.57,            0.00,         0.00,          0.00,         0.00,         0.00,           0.00],
+			"tier2": [ 0.12,        0.03,          0.00,         0.20,          0.54,            0.00,         0.05,          0.00,         0.00,         0.06,           0.00],
+			"tier3": [ 0.15,        0.07,          0.00,         0.00,          0.62,            0.00,         0.08,          0.00,         0.00,         0.08,           0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"factoryship": {
+		"importance": [5.5, 5.5],
+		"require_energy": false,
+
+		"income_tier": [30],
+		//             mariner    cutter,      hunter,           seawolf,     corsair,    mistral,     siren,         ronin,      zephyr
+		"unit":      ["shipcon", "shipscout", "shiptorpraider", "subraider", "shipriot", "shipskirm", "shipassault", "shiparty", "shipaa"],
+		"water": {
+			"tier0": [ 0.05,      0.15,        0.35,             0.10,        0.10,       0.10,        0.15,          0.00,       0.00],
+			"tier1": [ 0.05,      0.10,        0.20,             0.10,        0.05,       0.10,        0.25,          0.15,       0.00]
+		},
+
+		"caretaker": 6
+	},
+
+	"striderhub": {
+		"importance": [0, 1.5],
+		"require_energy": false,
+
+		"income_tier": [60, 80, 100],
+		//             ultimatum,          scorpion,          dante,          catapult,      funnelweb,          bantha,          detriment,          scylla,          reef,          battleship
+		"unit":      ["striderantiheavy", "striderscorpion", "striderdante", "striderarty", "striderfunnelweb", "striderbantha", "striderdetriment", "subtacmissile", "shipcarrier", "shipheavyarty"],
+		"land": {
+			"tier0": [ 0.01,               0.10,              0.81,           0.00,          0.05,               0.03,            0.00,               0.00,            0.00,          0.00],
+			"tier1": [ 0.03,               0.14,              0.22,           0.24,          0.20,               0.16,            0.01,               0.00,            0.00,          0.00],
+			"tier2": [ 0.05,               0.10,              0.16,           0.35,          0.10,               0.21,            0.03,               0.00,            0.00,          0.00],
+			"tier3": [ 0.05,               0.10,              0.01,           0.26,          0.10,               0.35,            0.13,               0.00,            0.00,          0.00]
+		},
+		"water": {
+			"tier1": [ 0.50,               0.00,              0.00,           0.00,          0.00,               0.00,            0.00,               0.00,            0.25,          0.25],
+			"tier2": [ 0.10,               0.00,              0.00,           0.00,          0.00,               0.00,            0.10,               0.00,            0.40,          0.40]
+		},
+
+		"caretaker": 100
+//	},
+//
+//	"staticmissilesilo": {
+//		"importance": [0, 0],
+//		"require_energy": false,
+//
+//		"income_tier": [0],
+//		"unit":      ["tacnuke", "seismic", "empmissile", "napalmmissile"],
+//		"land": {
+//			"tier0": [ 0.01,      0.01,      0.01,         0.97]
+//		},
+//
+//		"caretaker": 1
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/response.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/response.json
@@ -1,0 +1,136 @@
+// Mono-space font required
+{
+// Build special units when enemy_metal*ratio > response_metal*eps; eps=teamSize*eps_step+(1-eps_step)
+// AA condition for 3v3: (enemy_air_metal*0.67 > (aa_metal+aa_cost)*1.12) and (aa_metal+aa_cost < army_metal*0.5)
+//
+// Probability of UnitDef for AA role depends on income tier: (tierN[UnitDef]+_weight_)*enemy_air_metal/aa_metal*importance
+// armjeth probability for tier 1: (0.00+10.00)*enemy_air_metal*600.0
+"response": {
+	"_weight_": 70.0,  // base weight of response probability, default=0.5
+
+	"assault": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "super", "missileskirm", "turtle"],
+		"ratio":      [ 0.75,   2.0,      0.00,      0.20,        0.00,    0.75,    1.5,            3.0],
+		"importance": [ 15.00,  45.00,    25.00,     75.00,       0.00,    45.00,   125.00,         50.0],
+		"max_percent": 1.00
+	},
+	"skirmish": {
+		"vs":         ["riot", "static", "assault", "commander", "heavy", "anti_heavy"],
+		"ratio":      [ 1.50,   0.75,     1.00,      0.00,        0.00,    0.00],
+		"importance": [ 35.00,  25.00,    25.00,     75.00,       0.00,    0.00],
+		"max_percent": 1.00
+	},
+	"raider": {
+		"vs":         ["anti_air", "scout", "raider", "anti_heavy", "mine", "skirmish", "artillery"],
+		"ratio":      [ 0.00,       1.00,    1.0,      0.10,         0.35,   0.40,       0.8],
+		"importance": [ 15.00,      75.00,   75.00,    15.00,        60.00,  45.00,      10.00],
+		"max_percent": 1.00,
+		"eps_step": 0.75
+	},
+	"riot": {
+		"vs":         ["raider", "scout", "commander", "bullshit_raider"],
+		"ratio":      [ 0.8,      0.8,     0.33,        1.5],
+		"importance": [ 100.00,   100.00,  75.00,       125.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"missileskirm": {
+		"vs":         ["raider", "scout", "riot"],
+		"ratio":      [ 0.25,     0.5,     0.25],
+		"importance": [ 35.00,    50.00,   35.00],
+		"max_percent": 0.45,
+		"eps_step": 0.25
+	},
+	"transport": {
+		"vs":         ["super", "support", "shieldball"],
+		"ratio":      [ 0.75,    0.75,      0.75],
+		"importance": [ 50.00,   50.00,     50.00],
+		"max_percent": 0.30,
+		"eps_step": 0.015
+	},
+	"scout": {
+		"vs":         ["mine", "artillery", "anti_air", "scout", "static", "heavy", "anti_heavy", "cloaked_raider"],
+		"ratio":      [ 0.35,   0.05,        0.10,       1.00,    0.00,     0.00,    0.05,         0.5],
+		"importance": [ 60.00,  60.0,        60.0,       35.00,   0.00,     0.00,    10.00,        100.00],
+		"max_percent": 0.09,
+		"eps_step": 0.025
+	},
+	"artillery": {
+		"vs":         ["static", "artillery", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.66,     0.00,        0.66,    0.25,         3.0],
+		"importance": [ 20.00,    0.00,        40.00,   40.00,        40.0],
+		"max_percent": 0.66,
+		"eps_step": 0.02
+	},
+	"anti_air": {
+		"vs":         ["air"],
+		"ratio":      [ 0.8],
+		"importance": [ 75.0],
+		"max_percent": 0.4,
+		"eps_step": 0.75
+	},
+	"anti_sub": {
+		"vs":         ["sub"],
+		"ratio":      [ 0.0],
+		"importance": [ 0.0],
+		"max_percent": 0.00,
+		"eps_step": 0.0
+	},
+	"anti_heavy": {
+		"vs":         ["heavy", "artillery", "support", "anti_heavy", "commander", "super", "turtle"],
+		"ratio":      [ 0.45,    0.00,        0.00,      0.00,         0.4,         0.50,    3.00],
+		"importance": [ 85.00,   0.00,        0.00,      0.00,         50.00,       85.0,    50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"disarm_target": {
+		"vs":         ["disarm_target"],
+		"ratio":      [ 0.50],
+		"importance": [ 100.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"snipe_target": {
+		"vs":         ["snipe_target", "commander"],
+		"ratio":      [ 1.00,           0.20],
+		"importance": [ 100.00,         50.00],
+		"max_percent": 0.40,
+		"eps_step": 0.00
+	},
+	"cloaked_raider": {
+		"vs":         ["snipe_target", "commander", "transport"],
+		"ratio":      [ 0.50,           0.20,        2.00],
+		"importance": [ 35.00,          35.00,       125.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"heavy": {
+		"vs":         ["heavy", "static", "support", "skirmish", "super", "shieldball", "turtle"],
+		"ratio":      [ 0.75,    0.5,      0.00,      0.75,       0.75,    0.75,         3.00],
+		"importance": [ 75.00,   15.00,    0.00,      15.00,      75.00,   75.00,        75.00],
+		"max_percent": 0.50,
+		"eps_step": 0.00
+	},
+	"bomber": {
+		"vs":         ["shieldball", "anti_heavy", "artillery", "super"],
+		"ratio":      [ 0.50,         0.50,         0.50,        0.50],
+		"importance": [ 0.50,         50.00,        50.00,       50.00],
+		"max_percent": 1.0,
+		"eps_step": 0.00
+	},
+	"super": {
+		"vs":         ["heavy", "static", "support", "skirmish", "artillery", "super", "turtle"],
+		"ratio":      [ 0.3,     0.55,     0.00,      0.00,       0.00,        0.00,    0.5],
+		"importance": [ 45.00,   25.00,    0.00,      0.00,       0.00,        0.00,    45.00],
+		"max_percent": 0.2,
+		"eps_step": 0.00
+	},
+	"support": {
+		"vs":         ["assault", "bullshit_raider"],
+		"ratio":      [ 1.00,      0.4],
+		"importance": [ 35.00,     75.00],
+		"max_percent": 0.25,
+		"eps_step": 0.00
+	}
+}
+}

--- a/LuaMenu/configs/gameConfig/zk/defaultSettings/configversions.json
+++ b/LuaMenu/configs/gameConfig/zk/defaultSettings/configversions.json
@@ -32,590 +32,590 @@
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBeginner64/stable/config/behaviour.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBeginner64/stable/config/block_map.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBeginner64/stable/config/build_chain.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBeginner64/stable/config/commander.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBeginner64/stable/config/economy.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBeginner64/stable/config/factory.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBeginner64/stable/config/response.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/config/response.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBeginner64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/init.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/script/init.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/role.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/script/role.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/side.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBeginner64/stable/script/side.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINovice64/stable/config/behaviour.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINovice64/stable/config/block_map.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINovice64/stable/config/build_chain.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINovice64/stable/config/commander.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINovice64/stable/config/economy.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINovice64/stable/config/factory.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINovice64/stable/config/response.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/config/response.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINovice64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/init.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/script/init.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/role.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/script/role.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/side.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAINovice64/stable/script/side.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIEasy64/stable/config/behaviour.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIEasy64/stable/config/block_map.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIEasy64/stable/config/build_chain.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIEasy64/stable/config/commander.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIEasy64/stable/config/economy.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIEasy64/stable/config/factory.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIEasy64/stable/config/response.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/config/response.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIEasy64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/init.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/script/init.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/role.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/script/role.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/side.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIEasy64/stable/script/side.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINormal64/stable/config/behaviour.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINormal64/stable/config/block_map.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINormal64/stable/config/build_chain.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINormal64/stable/config/commander.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINormal64/stable/config/economy.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINormal64/stable/config/factory.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAINormal64/stable/config/response.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/config/response.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAINormal64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/init.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/script/init.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/role.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/script/role.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/side.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAINormal64/stable/script/side.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIHard64/stable/config/behaviour.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIHard64/stable/config/block_map.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIHard64/stable/config/build_chain.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIHard64/stable/config/commander.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIHard64/stable/config/economy.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIHard64/stable/config/factory.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIHard64/stable/config/response.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/config/response.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIHard64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/init.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/script/init.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/role.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/script/role.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/side.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIHard64/stable/script/side.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/libSkirmishAI.so"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBrutal64/stable/config/behaviour.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBrutal64/stable/config/block_map.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBrutal64/stable/config/build_chain.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBrutal64/stable/config/commander.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBrutal64/stable/config/economy.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBrutal64/stable/config/factory.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitAIBrutal64/stable/config/response.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/config/response.json",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAIBrutal64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/init.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/script/init.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/role.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/script/role.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/side.as",
          "TargetPath":"AI/Skirmish/1052188CircuitAIBrutal64/stable/script/side.as"
       },
       {
          "Platform":"linux64",
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/libSkirmishAI.so",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/libSkirmishAI.so",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/libSkirmishAI.so"
       },
       {
          "Platform":"win64",
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/SkirmishAI.dll",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/SkirmishAI.dll",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/SkirmishAI.dll"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/config/behaviour.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/behaviour.json",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/config/behaviour.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/config/block_map.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/block_map.json",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/config/block_map.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/config/build_chain.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/build_chain.json",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/config/build_chain.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/config/commander.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/commander.json",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/config/commander.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/config/economy.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/economy.json",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/config/economy.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/config/factory.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/factory.json",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/config/factory.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/config/response.json",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/config/response.json",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/config/response.json"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
+         "VersionNumber":2104,
          "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitTest64/stable/AIInfo.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/AIInfo.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/AIOptions.lua",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/AIOptions.lua",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/AIOptions.lua"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/script/init.as",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/init.as",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/script/init.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/script/role.as",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/role.as",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/script/role.as"
       },
       {
          "Platform":null,
-         "VersionNumber":2103,
-         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1051344CircuitTest64/stable/script/side.as",
+         "VersionNumber":2104,
+         "SourcePath":"LuaMenu/configs/gameConfig/zk/defaultSettings/AI/Skirmish/1052188CircuitAICommon64/stable/script/side.as",
          "TargetPath":"AI/Skirmish/1052188CircuitTest64/stable/script/side.as"
       },
       {


### PR DESCRIPTION
Breaking change: syntax of `economy->mex_max` is now https://github.com/rlcevg/CircuitAI/blob/edc74149c281e2140f28c091ed74310c11611cc7/data/config/economy.json#L50-L53

Changes:
* added `link_inc` param to control when to start building energy grid https://github.com/rlcevg/CircuitAI/blob/edc74149c281e2140f28c091ed74310c11611cc7/data/config/economy.json#L32
* `support` attribute for energy limits building place to home base (previously there was hardcoded metal cost) https://github.com/rlcevg/CircuitAI/blob/edc74149c281e2140f28c091ed74310c11611cc7/data/config/behaviour.json#L923
* added new attributes https://github.com/rlcevg/CircuitAI/blob/edc74149c281e2140f28c091ed74310c11611cc7/data/config/behaviour.json#L56-L58
* added `ally_base` aioption to control non-build area around ally factories (0=disabled by default to provide old behaviour) https://github.com/rlcevg/CircuitAI/blob/edc74149c281e2140f28c091ed74310c11611cc7/data/AIOptions.lua#L43-L48

This PR edits existing difficulty configs, except for `block_map` - was replaced everywhere.