### PR TITLE
Fix bad test at FriendListWindow:OnRemoveUser.

### DIFF
--- a/LuaMenu/widgets/chobby/components/friend_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/friend_list_window.lua
@@ -56,7 +56,7 @@ function FriendListWindow:OnAddUser(userName)
 end
 
 function FriendListWindow:OnRemoveUser(userName)
-	if (not lobby.status == "connected") then
+	if lobby.status ~= "connected" then
 		return
 	end
 	local userInfo = lobby:TryGetUser(userName)


### PR DESCRIPTION
It's incorrectly doing if not bla == "foo", that results in if (not bla) == "foo", that's always false.